### PR TITLE
[#361] Fix bug: sign in, unable access the profile

### DIFF
--- a/frontend/src/root.jsx
+++ b/frontend/src/root.jsx
@@ -261,11 +261,15 @@ const Root = () => {
               {!isAuthenticated || !isRegistered(profile) ? (
                 <div className="rightside btn-wrapper">
                   <JoinGPMLButton loginWithPopup={loginWithPopup} />
-                  <Button type="ghost" className="left">
-                    <Link to="/" onClick={loginWithPopup}>
-                      Sign in
-                    </Link>
-                  </Button>
+                  {isAuthenticated && !isRegistered(profile) ? (
+                    <UserButton {...{ logout, isRegistered, profile }} />
+                  ) : (
+                    <Button type="ghost" className="left">
+                      <Link to="/" onClick={loginWithPopup}>
+                        Sign in
+                      </Link>
+                    </Button>
+                  )}
                 </div>
               ) : (
                 <div className="rightside btn-wrapper">
@@ -277,7 +281,7 @@ const Root = () => {
                       setWarningModalVisible,
                     }}
                   />
-                  <UserButton {...{ logout }} />
+                  <UserButton {...{ logout, isRegistered, profile }} />
                 </div>
               )}
               {/* Drawer/ Menu for responsive design */}
@@ -546,7 +550,7 @@ const Search = withRouter(({ history }) => {
   );
 });
 
-const UserButton = withRouter(({ history, logout }) => {
+const UserButton = withRouter(({ history, logout, isRegistered, profile }) => {
   return (
     <Dropdown
       overlayClassName="user-btn-dropdown-wrapper"
@@ -554,7 +558,7 @@ const UserButton = withRouter(({ history, logout }) => {
         <Menu className="user-btn-dropdown">
           <Menu.Item
             onClick={() => {
-              history.push("/profile");
+              history.push(`/${isRegistered(profile) ? "profile" : "signup"}`);
             }}
           >
             Profile

--- a/frontend/src/utils/profile.js
+++ b/frontend/src/utils/profile.js
@@ -17,5 +17,5 @@ export const updateStatusProfile = (data) => {
 };
 
 export const isRegistered = (profile) => {
-  return Boolean(profile.about);
+  return Boolean(profile?.reviewStatus);
 };


### PR DESCRIPTION
- [x] Unable access profile after sign in.
  - For this problem (sign in / sign up in auth0 but not filling signup form on portal),
I think we can change the signin button to a user icon, and if user click profile that will going to `/signup` page (same as when user click Join GPML btn).