### PR TITLE
[#283] Show Other option when typing names not in search list

### DIFF
--- a/frontend/src/utils/forms/form-select.js
+++ b/frontend/src/utils/forms/form-select.js
@@ -66,7 +66,8 @@ const SelectWidget = ({
     <Select
       showSearch={uiSchema?.["ui:showSearch"] ? true : false}
       filterOption={(input, option) =>
-        option.children.toLowerCase().indexOf(input.toLowerCase()) >= 0
+        option.children.toLowerCase().indexOf(input.toLowerCase()) >= 0 ||
+        option.value === "-1"
       }
       autoFocus={autofocus}
       disabled={disabled || (readonlyAsDisabled && readonly)}


### PR DESCRIPTION
The sign up form shows the Other option when the name searched for is
not present in the list of options. This commit makes the other forms
behave similarly, when the Select list has the option added to the
list of options with a value -1. The organisation lists in the forms
already have this option added.