### PR TITLE
Basic implementation of Approval workflow

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -130,7 +130,7 @@
                                                                 :body [:or
                                                                        [:map
                                                                         [:review-comment string?]
-                                                                        [:review-status #ig/ref :gpml.handler.review/review-status]]
+                                                                        [:review-status #ig/ref :gpml.handler.review/review-status-params]]
                                                                        [:map
                                                                         [:reviewer int?]]]}
                                                    :handler #ig/ref :gpml.handler.review/update-review}}]]
@@ -304,7 +304,7 @@
   :gpml.handler.review/update-review {:db #ig/ref :duct.database/sql}
   :gpml.handler.review/list-reviews {:db #ig/ref :duct.database/sql}
   :gpml.handler.review/list-reviews-params {}
-  :gpml.handler.review/review-status {}
+  :gpml.handler.review/review-status-params {}
 
   :gpml.handler.landing/get {:db #ig/ref :duct.database/sql}
 

--- a/backend/src/gpml/db/review.sql
+++ b/backend/src/gpml/db/review.sql
@@ -12,7 +12,12 @@ SELECT r.*, (CASE
   WHEN r.topic_type = 'policy' THEN (SELECT t.title FROM policy t WHERE t.id = r.topic_id)
   WHEN r.topic_type = 'organisation' THEN (SELECT t.name FROM organisation t WHERE t.id = r.topic_id)
   WHEN r.topic_type = 'stakeholder' THEN (SELECT CONCAT(title, '. ', last_name,' ', first_name) FROM stakeholder t WHERE t.id = r.topic_id)
-END) AS title
+END) AS title,
+(CASE
+  WHEN r.topic_type = 'initiative' THEN 'project'
+  WHEN r.topic_type = 'resource' THEN (SELECT REPLACE(LOWER(t.type), ' ', '_') FROM resource t WHERE t.id = r.topic_id)
+  ELSE r.topic_type::text
+END) AS type
 FROM review r
 WHERE reviewer = :reviewer
 --~ (when (seq (:review-status params)) "AND review_status = ANY(ARRAY[:v*:review-status]::reviewer_review_status[])")

--- a/backend/src/gpml/db/review.sql
+++ b/backend/src/gpml/db/review.sql
@@ -4,7 +4,16 @@ SELECT * FROM review ORDER BY id;
 
 -- :name reviews-by-reviewer-id :? :*
 -- :doc Get reviews for reviewer
-SELECT * FROM review
+SELECT r.*, (CASE
+  WHEN r.topic_type = 'initiative' THEN (SELECT TRIM('"' FROM t.q2::text) FROM initiative t WHERE t.id = r.topic_id)
+  WHEN r.topic_type = 'technology' THEN (SELECT t.name FROM technology t WHERE t.id = r.topic_id)
+  WHEN r.topic_type = 'resource' THEN (SELECT t.title FROM resource t WHERE t.id = r.topic_id)
+  WHEN r.topic_type = 'event' THEN (SELECT t.title FROM event t WHERE t.id = r.topic_id)
+  WHEN r.topic_type = 'policy' THEN (SELECT t.title FROM policy t WHERE t.id = r.topic_id)
+  WHEN r.topic_type = 'organisation' THEN (SELECT t.name FROM organisation t WHERE t.id = r.topic_id)
+  WHEN r.topic_type = 'stakeholder' THEN (SELECT CONCAT(title, '. ', last_name,' ', first_name) FROM stakeholder t WHERE t.id = r.topic_id)
+END) AS title
+FROM review r
 WHERE reviewer = :reviewer
 --~ (when (seq (:review-status params)) "AND review_status = ANY(ARRAY[:v*:review-status]::reviewer_review_status[])")
 ORDER BY id

--- a/backend/src/gpml/db/submission.sql
+++ b/backend/src/gpml/db/submission.sql
@@ -40,9 +40,11 @@ SELECT json_build_object(
 
 -- :name detail :? :1
 -- :doc get detail of submission
-SELECT *
-from :i:table-name
-where id = :id::integer;
+SELECT s.email AS created_by_email, t.*
+FROM :i:table-name t
+LEFT JOIN stakeholder s ON s.id =
+--~ (if (= (:table-name params) "v_stakeholder_data") "t.id" "t.created_by")
+WHERE t.id = :id::integer;
 
 -- :name update-submission :! :n
 -- :doc approve or reject submission

--- a/backend/src/gpml/handler/review.clj
+++ b/backend/src/gpml/handler/review.clj
@@ -116,7 +116,7 @@
     (list-reviews db reviewer page limit review-status)))
 
 (defmethod ig/init-key ::review-status [_ _]
-  (apply conj [:enum] constants/reviewer-review-status))
+  (apply conj [:enum] (map name constants/reviewer-review-status)))
 
 (defmethod ig/init-key ::list-reviews-params [_ _]
   {:query [:map

--- a/backend/src/gpml/handler/review.clj
+++ b/backend/src/gpml/handler/review.clj
@@ -115,7 +115,7 @@
         reviewer :reviewer}]
     (list-reviews db reviewer page limit review-status)))
 
-(defmethod ig/init-key ::review-status [_ _]
+(defmethod ig/init-key ::review-status-params [_ _]
   (apply conj [:enum] (map name constants/reviewer-review-status)))
 
 (defmethod ig/init-key ::list-reviews-params [_ _]

--- a/frontend/src/modules/profile/admin.jsx
+++ b/frontend/src/modules/profile/admin.jsx
@@ -17,7 +17,7 @@ import { fetchArchiveData, fetchSubmissionData } from "./utils";
 import moment from "moment";
 import capitalize from "lodash/capitalize";
 import find from "lodash/find";
-import { ProfilePreview, GeneralPreview, InitiativePreview } from "./preview";
+import { DetailCollapse } from "./preview";
 import { topicNames, resourceTypeToTopicType } from "../../utils/misc";
 
 const ModalReject = ({ visible, close, reject, item }) => {
@@ -110,17 +110,6 @@ const AdminSection = ({
           });
         }
       });
-    }
-  };
-
-  const DetailCollapse = ({ data, item }) => {
-    switch (item.type) {
-      case "stakeholder":
-        return <ProfilePreview item={{ ...data, ...item }} />;
-      case "project":
-        return <InitiativePreview item={{ ...data, ...item }} />;
-      default:
-        return <GeneralPreview item={{ ...data, ...item }} />;
     }
   };
 

