### PR TITLE
Add basic UI and API end-points for changing roles for stakeholders

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -191,7 +191,15 @@
                                           {:get {:summary "List Stakeholders"
                                                  :swagger {:tags ["stakeholder"]}
                                                  :parameters #ig/ref :gpml.handler.stakeholder/list-params
-                                                 :handler #ig/ref :gpml.handler.stakeholder/list}}]]
+                                                 :handler #ig/ref :gpml.handler.stakeholder/list}}]
+                                         ["/:id"
+                                          {:patch {:middleware [#ig/ref :gpml.auth/auth-required
+                                                                #ig/ref :gpml.auth/approved-user
+                                                                #ig/ref :gpml.auth/admin-required-middleware]
+                                                   :summary "Edit stakeholder's data"
+                                                   :swagger {:tags ["stakeholder"]}
+                                                   :parameters #ig/ref :gpml.handler.stakeholder/patch-params
+                                                   :handler #ig/ref :gpml.handler.stakeholder/patch}}]]
                                         ["/landing"
                                          [""
                                           {:get {:summary "End-point for the landing page"
@@ -340,6 +348,8 @@
   :gpml.handler.profile/get {:db #ig/ref :duct.database/sql}
   :gpml.handler.stakeholder/list {:db #ig/ref :duct.database/sql}
   :gpml.handler.stakeholder/list-params {}
+  :gpml.handler.stakeholder/patch {:db #ig/ref :duct.database/sql}
+  :gpml.handler.stakeholder/patch-params {}
   :gpml.handler.profile/post {:db #ig/ref :duct.database/sql
                               :mailjet-config #ig/ref :gpml.config/mailjet}
   :gpml.handler.profile/post-params {}

--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -186,11 +186,12 @@
                                                             :security [{:id_token []}]}
                                                   :parameters {:body #ig/ref :gpml.handler.technology/post-params}
                                                   :handler #ig/ref :gpml.handler.technology/post}}]]
-                                        ["/stakeholder"
+                                        ["/stakeholder" {:middleware [#ig/ref :gpml.auth/auth-middleware]}
                                          [""
-                                          {:get {:summary "Get all public stakeholders"
+                                          {:get {:summary "List Stakeholders"
                                                  :swagger {:tags ["stakeholder"]}
-                                                 :handler #ig/ref :gpml.handler.stakeholder/public}}]]
+                                                 :parameters #ig/ref :gpml.handler.stakeholder/list-params
+                                                 :handler #ig/ref :gpml.handler.stakeholder/list}}]]
                                         ["/landing"
                                          [""
                                           {:get {:summary "End-point for the landing page"
@@ -337,7 +338,8 @@
   :gpml.handler.initiative/post-params {}
 
   :gpml.handler.profile/get {:db #ig/ref :duct.database/sql}
-  :gpml.handler.stakeholder/public {:db #ig/ref :duct.database/sql}
+  :gpml.handler.stakeholder/list {:db #ig/ref :duct.database/sql}
+  :gpml.handler.stakeholder/list-params {}
   :gpml.handler.profile/post {:db #ig/ref :duct.database/sql
                               :mailjet-config #ig/ref :gpml.config/mailjet}
   :gpml.handler.profile/post-params {}

--- a/backend/src/gpml/constants.clj
+++ b/backend/src/gpml/constants.clj
@@ -9,4 +9,8 @@
 
 (def reviewer-review-status [:PENDING :ACCEPTED :REJECTED])
 
+(def admin-review-status [:SUBMITTED :APPROVED])
+
+(def user-roles [:USER :REVIEWER :ADMIN])
+
 (def gcs-bucket-name "akvo-unep-gpml")

--- a/backend/src/gpml/db/stakeholder.sql
+++ b/backend/src/gpml/db/stakeholder.sql
@@ -6,6 +6,25 @@ select * from stakeholder order by id;
 -- :doc Get all stakeholder
 select * from stakeholder where public_email=true order by id;
 
+-- :name list-stakeholder-paginated :? :*
+-- :doc Get paginated list of stakeholders
+SELECT * FROM stakeholder
+WHERE 1=1
+--~ (when (:review-status params) "AND review_status = (:v:review-status)::review_status")
+--~ (when (seq (:roles params)) "AND role = ANY(ARRAY[:v*:roles]::stakeholder_role[])")
+--~ (when (:email-like params) "AND email LIKE :v:email-like")
+ORDER BY id
+LIMIT :limit
+OFFSET :limit * (:page - 1);
+
+-- :name count-stakeholder :? :1
+-- :doc Get paginated list of approved stakeholder
+SELECT COUNT(*) FROM stakeholder
+WHERE 1=1
+--~ (when (:review-status params) "AND review_status = (:v:review-status)::review_status")
+--~ (when (seq (:roles params)) "AND role = ANY(ARRAY[:v*:roles]::stakeholder_role[])")
+--~ (when (:email-like params) "AND email LIKE :v:email-like")
+
 -- :name stakeholder-by-id :? :1
 -- :doc Get stakeholder by id
 select

--- a/backend/src/gpml/db/submission.sql
+++ b/backend/src/gpml/db/submission.sql
@@ -40,11 +40,9 @@ SELECT json_build_object(
 
 -- :name detail :? :1
 -- :doc get detail of submission
-SELECT s.email AS created_by_email, t.*
-FROM :i:table-name t
-LEFT JOIN stakeholder s ON s.id =
---~ (if (= (:table-name params) "v_stakeholder_data") "t.id" "t.created_by")
-WHERE t.id = :id::integer;
+SELECT *
+from :i:table-name
+where id = :id::integer;
 
 -- :name update-submission :! :n
 -- :doc approve or reject submission

--- a/backend/src/gpml/handler/review.clj
+++ b/backend/src/gpml/handler/review.clj
@@ -5,6 +5,7 @@
    [gpml.constants :as constants]
    [gpml.db.stakeholder :as db.stakeholder]
    [gpml.db.review :as db.review]
+   [gpml.handler.util :as util]
    [integrant.core :as ig]
    [ring.util.response :as resp]))
 
@@ -85,7 +86,7 @@
         params {:reviewer (:id reviewer) :page page :limit limit :review-status review-status}
         reviews (db.review/reviews-by-reviewer-id conn params)
         count (:count (db.review/count-by-reviewer-id conn params))
-        pages (int (Math/ceil (float (/ count (or (and (> limit 0) limit) 1)))))]
+        pages (util/page-count count limit)]
     (resp/response {:reviews reviews :page page :limit limit :pages pages :count count})))
 
 (defmethod ig/init-key ::get-reviewers [_ {:keys [db]}]

--- a/backend/src/gpml/handler/stakeholder.clj
+++ b/backend/src/gpml/handler/stakeholder.clj
@@ -48,3 +48,17 @@
             [:re roles-re]]
            [:email-like {:optional true}
             string?]]})
+
+(defmethod ig/init-key :gpml.handler.stakeholder/patch [_ {:keys [db]}]
+  (fn [{{{:keys [id]} :path
+         {:keys [role]} :body}
+        :parameters
+        admin :admin}]
+    (let [params {:role role :reviewed_by (:id admin) :id id}
+          count (db.stakeholder/update-stakeholder-role (:spec db) params)]
+      (resp/response {:status (if (= count 1) "success" "failed")}))))
+
+(defmethod ig/init-key ::patch-params [_ _]
+  {:path [:map [:id int?]]
+   :body [:map [:role
+                (apply conj [:enum] (->> constants/user-roles (map name)))]]})

--- a/backend/src/gpml/handler/stakeholder.clj
+++ b/backend/src/gpml/handler/stakeholder.clj
@@ -1,9 +1,50 @@
 (ns gpml.handler.stakeholder
-  (:require [gpml.db.stakeholder :as db.stakeholder]
+  (:require [clojure.string :as str]
+            [gpml.constants :as constants]
+            [gpml.db.stakeholder :as db.stakeholder]
+            [gpml.handler.util :as util]
             [integrant.core :as ig]
             [ring.util.response :as resp]))
 
-(defmethod ig/init-key :gpml.handler.stakeholder/public [_ {:keys [db]}]
-  (fn [_]
-    (resp/response (->> (db.stakeholder/all-public-stakeholder (:spec db))
-                        (map #(select-keys % [:id :title :first_name :last_name :email]))))))
+(def roles-re (->> constants/user-roles
+                   (map name)
+                   (str/join "|")
+                   (format "^(%1$s)((,(%1$s))+)?$")
+                   re-pattern))
+
+(defmethod ig/init-key :gpml.handler.stakeholder/list [_ {:keys [db]}]
+  (fn [{{{:keys [page limit email-like roles] :as query} :query} :parameters
+        user :user approved? :approved?}]
+    (resp/response (if (and approved? (= (:role user) "ADMIN"))
+                     ;; FIXME: Currently hard-coded to allow only for ADMINS.
+                     (let [search (and email-like (format "%%%s%%" email-like))
+                           roles (and roles (str/split roles #","))
+                           params (assoc query :email-like search :roles roles)
+                           stakeholders (db.stakeholder/list-stakeholder-paginated (:spec db) params)
+                           count (:count (db.stakeholder/count-stakeholder (:spec db) params))
+                           pages (util/page-count count limit)]
+                       ;; FIXME: The response is differently shaped
+                       ;; for ADMINS and other users. This should be
+                       ;; changed once the work on the other branches
+                       ;; is finalized. Currently, leaving the public
+                       ;; response shape as before to not break other
+                       ;; uses of this end-point.
+                       {:stakeholders stakeholders :page page :limit limit :pages pages :count count})
+                     ;; FIXME: limit & page are ignored when returning public stakeholders!
+                     (->> (db.stakeholder/all-public-stakeholder (:spec db))
+                          (map #(select-keys % [:id :title :first_name :last_name :email])))))))
+
+(defmethod ig/init-key ::list-params [_ _]
+  {:query [:map
+           [:page {:optional true
+                   :default 1}
+            int?]
+           [:limit {:optional true
+                    :default 10}
+            int?]
+           [:review-status {:optional true}
+            (apply conj [:enum] (->> constants/admin-review-status (map name)))]
+           [:roles {:optional true}
+            [:re roles-re]]
+           [:email-like {:optional true}
+            string?]]})

--- a/backend/src/gpml/handler/submission.clj
+++ b/backend/src/gpml/handler/submission.clj
@@ -46,6 +46,16 @@
                       d)) data)]
     data))
 
+(defn- submission-detail [conn params]
+  (let [data (db.submission/detail conn params)
+        table (:table-name params)
+        creator-id (if (or (= table "stakeholder")
+                           (= table "v_stakeholder_data"))
+                     (:id data)
+                     (:created_by data))
+        creator (db.stakeholder/stakeholder-by-id conn {:id creator-id})]
+    (assoc data :created_by_email (:email creator))))
+
 (defmethod ig/init-key :gpml.handler.submission/get [_ {:keys [db auth0]}]
   (fn [{{:keys [query]} :parameters}]
     (let [submission (-> (db.submission/pages (:spec db) query) :result)
@@ -62,21 +72,22 @@
       (db.submission/update-submission (:spec db) data)
       (assoc (resp/status 204)
              :body {:message "Successfuly Updated"
-                    :data (db.submission/detail (:spec db) data)}))))
+                    :data (submission-detail (:spec db) data)}))))
 
 (defmethod ig/init-key :gpml.handler.submission/get-detail [_ {:keys [db]}]
   (fn [{{:keys [path]} :parameters}]
     (let [conn (:spec db)
           submission (:submission path)
           initiative? (and (= submission "project") (> (:id path) 10000))
-          table-name(cond
-                      (contains? constants/resource-types submission)
-                      "v_resource_data"
-                      initiative?
-                      "initiative"
-                      :else
-                      (str "v_" submission "_data"))
-          detail (db.submission/detail conn (conj path {:table-name table-name}))
+          table-name (cond
+                       (contains? constants/resource-types submission)
+                       "v_resource_data"
+                       initiative?
+                       "initiative"
+                       :else
+                       (str "v_" submission "_data"))
+          params (conj path {:table-name table-name})
+          detail (submission-detail conn params)
           detail (if (= submission "stakeholder")
                    (merge detail
                           (select-keys (db.stakeholder/stakeholder-by-id conn path) [:email])

--- a/backend/src/gpml/handler/util.clj
+++ b/backend/src/gpml/handler/util.clj
@@ -1,4 +1,7 @@
 (ns gpml.handler.util)
 
 (defn page-count [count limit]
-  (int (Math/ceil (float (/ count (or (and (> limit 0) limit) 1))))))
+  (let [limit* (or
+                (and (> limit 0) limit)
+                1)]
+    (int (Math/ceil (float (/ count limit*))))))

--- a/backend/src/gpml/handler/util.clj
+++ b/backend/src/gpml/handler/util.clj
@@ -1,0 +1,4 @@
+(ns gpml.handler.util)
+
+(defn page-count [count limit]
+  (int (Math/ceil (float (/ count (or (and (> limit 0) limit) 1))))))

--- a/backend/test/gpml/handler/stakeholder_test.clj
+++ b/backend/test/gpml/handler/stakeholder_test.clj
@@ -1,0 +1,106 @@
+(ns gpml.handler.stakeholder-test
+  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+            [gpml.fixtures :as fixtures]
+            [gpml.db.stakeholder :as db.stakeholder]
+            [gpml.handler.stakeholder :as stakeholder]
+            [integrant.core :as ig]
+            [ring.mock.request :as mock]))
+
+(use-fixtures :each fixtures/with-test-system)
+
+(defn- new-stakeholder [db email first_name last_name role review_status]
+  (let [info {:picture "https://picsum.photos/200"
+              :affiliation nil
+              :country nil
+              :representation ""
+              :geo_coverage_type nil
+              :title "Mr."
+              :first_name first_name
+              :last_name last_name
+              :public_email true
+              :email email}
+        sth (db.stakeholder/new-stakeholder db info)]
+    (db.stakeholder/update-stakeholder-status db (assoc sth :review_status review_status))
+    (db.stakeholder/update-stakeholder-role db (assoc sth :role role))
+    sth))
+
+(deftest get-stakeholders-public-test
+  (let [system (ig/init fixtures/*system* [::stakeholder/list])
+        handler (::stakeholder/list system)
+        db (-> system :duct.database.sql/hikaricp :spec)
+        ;; Reviewers
+        _ (new-stakeholder db "reviewer-approved@org.com" "R" "A" "REVIEWER" "APPROVED")
+        _ (new-stakeholder db "reviewer-submitted@org.com" "R" "S" "REVIEWER" "SUBMITTED")
+        ;; Admins
+        admin-id (new-stakeholder db "admin-approved@org.com" "A" "A" "ADMIN" "APPROVED")
+        admin (db.stakeholder/stakeholder-by-id db admin-id)
+        _ (new-stakeholder db "admin-submitted@org.com" "A" "S" "ADMIN" "SUBMITTED")
+        ;; User
+        user-id (new-stakeholder db "user-approved@org.com" "U" "A" "USER" "APPROVED")
+        user(db.stakeholder/stakeholder-by-id db user-id)
+        _ (new-stakeholder db "user-submitted@org.com" "U" "S" "USER" "SUBMITTED")]
+
+    (testing "Get stakeholders WITHOUT authenticating"
+      (let [resp (handler (mock/request :get "/"))
+            body (:body resp)]
+        (is (= 200 (:status resp)))
+        (is (= 6 (count body)))
+        (is (nil? (:stakeholders body)))))
+
+    (testing "Get all stakeholders WITHOUT admin role"
+      (let [resp (handler (-> (mock/request :get "/")
+                              (assoc :approved? true
+                                     :user user
+                                     :parameters {:query {:page 1 :limit 10}})))
+            body (:body resp)]
+        (is (= 200 (:status resp)))
+        (is (= 6 (count body)))
+        (is (nil? (:stakeholders body)))))
+
+    (testing "Get all stakeholders"
+      (let [resp (handler (-> (mock/request :get "/")
+                              (assoc :approved? true
+                                     :user admin
+                                     :parameters {:query {:page 1 :limit 10}})))
+            body (:body resp)
+            stakeholders (:stakeholders body)]
+        (is (= 200 (:status resp)))
+        (is (= 6 (:count body)))
+        (is (not-empty stakeholders))))
+
+    (testing "Get only approved stakeholders"
+      (let [resp (handler (-> (mock/request :get "/")
+                              (assoc :approved? true
+                                     :user admin
+                                     :parameters {:query {:page 1 :limit 10 :review-status "APPROVED"}})))
+            body (:body resp)
+            stakeholders (:stakeholders body)]
+        (is (= 200 (:status resp)))
+        (is (= 3 (:count body)))
+        (is (= #{"APPROVED"} (->> stakeholders (map :review_status) set)))))
+
+    (testing "Get USERS & REVIEWERS"
+      (let [resp (handler (-> (mock/request :get "/")
+                              (assoc :approved? true
+                                     :user admin
+                                     :parameters {:query {:page 1 :limit 10 :roles "USER,REVIEWER"}})))
+            body (:body resp)
+            stakeholders (:stakeholders body)]
+        (is (= 200 (:status resp)))
+        (is (= 4 (:count body)))
+        (is (= #{"APPROVED", "SUBMITTED"} (->> stakeholders (map :review_status) set)))
+        (is (= #{"USER", "REVIEWER"} (->> stakeholders (map :role) set)))))
+
+    (testing "Get stakeholders with -approved@ email"
+      (let [resp (handler (-> (mock/request :get "/")
+                              (assoc :approved? true
+                                     :user admin
+                                     :parameters {:query {:page 1 :limit 10 :email-like "-approved@"}})))
+            body (:body resp)
+            stakeholders (:stakeholders body)]
+        (is (= 200 (:status resp)))
+        (is (= 3 (:count body)))
+        (is (= #{"APPROVED"} (->> stakeholders (map :review_status) set)))
+        (is (= #{"USER", "REVIEWER", "ADMIN"} (->> stakeholders (map :role) set)))))
+    )
+  )

--- a/backend/test/gpml/handler/stakeholder_test.clj
+++ b/backend/test/gpml/handler/stakeholder_test.clj
@@ -101,9 +101,7 @@
         (is (= 200 (:status resp)))
         (is (= 3 (:count body)))
         (is (= #{"APPROVED"} (->> stakeholders (map :review_status) set)))
-        (is (= #{"USER", "REVIEWER", "ADMIN"} (->> stakeholders (map :role) set)))))
-    )
-  )
+        (is (= #{"USER", "REVIEWER", "ADMIN"} (->> stakeholders (map :role) set)))))))
 
 (deftest stakeholder-patch-test
   (let [system (ig/init fixtures/*system* [::stakeholder/patch])
@@ -124,6 +122,4 @@
             user (db.stakeholder/stakeholder-by-id db user-id)]
         (is (= 200 (:status resp)))
         (is (= "success" (:status body)))
-        (is (= "REVIEWER" (:role user)))))
-    )
-  )
+        (is (= "REVIEWER" (:role user)))))))

--- a/backend/test/gpml/handler/util_test.clj
+++ b/backend/test/gpml/handler/util_test.clj
@@ -1,0 +1,9 @@
+(ns gpml.handler.util-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [gpml.handler.util :as util]))
+
+(deftest page-count-test
+  (testing "page-count"
+    (is (= 5 (util/page-count 10 2)))
+    (is (= 50 (util/page-count 100 2)))
+    (is (= 100 (util/page-count 100 0)))))

--- a/frontend/src/modules/profile/stakeholders.jsx
+++ b/frontend/src/modules/profile/stakeholders.jsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { Select, Space, Pagination } from "antd";
+import api from "../../utils/api";
+import { userRoles } from "../../utils/misc";
+import { fetchStakeholders } from "./utils";
+
+const RoleSelect = ({ stakeholder, onChangeRole }) => {
+  return (
+    <Select
+      showSearch={false}
+      style={{ width: 150 }}
+      onChange={(role) => onChangeRole(stakeholder, role)}
+      defaultValue={stakeholder?.role}
+      // FIXME: Disallow changing roles of other admins?
+      // disabled={stakeholder?.role === "ADMIN"}
+    >
+      {userRoles.map((r) => (
+        <Select.Option key={r} value={r}>
+          {r}
+        </Select.Option>
+      ))}
+    </Select>
+  );
+};
+
+const Stakeholder = ({ stakeholder, onChangeRole }) => {
+  const { firstName, lastName, title, email } = stakeholder;
+  return (
+    <div className="row stakeholder-row">
+      <Space size="large">
+        <div className="col">{`${firstName} ${lastName} (${email})`}</div>
+        <div className="col">
+          <RoleSelect stakeholder={stakeholder} onChangeRole={onChangeRole} />
+        </div>
+      </Space>
+    </div>
+  );
+};
+
+const ManageRoles = ({ stakeholdersData, setStakeholdersData }) => {
+  const { stakeholders, page, limit, count } = stakeholdersData;
+
+  const updateStakeholdersData = async (page, limit) => {
+    setStakeholdersData(await fetchStakeholders(page, limit));
+  };
+
+  const onPageChange = (page) => {
+    updateStakeholdersData(page, limit);
+  };
+
+  // FIXME: Add Search
+  const changeRole = (stakeholder, role) => {
+    api.patch(`/stakeholder/${stakeholder.id}`, { role }).then((resp) => {
+      // FIXME: Add error handling in case the PATCH fails!
+      updateStakeholdersData(page, limit);
+    });
+  };
+
+  return (
+    <>
+      <h2>Manage Stakeholder Roles</h2>
+      {stakeholders?.map((stakeholder) => (
+        <Stakeholder stakeholder={stakeholder} onChangeRole={changeRole} />
+      ))}
+      <div style={{ padding: "10px 0px" }}>
+        <Pagination
+          defaultCurrent={1}
+          current={page}
+          onChange={onPageChange}
+          pageSize={limit}
+          total={count}
+          defaultPageSize={limit}
+        />
+      </div>
+      <small>* Only approved stakeholders are displayed here</small>
+    </>
+  );
+};
+
+export default ManageRoles;

--- a/frontend/src/modules/profile/utils.js
+++ b/frontend/src/modules/profile/utils.js
@@ -22,3 +22,13 @@ export const fetchReviewItems = async (items, reviewStatus) => {
   const resp = await api.get("review", params);
   return resp.data;
 };
+
+export const fetchStakeholders = async (
+  page,
+  limit,
+  reviewStatus = "APPROVED"
+) => {
+  const params = { page, limit, "review-status": reviewStatus };
+  const resp = await api.get("stakeholder", params);
+  return resp.data;
+};

--- a/frontend/src/modules/profile/view.jsx
+++ b/frontend/src/modules/profile/view.jsx
@@ -23,6 +23,7 @@ import {
   fetchSubmissionData,
   fetchReviewItems,
 } from "./utils";
+import { userRoles as roles } from "../../utils/misc";
 import SignupForm from "../signup/signup-form";
 import AdminSection from "./admin";
 import ReviewSection from "./review";
@@ -36,7 +37,7 @@ import {
 } from "@ant-design/icons";
 const { TabPane } = Tabs;
 
-const userRoles = new Set(["USER", "REVIEWER", "ADMIN"]);
+const userRoles = new Set(roles);
 const reviewerRoles = new Set(["REVIEWER", "ADMIN"]);
 const adminRoles = new Set(["ADMIN"]);
 const menuItems = [

--- a/frontend/src/modules/profile/view.jsx
+++ b/frontend/src/modules/profile/view.jsx
@@ -22,11 +22,13 @@ import {
   fetchArchiveData,
   fetchSubmissionData,
   fetchReviewItems,
+  fetchStakeholders,
 } from "./utils";
 import { userRoles as roles } from "../../utils/misc";
 import SignupForm from "../signup/signup-form";
 import AdminSection from "./admin";
 import ReviewSection from "./review";
+import ManageRoles from "./stakeholders";
 import "./styles.scss";
 import isEmpty from "lodash/isEmpty";
 import {
@@ -55,6 +57,11 @@ const menuItems = [
     key: "my-network",
     name: "My Network",
     role: userRoles,
+  },
+  {
+    key: "manage-roles",
+    name: "Manage User Roles",
+    role: adminRoles,
   },
   {
     key: "review-section",
@@ -101,7 +108,13 @@ const ProfileView = ({ ...props }) => {
     count: 0,
     pages: 0,
   });
-
+  const [stakeholdersData, setStakeholdersData] = useState({
+    stakeholders: [],
+    limit: 10,
+    page: 1,
+    count: 0,
+    pages: 0,
+  });
   useEffect(() => {
     UIStore.update((e) => {
       e.disclaimer = null;
@@ -114,6 +127,11 @@ const ProfileView = ({ ...props }) => {
       (async function fetchData() {
         const archive = await fetchArchiveData(1, 10);
         setArchiveItems(archive);
+      })();
+      (async () => {
+        const { page, limit } = stakeholdersData;
+        const data = await fetchStakeholders(page, limit);
+        setStakeholdersData(data);
       })();
     }
     if (reviewerRoles.has(profile?.role)) {
@@ -263,6 +281,12 @@ const ProfileView = ({ ...props }) => {
                     Update
                   </Button>
                 </div>
+              )}
+              {menu === "manage-roles" && adminRoles.has(profile?.role) && (
+                <ManageRoles
+                  stakeholdersData={stakeholdersData}
+                  setStakeholdersData={setStakeholdersData}
+                />
               )}
               {menu === "review-section" && adminRoles.has(profile?.role) && (
                 <ReviewSection

--- a/frontend/src/utils/misc.js
+++ b/frontend/src/utils/misc.js
@@ -76,3 +76,5 @@ export const relationsByTopicType = {
   stakeholder: ["interested in", "other"],
   organisation: ["interested in", "other"],
 };
+
+export const userRoles = ["USER", "REVIEWER", "ADMIN"];


### PR DESCRIPTION
The UI is intentionally very basic, since this is an MVP and the eventual plan is to have different tabs for managing users (including approvals) and managing resources. This is the eventual design we wish to move towards, as per @loicsans design, but this would require bigger API changes and should be pushed to later.

The basic UI could use some basic CSS and styling improvements, though. @wayangalihpratama may be you could help with this, after this branch is merged, and when you have some time. I didn't spend any effort on CSS work on this branch. 

Issues to think about (or work on):
- Should admins be allowed to remove admin status of other admins? 
- Search functionality for quickly looking up users has not been added in the UI. The API supports searching for users using the email, as of now. 
- The UI doesn't make it super clear to the user that the role of the user has been changed. Some kind of a notice to the user would be helpful. Similarly, when the API call fails, it silently fails. Notifying the user could be useful, here.