### PR TITLE
Restrict /details API access for private topics 

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -271,7 +271,8 @@
   :duct.database/sql {:jdbc-url #duct/env "DATABASE_URL"}
 
   :gpml.auth/auth-middleware {:issuer #duct/env "OIDC_ISSUER"
-                              :audience #duct/env "OIDC_AUDIENCE"}
+                              :audience #duct/env "OIDC_AUDIENCE"
+                              :db #ig/ref :duct.database/sql}
   :gpml.auth/auth-required {}
   :gpml.auth/approved-user {:db #ig/ref :duct.database/sql}
   :gpml.auth/admin-required-middleware {:db #ig/ref :duct.database/sql}

--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -184,13 +184,14 @@
                                                             :security [{:id_token []}]}
                                                   :parameters {:body #ig/ref :gpml.handler.favorite/post-params}
                                                   :handler #ig/ref :gpml.handler.favorite/post}}]]
-                                        ["/detail/{topic-type}/{topic-id}"
-                                         {:get {:summary "Get the details for a specific resource"
-                                                :swagger {:tags ["resource detail"]}
-                                                :parameters {:path [:map
-                                                                    [:topic-type #ig/ref :gpml.handler.detail/topics]
-                                                                    [:topic-id int?]]}
-                                                :handler #ig/ref :gpml.handler.detail/get}}]]]}
+                                        ["/detail" {:middleware [#ig/ref :gpml.auth/auth-middleware]}
+                                         ["/{topic-type}/{topic-id}"
+                                          {:get {:summary "Get the details for a specific resource"
+                                                 :swagger {:tags ["resource detail"]}
+                                                 :parameters {:path [:map
+                                                                     [:topic-type #ig/ref :gpml.handler.detail/topics]
+                                                                     [:topic-id int?]]}
+                                                 :handler #ig/ref :gpml.handler.detail/get}}]]]]}
 
   :duct.server.http/jetty {:handler #ig/ref :gpml.handler.main/handler}
 

--- a/backend/src/gpml/constants.clj
+++ b/backend/src/gpml/constants.clj
@@ -1,6 +1,7 @@
 (ns gpml.constants)
 
 (def resource-types ["financing_resource" "technical_resource" "action_plan"])
+(def approved-user-topics #{"organisation" "stakeholder"})
 (def topics
   (vec
    (sort

--- a/backend/src/gpml/handler/browse.clj
+++ b/backend/src/gpml/handler/browse.clj
@@ -2,7 +2,6 @@
   (:require [clojure.string :as str]
             [gpml.constants :refer [topics resource-types approved-user-topics]]
             [gpml.db.browse :as db.browse]
-            [gpml.db.stakeholder :as db.stakeholder]
             [integrant.core :as ig]
             [ring.util.response :as resp]))
 
@@ -93,15 +92,13 @@
     data))
 
 (defmethod ig/init-key :gpml.handler.browse/get [_ {:keys [db]}]
-  (fn [{{:keys [query]} :parameters {:keys [email]} :jwt-claims}]
-    (let [stakeholder (and email (->> {:email email}
-                                      (db.stakeholder/stakeholder-by-email (:spec db))))
-          user-id (:id stakeholder)
-          approved? (= "APPROVED" (:review_status stakeholder))]
-      (resp/response {:results (#'results
-                                (merge query {:user user-id})
-                                (:spec db)
-                                approved?)}))))
+  (fn [{{:keys [query]} :parameters
+        approved? :approved?
+        user-id :user-id}]
+    (resp/response {:results (#'results
+                              (merge query {:user user-id})
+                              (:spec db)
+                              approved?)})))
 
 (defmethod ig/init-key :gpml.handler.browse/query-params [_ _]
   query-params)

--- a/backend/src/gpml/handler/browse.clj
+++ b/backend/src/gpml/handler/browse.clj
@@ -1,6 +1,6 @@
 (ns gpml.handler.browse
   (:require [clojure.string :as str]
-            [gpml.constants :refer [topics resource-types]]
+            [gpml.constants :refer [topics resource-types approved-user-topics]]
             [gpml.db.browse :as db.browse]
             [gpml.db.stakeholder :as db.stakeholder]
             [integrant.core :as ig]
@@ -71,7 +71,7 @@
 (defn maybe-filter-private-topics [topics approved?]
   (or (and approved? topics)
       (->> topics
-           (filter #(not (contains? #{"organisation" "stakeholder"} %)))
+           (filter #(not (contains? approved-user-topics %)))
            vec)))
 
 (defn modify-db-filter-topics [db-filter]

--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -268,11 +268,11 @@
 
 (defmethod ig/init-key ::get [_ {:keys [db]}]
   (cache-hierarchies! (:spec db))
-  (fn [{:keys [path-params]}]
-    (if-let [data (db.detail/get-detail (:spec db) (update path-params :topic-id #(Long/parseLong %)))] ;; TODO: investigate why id value is not coerced
+  (fn [{{:keys [path]} :parameters}]
+    (if-let [data (db.detail/get-detail (:spec db) path)]
       (resp/response (merge
                       (:json data)
-                      (extra-details (:topic-type path-params) (:spec db) (:json data))))
+                      (extra-details (:topic-type path) (:spec db) (:json data))))
       (resp/not-found {:message "Not Found"}))))
 
 #_:clj-kondo/ignore

--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -3,7 +3,6 @@
             [gpml.db.detail :as db.detail]
             [gpml.db.project :as db.project]
             [gpml.db.initiative :as db.initiative]
-            [gpml.db.stakeholder :as db.stakeholder]
             [integrant.core :as ig]
             [medley.core :as medley]
             [ring.util.response :as resp]
@@ -269,15 +268,11 @@
 
 (defmethod ig/init-key ::get [_ {:keys [db]}]
   (cache-hierarchies! (:spec db))
-  (fn [{{:keys [path]} :parameters jwt-claims :jwt-claims}]
+  (fn [{{:keys [path]} :parameters approved? :approved?}]
     (let [conn (:spec db)
           topic (:topic-type path)
           public-topic? (not (contains? constants/approved-user-topics topic))
-          authorized? (or public-topic?
-                          (and (:email jwt-claims)
-                               (= "APPROVED"
-                                  (:review_status
-                                   (db.stakeholder/stakeholder-by-email conn jwt-claims)))))]
+          authorized? (or public-topic? approved?)]
       (if-let [data (and authorized? (db.detail/get-detail conn path))]
         (resp/response (merge
                         (:json data)

--- a/backend/test/gpml/auth_test.clj
+++ b/backend/test/gpml/auth_test.clj
@@ -25,55 +25,59 @@
                  (auth/validate-opts {:issuer "https://tenant.auth0.com/"
                                       :audience ""})))))
 
-(defn- new-stakeholder [db id email role]
-  (let [sth (db.stakeholder/new-stakeholder db
-                                            {:id id
-                                             :picture "https://picsum.photos/200"
-                                             :cv nil
-                                             :title "Mr."
-                                             :first_name "First name"
-                                             :last_name "Last name"
-                                             :affiliation nil
-                                             :email email
-                                             :linked_in nil
-                                             :twitter nil
-                                             :url nil
-                                             :country nil
-                                             :representation "test"
-                                             :about "Lorem Ipsum"
-                                             :geo_coverage_type nil})]
-    (db.stakeholder/update-stakeholder-status db (assoc sth :review_status "APPROVED"))
-    (db.stakeholder/update-stakeholder-role db {:id (:id sth)
-                                                :role role})))
+(defn- new-stakeholder [db id email role review_status]
+  (let [info {:id id
+              :picture "https://picsum.photos/200"
+              :cv nil
+              :title "Mr."
+              :first_name "First name"
+              :last_name "Last name"
+              :affiliation nil
+              :email email
+              :linked_in nil
+              :twitter nil
+              :url nil
+              :country nil
+              :representation "test"
+              :about "Lorem Ipsum"
+              :geo_coverage_type nil}
+        sth (db.stakeholder/new-stakeholder db info)]
+    (db.stakeholder/update-stakeholder-status db (assoc sth :review_status review_status))
+    (db.stakeholder/update-stakeholder-role db (assoc sth :role role))
+    (db.stakeholder/stakeholder-by-id db sth)))
 
-(defn post-request
-  [email]
+(defn post-approved-user-request
+  [user]
   (->
    (mock/request :post "/" {})
-   (assoc :jwt-claims {:email email})))
+   (assoc :approved? true
+          :user user
+          :jwt-claims {:email (:email user) :email_verified true})))
 
 (deftest test-admin-middleware
   (let [system (-> fixtures/*system*
                    (ig/init [::auth/admin-required-middleware]))
         db (-> system :duct.database.sql/hikaricp :spec)
         middleware (::auth/admin-required-middleware system)
-        admin (new-stakeholder db 1 "admin@un.org" "ADMIN")]
-    (new-stakeholder db 2 "user@un.org" "USER")
-    (prn admin)
-    (let [handler (middleware (fn [{{admin-id :id} :admin}]
-                                (testing "> admin id added correctly to request"
-                                  (is (= admin admin-id)))
-                                {:status 200 :body "OK"}))]
-      (testing "An admin is authorized to perform the request"
-        (is (= 200 (-> "admin@un.org"
-                       post-request
-                       handler
-                       :status))))
-      (testing "A normal user is **not** authorized to perform the request"
-        (is (= 403 (-> "user@un.org"
-                       post-request
-                       handler
-                       :status)))))))
+        admin (new-stakeholder db 1 "admin@un.org" "ADMIN" "APPROVED")
+        user (new-stakeholder db 2 "user@un.org" "USER" "APPROVED")
+        test-fn (fn [{{admin-id :id} :admin}]
+                  (testing "> admin id added correctly to request"
+                    (is (= (:id admin) admin-id)))
+                  {:status 200 :body "OK"})
+        handler (middleware test-fn)]
+
+    (testing "An admin is authorized to perform the request"
+      (is (= 200 (-> admin
+                     post-approved-user-request
+                     handler
+                     :status))))
+
+    (testing "A normal user is **not** authorized to perform the request"
+      (is (= 403 (-> user
+                     post-approved-user-request
+                     handler
+                     :status))))))
 
 (deftest test-check-authentication
   (testing "Testing check-authentication logic"
@@ -85,3 +89,33 @@
       {:authenticated? true} "any-token-that-is-valid" [true {:any-claim true}]
       {:status 403
        :authenticated? false} "not-a-valid-token" [false "IDToken can't be verified"])))
+
+(deftest test-check-approved
+  (testing "Testing check-approved logic"
+    (let [system (-> fixtures/*system*
+                     (ig/init [::auth/admin-required-middleware]))
+          db (-> system :duct.database.sql/hikaricp :spec)
+
+          ;; Create approved user
+          approved (new-stakeholder db 1 "user@un.org" "USER" "APPROVED")
+
+          ;; Create unapproved stakeholder
+          unapproved (new-stakeholder db 2 "foo@bar.org" "USER" "SUBMITTED")]
+
+      (are [expected auth-header]
+          (= expected (auth/check-approved db auth-header))
+
+        ;; Anonymous user
+        {:approved? false :user nil} {:authenticated? false}
+
+        ;; Unverified email user
+        {:approved? false :user nil}
+        {:jwt-claims unapproved}
+
+        ;; Unapproved email user
+        {:approved? false :user unapproved}
+        {:jwt-claims (assoc unapproved :email_verified true)}
+
+        ;; Approved, verified email user
+        {:approved? true :user approved}
+        {:jwt-claims (assoc approved :email_verified true)}))))


### PR DESCRIPTION
Stakeholders and Organizations details should only be visible to
approved users. This change ensures that the API returns 404 for
unapproved/anonymous users when requesting these resources.