--- a/frontend/src/modules/profile/admin.jsx
+++ b/frontend/src/modules/profile/admin.jsx
@@ -13,7 +13,7 @@ import {
 import React, { Fragment } from "react";
 import { useState } from "react";
 import api from "../../utils/api";
-import { fetchArchiveData } from "./utils";
+import { fetchArchiveData, fetchSubmissionData } from "./utils";
 import moment from "moment";
 import capitalize from "lodash/capitalize";
 import find from "lodash/find";
@@ -86,17 +86,12 @@ const AdminSection = ({
           data: [newArchive, ...archiveData],
           count: archiveItems.count + 1,
         });
-        api
-          .get(
-            "/submission?page=" +
-              pendingItems.page +
-              "&limit=" +
-              pendingItems.limit
-          )
-          .then((res) => {
-            setPendingItems(res.data);
-            setApproveLoading({});
-          });
+        (async () => {
+          const { page, limit } = pendingItems;
+          const items = await fetchSubmissionData(page, limit);
+          setPendingItems(items);
+          setApproveLoading({});
+        })();
         setModalRejectVisible(false);
       });
   };
@@ -130,17 +125,16 @@ const AdminSection = ({
   };
 
   const renderNewApprovalRequests = () => {
-    const onChangePagePending = (p) => {
-      api
-        .get("/submission?page=" + p + "&limit=" + pendingItems.limit)
-        .then((res) => {
-          setPendingItems(res.data);
-        });
+    const onChangePagePending = (page) => {
+      (async () => {
+        const { limit } = pendingItems;
+        setPendingItems(await fetchSubmissionData(page, limit));
+      })();
     };
-    const onChangePagePendingSize = (p, l) => {
-      api.get("/submission?page=" + p + "&limit=" + l).then((res) => {
-        setPendingItems(res.data);
-      });
+    const onChangePagePendingSize = (page, limit) => {
+      (async () => {
+        setPendingItems(await fetchSubmissionData(page, limit));
+      })();
     };
     return (
       <Fragment key="new-approval">

--- a/frontend/src/modules/profile/preview.jsx
+++ b/frontend/src/modules/profile/preview.jsx
@@ -505,3 +505,14 @@ export const InitiativePreview = ({ item }) => {
     </div>
   );
 };
+
+export const DetailCollapse = ({ data, item }) => {
+  switch (item.type) {
+    case "stakeholder":
+      return <ProfilePreview item={{ ...data, ...item }} />;
+    case "project":
+      return <InitiativePreview item={{ ...data, ...item }} />;
+    default:
+      return <GeneralPreview item={{ ...data, ...item }} />;
+  }
+};

--- a/frontend/src/modules/profile/preview.jsx
+++ b/frontend/src/modules/profile/preview.jsx
@@ -229,7 +229,7 @@ export const GeneralPreview = ({ item }) => {
         <li>
           <div className="detail-title">Submitted by</div>:
           <div className="detail-content">
-            <b>{item?.createdBy && item.createdBy}</b>
+            <b>{item?.createdByEmail && item.createdByEmail}</b>
           </div>
         </li>
         <li className="has-border">
@@ -418,7 +418,7 @@ export const InitiativePreview = ({ item }) => {
         <li>
           <div className="detail-title">Submitted by</div>:
           <div className="detail-content">
-            <b>{item?.createdBy && item.createdBy}</b>
+            <b>{item?.createdByEmail && item.createdByEmail}</b>
           </div>
         </li>
         <li>

--- a/frontend/src/modules/profile/review.jsx
+++ b/frontend/src/modules/profile/review.jsx
@@ -1,0 +1,166 @@
+import React, { Fragment, useState } from "react";
+import { Button, Collapse, Space, Pagination } from "antd";
+import { DetailCollapse } from "./preview";
+import { topicNames } from "../../utils/misc";
+import api from "../../utils/api";
+import { fetchReviewItems } from "./utils";
+
+const ReviewSection = ({
+  reviewItems,
+  setReviewItems,
+  reviewedItems,
+  setReviewedItems,
+}) => {
+  const ReviewHeader = ({ item }) => {
+    const submitReview = (item, reviewStatus, reviewComment) => {
+      const data = {
+        "review-status": reviewStatus,
+        "review-comment": reviewComment || "",
+      };
+      api.patch(`review/${item.type}/${item.topicId}`, data).then((resp) => {
+        // Move current item to reviewed items
+        const reviewedItem = { ...item, reviewStatus };
+        setReviewedItems({
+          ...reviewedItems,
+          count: reviewedItems.count + 1,
+          reviews: [reviewedItem, ...reviewedItems.reviews],
+        });
+        // Fetch review items again, to fetch any new items in the current page, etc.
+        (async () => {
+          setReviewItems(await fetchReviewItems(reviewItems, "PENDING"));
+        })();
+      });
+    };
+    const accept = (item) => submitReview(item, "ACCEPTED");
+    const reject = (item) => submitReview(item, "REJECTED");
+
+    return (
+      <div className="row">
+        <div className="col">{topicNames(item.type)}</div>
+        <div className="col">{item.title}</div>
+        <div
+          className="col"
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
+        >
+          <Space size="middle">
+            <Button type="primary" onClick={() => accept(item)}>
+              Accept
+            </Button>
+            <Button type="secondary" onClick={() => reject(item)}>
+              Reject
+            </Button>
+          </Space>
+        </div>
+      </div>
+    );
+  };
+
+  const ReviewedHeader = ({ item }) => {
+    return (
+      <div className="row">
+        <div className="col">{topicNames(item.type)}</div>
+        <div className="col">{item.title}</div>
+        <div className="col">{item.reviewStatus}</div>
+      </div>
+    );
+  };
+
+  const CollapseItemTable = ({ Header, items, setItems, reviewStatus }) => {
+    const [previewContent, storePreviewContent] = useState({});
+
+    const getPreviewContent = (urls) => {
+      if (urls.length > 0) {
+        urls.forEach((url) => {
+          if (!previewContent[url]) {
+            api.get(url).then((res) => {
+              storePreviewContent({ ...previewContent, [url]: res.data });
+            });
+          }
+        });
+      }
+    };
+
+    const onChangePage = (page) => {
+      const params = { ...items, page };
+      (async () => {
+        setItems(await fetchReviewItems(params, reviewStatus));
+      })();
+    };
+
+    return (
+      <>
+        <Collapse onChange={getPreviewContent}>
+          {items?.reviews?.length > 0 ? (
+            items?.reviews?.map((item, index) => {
+              const previewUrl = `/submission/${item.type}/${item.topicId}`;
+              return (
+                <Collapse.Panel
+                  key={previewUrl}
+                  header={<Header item={item} />}
+                >
+                  <DetailCollapse
+                    data={previewContent?.[previewUrl] || {}}
+                    item={item}
+                  />
+                </Collapse.Panel>
+              );
+            })
+          ) : (
+            <Collapse.Panel
+              showArrow={false}
+              collapsible="disabled"
+              key="collapse-pending-no-data"
+              header={<div className="row">No items to display</div>}
+            ></Collapse.Panel>
+          )}
+        </Collapse>
+        <div style={{ padding: "10px 0px" }}>
+          <Pagination
+            defaultCurrent={1}
+            current={items.page}
+            onChange={onChangePage}
+            pageSize={items.limit}
+            total={items.count}
+            defaultPageSize={items.limit}
+          />
+        </div>
+      </>
+    );
+  };
+  return (
+    <div className="admin-view">
+      <Fragment key="new-review">
+        <h2>New review requests ({`${reviewItems.count}`})</h2>
+        <div className="row head">
+          <div className="col">Type</div>
+          <div className="col">Name</div>
+          <div className="col">Action</div>
+        </div>
+        <CollapseItemTable
+          Header={ReviewHeader}
+          items={reviewItems}
+          setItems={setReviewItems}
+          reviewStatus="PENDING"
+        />
+      </Fragment>
+      <Fragment key="reviewed">
+        <h2>Reviewed requests ({`${reviewedItems.count}`})</h2>
+        <div className="row head">
+          <div className="col">Type</div>
+          <div className="col">Name</div>
+          <div className="col">Status</div>
+        </div>
+        <CollapseItemTable
+          Header={ReviewedHeader}
+          items={reviewedItems}
+          setItems={setReviewedItems}
+          reviewStatus="ACCEPTED,REJECTED"
+        />
+      </Fragment>
+    </div>
+  );
+};
+
+export default ReviewSection;

--- a/frontend/src/modules/profile/utils.js
+++ b/frontend/src/modules/profile/utils.js
@@ -15,3 +15,10 @@ export const fetchSubmissionData = async (page, limit) => {
   const resp = await api.get("/submission", params);
   return resp.data;
 };
+
+export const fetchReviewItems = async (items, reviewStatus) => {
+  const { page, limit } = items;
+  const params = { "review-status": reviewStatus, page, limit };
+  const resp = await api.get("review", params);
+  return resp.data;
+};

--- a/frontend/src/modules/profile/utils.js
+++ b/frontend/src/modules/profile/utils.js
@@ -9,3 +9,9 @@ export const fetchArchiveData = async (page, limit) => {
   }));
   return { ...res.data, data };
 };
+
+export const fetchSubmissionData = async (page, limit) => {
+  const params = { page, limit };
+  const resp = await api.get("/submission", params);
+  return resp.data;
+};

--- a/frontend/src/modules/profile/utils.js
+++ b/frontend/src/modules/profile/utils.js
@@ -1,9 +1,8 @@
 import api from "../../utils/api";
 
 export const fetchArchiveData = async (page, limit) => {
-  const params = new URLSearchParams({ page, limit });
-  const url = `/archive?${params.toString()}`;
-  const res = await api.get(url);
+  const params = { page, limit };
+  const res = await api.get("/archive", params);
   const data = res.data.data.map((item) => ({
     ...item,
     preview: `/submission/${item.type}/${item.id}`,

--- a/frontend/src/modules/profile/view.jsx
+++ b/frontend/src/modules/profile/view.jsx
@@ -31,26 +31,29 @@ import {
 } from "@ant-design/icons";
 const { TabPane } = Tabs;
 
+const userRoles = new Set(["USER", "REVIEWER", "ADMIN"]);
+const reviewerRoles = new Set(["REVIEWER", "ADMIN"]);
+const adminRoles = new Set(["ADMIN"]);
 const menuItems = [
   {
     key: "personal-details",
     name: "Personal Details",
-    role: "user",
+    role: userRoles,
   },
   {
     key: "my-favourites",
     name: "My Favourites",
-    role: "user",
+    role: userRoles,
   },
   {
     key: "my-network",
     name: "My Network",
-    role: "user",
+    role: userRoles,
   },
   {
     key: "admin-section",
     name: "Admin Section",
-    role: "admin",
+    role: adminRoles,
   },
 ];
 
@@ -78,7 +81,7 @@ const ProfileView = ({ ...props }) => {
     UIStore.update((e) => {
       e.disclaimer = null;
     });
-    if (profile?.role === "ADMIN") {
+    if (adminRoles.has(profile?.role)) {
       (async () => {
         const { page, limit } = pendingItems;
         setPendingItems(await fetchSubmissionData(page, limit));
@@ -141,10 +144,7 @@ const ProfileView = ({ ...props }) => {
   };
 
   const renderMenuItem = (profile) => {
-    let menus = menuItems;
-    if (profile?.role !== "ADMIN") {
-      menus = menuItems.filter((it) => it.role === "user");
-    }
+    const menus = menuItems.filter((it) => it.role.has(profile?.role));
     return menus.map((it) => {
       return (
         <Menu.Item key={it.key} onClick={() => handleOnClickMenu(it.key)}>
@@ -228,7 +228,7 @@ const ProfileView = ({ ...props }) => {
                   </Button>
                 </div>
               )}
-              {menu === "admin-section" && profile?.role === "ADMIN" && (
+              {menu === "admin-section" && adminRoles.has(profile?.role) && (
                 <AdminSection
                   pendingItems={pendingItems}
                   setPendingItems={setPendingItems}

--- a/frontend/src/modules/profile/view.jsx
+++ b/frontend/src/modules/profile/view.jsx
@@ -51,6 +51,11 @@ const menuItems = [
     role: userRoles,
   },
   {
+    key: "review-section",
+    name: "Review Section",
+    role: reviewerRoles,
+  },
+  {
     key: "admin-section",
     name: "Admin Section",
     role: adminRoles,
@@ -190,6 +195,7 @@ const ProfileView = ({ ...props }) => {
             <div>
               {it.key === "my-favourites" && `(${0})`}
               {it.key === "my-network" && `(${0})`}
+              {it.key === "review-section" && `(${reviewItems.count})`}
               {it.key === "admin-section" && `(${pendingItems.count})`}
               &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
               <RightOutlined />

--- a/frontend/src/modules/profile/view.jsx
+++ b/frontend/src/modules/profile/view.jsx
@@ -237,31 +237,6 @@ const ProfileView = ({ ...props }) => {
                 />
               )}
             </Col>
-            {/* <Tabs tabPosition="left" className="fade-in">
-              <TabPane tab="Personal details" key="1">
-                <SignupForm
-                  {...{ onSubmit, tags }}
-                  handleSubmitRef={(ref) => {
-                    handleSubmitRef.current = ref;
-                  }}
-                  initialValues={profile}
-                />
-                <Button
-                  loading={saving}
-                  type="primary"
-                  onClick={(ev) => {
-                    handleSubmitRef.current(ev);
-                  }}
-                >
-                  Update
-                </Button>
-              </TabPane>
-              {profile?.role === "ADMIN" && (
-                <TabPane tab="Admin section" key="2">
-                  <AdminSection />
-                </TabPane>
-              )}
-            </Tabs> */}
           </Row>
         )}
       </div>

--- a/frontend/src/modules/profile/view.jsx
+++ b/frontend/src/modules/profile/view.jsx
@@ -18,9 +18,14 @@ import React, {
 } from "react";
 import StickyBox from "react-sticky-box";
 import api from "../../utils/api";
-import { fetchArchiveData, fetchSubmissionData } from "./utils";
+import {
+  fetchArchiveData,
+  fetchSubmissionData,
+  fetchReviewItems,
+} from "./utils";
 import SignupForm from "../signup/signup-form";
 import AdminSection from "./admin";
+import ReviewSection from "./review";
 import "./styles.scss";
 import isEmpty from "lodash/isEmpty";
 import {
@@ -111,15 +116,13 @@ const ProfileView = ({ ...props }) => {
       })();
     }
     if (reviewerRoles.has(profile?.role)) {
-      (async function fetchData() {
-        const params = { "review-status": "PENDING" };
-        const resp = await api.get("review", params);
-        setReviewItems(resp.data);
+      (async () => {
+        setReviewItems(await fetchReviewItems(reviewItems, "PENDING"));
       })();
-      (async function fetchData() {
-        const params = { "review-status": "ACCEPTED,REJECTED" };
-        const resp = await api.get("review", params);
-        setReviewedItems(resp.data);
+      (async () => {
+        setReviewedItems(
+          await fetchReviewItems(reviewedItems, "ACCEPTED,REJECTED")
+        );
       })();
     }
   }, [profile]);
@@ -259,6 +262,14 @@ const ProfileView = ({ ...props }) => {
                     Update
                   </Button>
                 </div>
+              )}
+              {menu === "review-section" && adminRoles.has(profile?.role) && (
+                <ReviewSection
+                  reviewItems={reviewItems}
+                  setReviewItems={setReviewItems}
+                  reviewedItems={reviewedItems}
+                  setReviewedItems={setReviewedItems}
+                />
               )}
               {menu === "admin-section" && adminRoles.has(profile?.role) && (
                 <AdminSection

--- a/frontend/src/modules/profile/view.jsx
+++ b/frontend/src/modules/profile/view.jsx
@@ -18,7 +18,7 @@ import React, {
 } from "react";
 import StickyBox from "react-sticky-box";
 import api from "../../utils/api";
-import { fetchArchiveData } from "./utils";
+import { fetchArchiveData, fetchSubmissionData } from "./utils";
 import SignupForm from "../signup/signup-form";
 import AdminSection from "./admin";
 import "./styles.scss";
@@ -62,14 +62,14 @@ const ProfileView = ({ ...props }) => {
   const [pendingItems, setPendingItems] = useState({
     data: [],
     limit: 10,
-    page: 0,
+    page: 1,
     count: 0,
     pages: 0,
   });
   const [archiveItems, setArchiveItems] = useState({
     data: [],
     limit: 10,
-    page: 0,
+    page: 1,
     count: 0,
     pages: 0,
   });
@@ -79,9 +79,9 @@ const ProfileView = ({ ...props }) => {
       e.disclaimer = null;
     });
     if (profile?.role === "ADMIN") {
-      (async function fetchData() {
-        const resp = await api.get("submission");
-        setPendingItems(resp.data);
+      (async () => {
+        const { page, limit } = pendingItems;
+        setPendingItems(await fetchSubmissionData(page, limit));
       })();
       (async function fetchData() {
         const archive = await fetchArchiveData(1, 10);

--- a/frontend/src/modules/profile/view.jsx
+++ b/frontend/src/modules/profile/view.jsx
@@ -76,6 +76,20 @@ const ProfileView = ({ ...props }) => {
     count: 0,
     pages: 0,
   });
+  const [reviewItems, setReviewItems] = useState({
+    reviews: [],
+    limit: 10,
+    page: 1,
+    count: 0,
+    pages: 0,
+  });
+  const [reviewedItems, setReviewedItems] = useState({
+    reviews: [],
+    limit: 10,
+    page: 1,
+    count: 0,
+    pages: 0,
+  });
 
   useEffect(() => {
     UIStore.update((e) => {
@@ -89,6 +103,18 @@ const ProfileView = ({ ...props }) => {
       (async function fetchData() {
         const archive = await fetchArchiveData(1, 10);
         setArchiveItems(archive);
+      })();
+    }
+    if (reviewerRoles.has(profile?.role)) {
+      (async function fetchData() {
+        const params = { "review-status": "PENDING" };
+        const resp = await api.get("review", params);
+        setReviewItems(resp.data);
+      })();
+      (async function fetchData() {
+        const params = { "review-status": "ACCEPTED,REJECTED" };
+        const resp = await api.get("review", params);
+        setReviewedItems(resp.data);
       })();
     }
   }, [profile]);

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -42,9 +42,9 @@ const API = () => {
   };
   return {
     get: (url, params, config = {}) =>
-      axios({ url, ...getConfig(), ...config }),
+      axios({ url, params, ...getConfig(), ...config }),
     getRaw: (url, params, config = {}) =>
-      axios({ url, ...getConfig(), ...config, transformResponse: [] }),
+      axios({ url, params, ...getConfig(), ...config, transformResponse: [] }),
     post: (url, data, config = {}) =>
       axios({ url, method: "POST", data, ...getConfig(), ...config }),
     put: (url, data, config) =>


### PR DESCRIPTION
This pull request implements the basic approval workflow where reviewers (users with the roles REVIEWER or ADMIN) can be assigned as reviewers to specific resources.  

A new review section is added to the profile page of reviewers, where a list of all assigned resources can be seen. The reviewers can then accept or reject resources.  This status is visible to admins in the existing admin section. 

Known issues (or things to be done): 
- Allow both reviewers and admins to add a note when accepting/rejecting during the review or approval process. 
- Items that are once accepted or rejected by reviewers cannot be changed in their review status. 
- Items already approved (or declined) by admins are still shown to reviewers as items pending review. It may be confusing if the reviewer accepts/rejects the review later on, after the admin has already approved (or declined) the request. 