### PR TITLE
[#330] String.replaceAll is not available in old browsers

### DIFF
--- a/frontend/src/utils/trim.js
+++ b/frontend/src/utils/trim.js
@@ -1,5 +1,7 @@
 const lastCharEscape = [".", ",", ";"];
 const escapeRegex = /\(([^)]+)\)\s\w+/g;
+const replace1 = /###/g;
+const replace2 = /·/g;
 
 const TrimText = ({ text, max = 400 }) => {
   if (text.length < max) {
@@ -20,7 +22,7 @@ const TrimText = ({ text, max = 400 }) => {
 
   while (text.length < max - 1 && arrayText[startIndex]) {
     text +=
-      arrayText[startIndex].replaceAll("###", " ").replaceAll("·", "") + " ";
+      arrayText[startIndex].replace(replace1, " ").replace(replace2, "") + " ";
     startIndex++;
   }
   text = text.slice(0, -1);


### PR DESCRIPTION
We have a user using Chrome 73 and String.replaceAll is not available:

In Chrome support for replaceAll started in version 85. More info:

https://caniuse.com/?search=replaceAll

Switch to use global `String.replace()`

> Global replace can only be done with a regular expression [...]

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#using_global_and_ignore_with_replace
