### PR TITLE
286 support sentry error

### DIFF
--- a/backend/src/gpml/db/organisation.sql
+++ b/backend/src/gpml/db/organisation.sql
@@ -56,7 +56,7 @@ where id = :id
 -- :name geo-coverage :? :*
 -- :doc Get geo coverage by organisation id
 select id, coalesce(country, country_group) as geo_coverage_values from organisation_geo_coverage
-where o.organisation = :id
+where organisation = :id
 
 -- :name add-geo-coverage :<! :1
 -- :doc add organisation geo coverage

--- a/backend/src/gpml/db/organisation.sql
+++ b/backend/src/gpml/db/organisation.sql
@@ -4,10 +4,9 @@ select id, name from organisation order by id
 
 -- :name organisation-by-id :? :1
 -- :doc Get organisation by id
-select o.id, o.name, o.url, o.type, o.geo_coverage_type, c.iso_code as country
-from organisation o
-left join country c on o.country = c.id
-where o.id = :id;
+select id, name, url, type, geo_coverage_type, country
+from organisation
+where id = :id;
 
 -- :name organisation-by-name :? :1
 -- :doc Get organisation by name
@@ -56,9 +55,7 @@ where id = :id
 
 -- :name geo-coverage :? :*
 -- :doc Get geo coverage by organisation id
-select cg.id, c.iso_code, cg.name from organisation_geo_coverage o
-left join country c on c.id = o.country
-left join country_group cg on cg.id = o.country_group
+select id, coalesce(country, country_group) as geo_coverage_values from organisation_geo_coverage
 where o.organisation = :id
 
 -- :name add-geo-coverage :<! :1

--- a/frontend/src/modules/events/form.jsx
+++ b/frontend/src/modules/events/form.jsx
@@ -241,6 +241,8 @@ const AddEventForm = () => {
     setTimeout(() => {
       formRef.current?.change("ts", new Date().getTime());
       formRef.current?.change("geoCoverageType", value);
+      // set geoCoverageValue to null when geoCoverageType change
+      formRef.current?.change("geoCoverageValue", null);
     });
   };
 

--- a/frontend/src/modules/signup/signup-form.jsx
+++ b/frontend/src/modules/signup/signup-form.jsx
@@ -262,6 +262,10 @@ const SignupForm = ({
     setTimeout(() => {
       formRef.current?.change("ts", new Date().getTime());
       formRef.current?.change("geoCoverageType", value);
+      // set geoCoverageValue to null when geoCoverageType change
+      initialValues?.geoCoverageType !== value &&
+        initialValues?.geoCoverageValue &&
+        formRef.current?.change("geoCoverageValue", null);
     });
   };
 
@@ -372,6 +376,17 @@ const SignupForm = ({
                   <FormSpy
                     subscription={{ values: true }}
                     onChange={({ values }) => {
+                      // set geoCoverageValue to null when geoCoverageType change
+                      if (
+                        prevVals.current?.org?.geoCoverageType !==
+                        values?.org?.geoCoverageType
+                      ) {
+                        setTimeout(() => {
+                          formRef.current?.change("ts", new Date().getTime());
+                          // set geoCoverageValue to null when geoCoverageType change
+                          formRef.current?.change("org.geoCoverageValue", null);
+                        });
+                      }
                       const newSchema = cloneDeep(formSchema);
                       let changedSchema = false;
                       if (


### PR DESCRIPTION
- Make **Geo Coverage Values** field empty when we changed **Geo Coverage Type** in forms.
- Fix **Geo Coverage Values** to use id instead of iso_code (national, transnational) / name (other geo coverage type, except global) 