### PR TITLE
Show docker logs when build fails

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -62,6 +62,6 @@ frontend_build () {
 backend_build
 frontend_build
 
-if dci run -T ci ./basic.sh; then
+if ! dci run -T ci ./basic.sh; then
   dci logs
 fi

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -62,4 +62,6 @@ frontend_build () {
 backend_build
 frontend_build
 
-dci run -T ci ./basic.sh
+if dci run -T ci ./basic.sh; then
+  dci logs
+fi

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -64,4 +64,6 @@ frontend_build
 
 if ! dci run -T ci ./basic.sh; then
   dci logs
+  echo "Build failed when running basic.sh"
+  exit 1
 fi

--- a/ci/test/basic.sh
+++ b/ci/test/basic.sh
@@ -3,6 +3,7 @@
 
 set -euo pipefail
 
+exit 2
 wait4ports -q -s 1 -t 60 tcp://localhost:80 tcp://localhost:3000 tcp://db:5432
 
 http_get() {

--- a/ci/test/basic.sh
+++ b/ci/test/basic.sh
@@ -3,7 +3,6 @@
 
 set -euo pipefail
 
-exit 2
 wait4ports -q -s 1 -t 60 tcp://localhost:80 tcp://localhost:3000 tcp://db:5432
 
 http_get() {


### PR DESCRIPTION
When the "basic.sh" script fails, show the docker-compose logs as it can contain useful information to debug why the CI environment did not start properly or show some exception

Part of #203 