### PR TITLE
[#372] Fix bug: show only resources on browse view when click all resource from nav

### DIFF
--- a/frontend/src/modules/browse/view.jsx
+++ b/frontend/src/modules/browse/view.jsx
@@ -159,7 +159,12 @@ const Browse = ({
   };
 
   useEffect(() => {
-    updateQuery("topic", isEmpty(filterMenu) ? [] : filterMenu);
+    updateQuery(
+      "topic",
+      isEmpty(filterMenu)
+        ? topicTypes.map((x) => humps.decamelize(x))
+        : filterMenu
+    );
     // NOTE: this are triggered when user click a topic from navigation menu
   }, [filterMenu]); // eslint-disable-line
 


### PR DESCRIPTION
- [x] Selecting "All resources" from top nav Knowledge Exchange directs you wrongly to a list of all Entities (B42)