### PR TITLE
Add an additional parameter to the browse query to filter by tag

### DIFF
--- a/backend/src/gpml/db/browse.clj
+++ b/backend/src/gpml/db/browse.clj
@@ -1,48 +1,4 @@
 (ns gpml.db.browse
-  (:require [gpml.db.country :as db.country]
-            [hugsql.core :as hugsql]))
+  (:require [hugsql.core :as hugsql]))
 
 (hugsql/def-db-fns "gpml/db/browse.sql")
-
-(comment
-  (require 'dev)
-
-  (declare filter-topic) ;; to make clj-kondo happy
-  (declare topic-counts) ;; to make clj-kondo happy
-  (def params {:favorites 1 :user 1 :resource-types 1 :limit nil}) ;; to make clj-kondo happy
-  (when (seq (:search-text params)) "AND search_text @@ to_tsquery(:search-text)")
-  (when (seq (:geo-coverage params)) "AND geo_coverage IN (:v*:geo-coverage)")
-  (when (seq (:topic params)) "AND topic IN (:v*:topic)")
-  (when-not (or (seq (:geo-coverage params)) (seq (:search-text params))) "LIMIT 50")
-
-  (format "LIMIT %s" (or (and (contains? params :limit) (:limit params)) 20) )
-
-  (when (and (:favorites params) (:user params) (:resource-types params)) "JOIN v_stakeholder_association a ON a.stakeholder = :user AND a.id = (t.json->>'id')::int AND (a.topic = t.topic OR (a.topic = 'resource' AND t.topic IN (:v*:resource-types)))")
-
-  (def db (dev/db-conn))
-
-  (count (filter-topic db {:search-text "marine" :limit nil :offset nil}))
-
-  (count (filter-topic db {:geo-coverage (->> {:codes ["ESP"]}
-                                              (db.country/country-by-codes db)
-                                              (map :id))}))
-  ;; => 50
-
-
-  (count (filter-topic db {:search-text "act"}))
-  ;; => 50
-
-  (count (filter-topic db {:search-text "act"
-                           :geo-coverage [0, (-> (db.country/country-by-code db {:name "IND"}) :id)]}))
-  ;; => 5
-
-  (count (filter-topic db {:search-text "float"
-                           :topic ["technology"]}))
-  ;; => 5
-
-  (filter-topic db {:search-text "act"
-                    :geo-coverage [0, (-> (db.country/country-by-code db {:name "IND"}) :id)]})
-
-  (count (filter-topic db {:search-text "closed" :topic ["technical_resource"]}))
-
-  ,)

--- a/backend/src/gpml/db/browse.sql
+++ b/backend/src/gpml/db/browse.sql
@@ -1,34 +1,19 @@
 -- :name filter-topic :? :*
 -- :doc Filter topic by type, geo_coverage and search string
-SELECT DISTINCT ON (t.topic, (COALESCE(t.json->>'start_date', t.json->>'created'))::timestamptz, (t.json->>'id')::int) t.topic, t.geo_coverage, t.json
-  FROM v_topic t
---~ (when (and (:favorites params) (:user-id params) (:resource-types params)) "JOIN v_stakeholder_association a ON a.stakeholder = :user-id AND a.id = (t.json->>'id')::int AND (a.topic = t.topic OR (a.topic = 'resource' AND t.topic IN (:v*:resource-types)))")
---~ (when (seq (:tag params)) "JOIN json_array_elements(t.json->'tags') tags ON true JOIN json_each_text(tags) tag ON tag.value = ANY(ARRAY[:v*:tag]::varchar[])")
- WHERE 1=1
---~ (when (seq (:search-text params)) "AND t.search_text @@ to_tsquery(:search-text)")
---~ (when (seq (:geo-coverage params)) "AND t.geo_coverage IN (:v*:geo-coverage)")
+-- :require [gpml.sql-util]
+--~ (#'gpml.sql-util/generate-filter-topic-snippet params)
 -- NOTE: We deliberately use a check for nil as opposed to empty list, here. See commit message in
 -- 938110757e03f60e8c5a4396ccea8bd99bcef579
 --~ (when (some? (:topic params)) "AND t.topic = ANY(ARRAY[:v*:topic]::varchar[])")
--- NOTE: Empty strings in the tags column cause problems with using json_array_elements
---~ (when (seq (:tag params)) "AND t.json->>'tags' <> ''")
 ORDER BY (COALESCE(t.json->>'start_date', t.json->>'created'))::timestamptz DESC, (t.json->>'id')::int DESC
 --~ (format "LIMIT %s" (or (and (contains? params :limit) (:limit params)) 50))
 --~ (format "OFFSET %s" (or (and (contains? params :offset) (:offset params)) 0))
 
 -- :name topic-counts :? :*
 -- :doc Return the counts of all topics based on query params
+-- :require [gpml.sql-util]
 WITH results AS (
--- FIXME: Use hugsql snippets to re-use common SQL also used in filter-topic
-  SELECT DISTINCT ON (t.topic, (COALESCE(t.json->>'start_date', t.json->>'created'))::timestamptz, (t.json->>'id')::int) t.topic, t.geo_coverage, t.json
-    FROM v_topic t
---~ (when (and (:favorites params) (:user-id params) (:resource-types params)) "JOIN v_stakeholder_association a ON a.stakeholder = :user-id AND a.id = (t.json->>'id')::int AND (a.topic = t.topic OR (a.topic = 'resource' AND t.topic IN (:v*:resource-types)))")
---~ (when (seq (:tag params)) "JOIN json_array_elements(t.json->'tags') tags ON true JOIN json_each_text(tags) tag ON tag.value = ANY(ARRAY[:v*:tag]::varchar[])")
-  WHERE 1=1
---~ (when (seq (:search-text params)) "AND t.search_text @@ to_tsquery(:search-text)")
---~ (when (seq (:geo-coverage params)) "AND t.geo_coverage IN (:v*:geo-coverage)")
--- NOTE: Empty strings in the tags column cause problems with using json_array_elements
---~ (when (seq (:tag params)) "AND t.json->>'tags' <> ''")
+--~ (#'gpml.sql-util/generate-filter-topic-snippet params)
 )
 SELECT topic, COUNT(topic) FROM results
 GROUP BY topic;

--- a/backend/src/gpml/db/browse.sql
+++ b/backend/src/gpml/db/browse.sql
@@ -3,12 +3,15 @@
 SELECT DISTINCT ON (t.topic, (COALESCE(t.json->>'start_date', t.json->>'created'))::timestamptz, (t.json->>'id')::int) t.topic, t.geo_coverage, t.json
   FROM v_topic t
 --~ (when (and (:favorites params) (:user-id params) (:resource-types params)) "JOIN v_stakeholder_association a ON a.stakeholder = :user-id AND a.id = (t.json->>'id')::int AND (a.topic = t.topic OR (a.topic = 'resource' AND t.topic IN (:v*:resource-types)))")
+--~ (when (seq (:tag params)) "JOIN json_array_elements(t.json->'tags') tags ON true JOIN json_each_text(tags) tag ON tag.value = ANY(ARRAY[:v*:tag]::varchar[])")
  WHERE 1=1
 --~ (when (seq (:search-text params)) "AND t.search_text @@ to_tsquery(:search-text)")
 --~ (when (seq (:geo-coverage params)) "AND t.geo_coverage IN (:v*:geo-coverage)")
 -- NOTE: We deliberately use a check for nil as opposed to empty list, here. See commit message in
 -- 938110757e03f60e8c5a4396ccea8bd99bcef579
 --~ (when (some? (:topic params)) "AND t.topic = ANY(ARRAY[:v*:topic]::varchar[])")
+-- NOTE: Empty strings in the tags column cause problems with using json_array_elements
+--~ (when (seq (:tag params)) "AND t.json->>'tags' <> ''")
 ORDER BY (COALESCE(t.json->>'start_date', t.json->>'created'))::timestamptz DESC, (t.json->>'id')::int DESC
 --~ (format "LIMIT %s" (or (and (contains? params :limit) (:limit params)) 50))
 --~ (format "OFFSET %s" (or (and (contains? params :offset) (:offset params)) 0))
@@ -20,9 +23,12 @@ WITH results AS (
   SELECT DISTINCT ON (t.topic, (COALESCE(t.json->>'start_date', t.json->>'created'))::timestamptz, (t.json->>'id')::int) t.topic, t.geo_coverage, t.json
     FROM v_topic t
 --~ (when (and (:favorites params) (:user-id params) (:resource-types params)) "JOIN v_stakeholder_association a ON a.stakeholder = :user-id AND a.id = (t.json->>'id')::int AND (a.topic = t.topic OR (a.topic = 'resource' AND t.topic IN (:v*:resource-types)))")
+--~ (when (seq (:tag params)) "JOIN json_array_elements(t.json->'tags') tags ON true JOIN json_each_text(tags) tag ON tag.value = ANY(ARRAY[:v*:tag]::varchar[])")
   WHERE 1=1
 --~ (when (seq (:search-text params)) "AND t.search_text @@ to_tsquery(:search-text)")
 --~ (when (seq (:geo-coverage params)) "AND t.geo_coverage IN (:v*:geo-coverage)")
+-- NOTE: Empty strings in the tags column cause problems with using json_array_elements
+--~ (when (seq (:tag params)) "AND t.json->>'tags' <> ''")
 )
 SELECT topic, COUNT(topic) FROM results
 GROUP BY topic;

--- a/backend/src/gpml/db/browse.sql
+++ b/backend/src/gpml/db/browse.sql
@@ -8,7 +8,7 @@ SELECT DISTINCT ON (t.topic, (COALESCE(t.json->>'start_date', t.json->>'created'
 --~ (when (seq (:geo-coverage params)) "AND t.geo_coverage IN (:v*:geo-coverage)")
 -- NOTE: We deliberately use a check for nil as opposed to empty list, here. See commit message in
 -- 938110757e03f60e8c5a4396ccea8bd99bcef579
---~ (when (not (nil? (:topic params))) "AND t.topic = ANY(ARRAY[:v*:topic]::varchar[])")
+--~ (when (some? (:topic params)) "AND t.topic = ANY(ARRAY[:v*:topic]::varchar[])")
 ORDER BY (COALESCE(t.json->>'start_date', t.json->>'created'))::timestamptz DESC, (t.json->>'id')::int DESC
 --~ (format "LIMIT %s" (or (and (contains? params :limit) (:limit params)) 50))
 --~ (format "OFFSET %s" (or (and (contains? params :offset) (:offset params)) 0))

--- a/backend/src/gpml/db/browse.sql
+++ b/backend/src/gpml/db/browse.sql
@@ -6,6 +6,8 @@ SELECT DISTINCT ON (t.topic, (COALESCE(t.json->>'start_date', t.json->>'created'
  WHERE 1=1
 --~ (when (seq (:search-text params)) "AND t.search_text @@ to_tsquery(:search-text)")
 --~ (when (seq (:geo-coverage params)) "AND t.geo_coverage IN (:v*:geo-coverage)")
+-- NOTE: We deliberately use a check for nil as opposed to empty list, here. See commit message in
+-- 938110757e03f60e8c5a4396ccea8bd99bcef579
 --~ (when (not (nil? (:topic params))) "AND t.topic = ANY(ARRAY[:v*:topic]::varchar[])")
 ORDER BY (COALESCE(t.json->>'start_date', t.json->>'created'))::timestamptz DESC, (t.json->>'id')::int DESC
 --~ (format "LIMIT %s" (or (and (contains? params :limit) (:limit params)) 50))

--- a/backend/src/gpml/db/detail.sql
+++ b/backend/src/gpml/db/detail.sql
@@ -15,6 +15,8 @@ WHERE st.stakeholder = :id
 GROUP BY tc.category) AS data;
 
 -- :name update-initiative :! :n
+-- :doc Update the specified initiative row
+-- :require [gpml.sql-util]
 UPDATE initiative SET
 --~ (#'gpml.sql-util/generate-update-initiative params)
 WHERE id = :id;

--- a/backend/src/gpml/handler/browse.clj
+++ b/backend/src/gpml/handler/browse.clj
@@ -26,6 +26,12 @@
     [:or
      [:string {:max 0}]
      [:re topic-re]]]
+   [:tag {:optional true
+          :swagger {:description "Comma separated list of tags"
+                    :type "string"
+                    :collectionFormat "csv"
+                    :allowEmptyValue true}}
+    string?]
    [:q {:optional true
         :swagger {:description "Text search term to be found on the different topics"
                   :type "string"
@@ -49,7 +55,7 @@
     [:int {:min 0}]]])
 
 (defn get-db-filter
-  [{:keys [q country topic favorites user-id limit offset]}]
+  [{:keys [q country topic tag favorites user-id limit offset]}]
   (merge {}
          (when offset
            {:offset offset})
@@ -63,6 +69,8 @@
                                (map read-string))})
          (when (seq topic)
            {:topic (set (str/split topic #","))})
+         (when (seq tag)
+           {:tag (set (str/split tag #","))})
          (when (seq q)
            {:search-text (->> (str/trim q)
                               (re-seq #"\w+")

--- a/backend/src/gpml/sql_util.clj
+++ b/backend/src/gpml/sql_util.clj
@@ -66,6 +66,22 @@
 
               :else value))))))
 
+
+(defn generate-filter-topic-snippet [params]
+  (str/join
+   " "
+   (list
+    "SELECT DISTINCT ON (t.topic, (COALESCE(t.json->>'start_date', t.json->>'created'))::timestamptz, (t.json->>'id')::int) t.topic, t.geo_coverage, t.json FROM v_topic t"
+    (when (and (:favorites params) (:user-id params) (:resource-types params))
+      "JOIN v_stakeholder_association a ON a.stakeholder = :user-id AND a.id = (t.json->>'id')::int AND (a.topic = t.topic OR (a.topic = 'resource' AND t.topic IN (:v*:resource-types)))")
+    (when (seq (:tag params))
+      "JOIN json_array_elements(t.json->'tags') tags ON true JOIN json_each_text(tags) tag ON tag.value = ANY(ARRAY[:v*:tag]::varchar[])")
+    "WHERE 1=1"
+    (when (seq (:search-text params)) "AND t.search_text @@ to_tsquery(:search-text)")
+    (when (seq (:geo-coverage params)) "AND t.geo_coverage IN (:v*:geo-coverage)")
+    ;; NOTE: Empty strings in the tags column cause problems with using json_array_elements
+     (when (seq (:tag params)) "AND t.json->>'tags' <> ''"))))
+
 (comment
   (generate-jsonb {:q3 1 :q4 "300" :q5 nil :created_by "John" :version 1})
   (generate-insert {:q3 1 :q4 "300" :q5 nil :created_by "John" :version 1})

--- a/backend/test/gpml/handler/browse_test.clj
+++ b/backend/test/gpml/handler/browse_test.clj
@@ -214,4 +214,19 @@
         ;; only tech returned
         (is (= 1 (count counts)))
         (is (= (:topic tech-count) "technology"))
-        (is (= (:count tech-count) 1))))))
+        (is (= (:count tech-count) 1))))
+
+    (testing "Testing query for BOGUS tags"
+      (let [resp (handler (-> (mock/request :get "/")
+                              (assoc :parameters {:query {:tag "bogus1,bogus2"}})))
+            body (-> resp :body)
+            results (:results body)]
+        (is (= 0 (count results)))))
+
+    (testing "Testing query for existing tags"
+      (let [resp (handler (-> (mock/request :get "/")
+                              (assoc :parameters {:query {:tag "waste management"}})
+                              ))
+            body (-> resp :body)
+            results (:results body)]
+        (is (= 16 (count results)))))))

--- a/backend/test/gpml/sql_util_test.clj
+++ b/backend/test/gpml/sql_util_test.clj
@@ -1,0 +1,39 @@
+(ns gpml.sql-util-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [clojure.string :as str]
+            [gpml.sql-util :as util]))
+
+(deftest test-generate-filter-topic-snippet
+  (testing "Testing filter-topic snippet with no params"
+    (let [snippet (str/trim (util/generate-filter-topic-snippet nil))]
+      (is (str/starts-with? snippet "SELECT DISTINCT ON"))
+      (is (str/ends-with? snippet "WHERE 1=1"))
+      (is (not (str/includes? snippet "JOIN")))))
+
+  (testing "Testing filter-topic snippet with favorites"
+    (let [params {:favorites true :user-id 1 :resource-types []}
+          snippet (str/trim (util/generate-filter-topic-snippet params))]
+      (is (str/starts-with? snippet "SELECT DISTINCT ON"))
+      (is (str/ends-with? snippet "WHERE 1=1"))
+      (is (str/includes? snippet "JOIN v_stakeholder_association"))))
+
+  (testing "Testing filter-topic snippet with tags"
+    (let [params {:tag ["waste management"]}
+          snippet (str/trim (util/generate-filter-topic-snippet params))]
+      (is (str/starts-with? snippet "SELECT DISTINCT ON"))
+      (is (str/includes? snippet "AND t.json->>'tags'"))
+      (is (str/includes? snippet "JOIN json_array_elements(t.json->'tags')"))))
+
+  (testing "Testing filter-topic snippet with geo-coverage"
+    (let [params {:geo-coverage "global"}
+          snippet (str/trim (util/generate-filter-topic-snippet params))]
+      (is (str/starts-with? snippet "SELECT DISTINCT ON"))
+      (is (str/includes? snippet "AND t.geo_coverage"))
+      (is (not (str/includes? snippet "JOIN")))))
+
+  (testing "Testing filter-topic snippet with search-text"
+    (let [params {:search-text "marine litter"}
+          snippet (str/trim (util/generate-filter-topic-snippet params))]
+      (is (str/starts-with? snippet "SELECT DISTINCT ON"))
+      (is (str/includes? snippet "AND t.search_text"))
+      (is (not (str/includes? snippet "JOIN"))))))


### PR DESCRIPTION
Ideally, we'd like to filter by tag ID, but the initiatives use slightly different tags, searching by tag IDs is not possible. Instead, we allow searching by the actual tag name currently. 