### PR TITLE
[#367] Fix tags data submitted on signup to be numbers

### DIFF
--- a/frontend/src/modules/signup/form.jsx
+++ b/frontend/src/modules/signup/form.jsx
@@ -87,6 +87,9 @@ const SignUpForm = withRouter(
       if (data.offering) {
         data.offering = data.offering.map((x) => Number(x));
       }
+      if (data.tags) {
+        data.tags = data.tags.map((x) => Number(x));
+      }
       data.org = {};
 
       if (data.orgName) {


### PR DESCRIPTION
I'm not sure why we convert the data to String and back to Number, but this is a quick fix to get the signup working on the test server. 