### PR TITLE
[#395] Fix crashes when opening /profile directly

### DIFF
--- a/frontend/src/utils/final-field.jsx
+++ b/frontend/src/utils/final-field.jsx
@@ -73,7 +73,7 @@ const CONTROLS = {
     }
     return (
       <Select {...allProps} virtual={false}>
-        {options.map(({ label, value }, i) => (
+        {options?.map(({ label, value }, i) => (
           <Select.Option
             key={`${label}-${value}-${i.toString(36)}`}
             value={value}


### PR DESCRIPTION
When the /profile page is opened directly the tags are not *yet*
populated in the UIStore correctly, and the seeking.options,
offering.options, etc. in the profile form are not set correctly,
causing the profile page to crash. This commit fixes our final-field
Select CONTROL to not crash when options are not set.

This bug was probably present before, but have been exacerbated by the
change in 06882bdd3afa49e33f167b118cc78d1cc5ae93b6, which updates the
UIStore after a bunch of API calls finish, instead of updating the
data when each call finishes. This means the tags data often gets in
the UIStore after the profile data has been fetched.

Previously, fa87bd13b2472248ad4bae4a97507c42c3a0e8c8 tried to fix a
similar crash, but is only half the fix.

Closes #395