### PR TITLE
[#478] Filter/split GET review API call by resources or stakeholders

### DIFF
--- a/backend/src/gpml/db/review.sql
+++ b/backend/src/gpml/db/review.sql
@@ -20,7 +20,9 @@ END) AS title,
 END) AS type
 FROM review r
 WHERE reviewer = :reviewer
---~ (when (seq (:review-status params)) "AND review_status = ANY(ARRAY[:v*:review-status]::reviewer_review_status[])")
+--~ (when (seq (:review-status params)) "AND review_status = ANY(ARRAY[:v*:review-status]::reviewer_review_status[]) ")
+--~ (when (= "stakeholders" (:only params)) "AND topic_type IN ('stakeholder', 'organisation') ")
+--~ (when (= "resources" (:only params)) "AND topic_type NOT IN ('stakeholder', 'organisation') ")
 ORDER BY id
 LIMIT :limit
 OFFSET :limit * (:page - 1);
@@ -29,7 +31,9 @@ OFFSET :limit * (:page - 1);
 -- :doc Get reviews for reviewer
 SELECT COUNT(*) FROM review
 WHERE reviewer = :reviewer
---~ (when (seq (:review-status params)) "AND review_status = ANY(ARRAY[:v*:review-status]::reviewer_review_status[])")
+--~ (when (seq (:review-status params)) "AND review_status = ANY(ARRAY[:v*:review-status]::reviewer_review_status[]) ")
+--~ (when (= "stakeholders" (:only params)) "AND topic_type IN ('stakeholder', 'organisation') ")
+--~ (when (= "resources" (:only params)) "AND topic_type NOT IN ('stakeholder', 'organisation') ")
 
 -- :name review-by-id :? :1
 -- :doc Get review by id

--- a/backend/src/gpml/handler/review.clj
+++ b/backend/src/gpml/handler/review.clj
@@ -101,10 +101,11 @@
           resp403)
         resp403))))
 
-(defn list-reviews [db reviewer page limit status]
+(defn list-reviews [db reviewer page limit status only]
   (let [conn (:spec db)
         review-status (and status (str/split status #","))
-        params {:reviewer (:id reviewer) :page page :limit limit :review-status review-status}
+        params {:reviewer (:id reviewer) :page page :limit limit :review-status review-status
+                :only only}
         reviews (db.review/reviews-by-reviewer-id conn params)
         count (:count (db.review/count-by-reviewer-id conn params))
         pages (util/page-count count limit)]
@@ -133,9 +134,9 @@
       (update-review-status db mailjet-config topic-type topic-id review-status review-comment current-user))))
 
 (defmethod ig/init-key ::list-reviews [_ {:keys [db]}]
-  (fn [{{{:keys [page limit review-status]} :query} :parameters
+  (fn [{{{:keys [page limit review-status only]} :query} :parameters
         reviewer :reviewer}]
-    (list-reviews db reviewer page limit review-status)))
+    (list-reviews db reviewer page limit review-status only)))
 
 (defmethod ig/init-key ::review-status-params [_ _]
   (apply conj [:enum] (map name constants/reviewer-review-status)))
@@ -148,5 +149,6 @@
            [:limit {:optional true
                     :default 10}
             int?]
+           [:only {:optional true} [:enum "resources" "stakeholders"]]
            [:review-status {:optional true}
             [:re review-status-re]]]})


### PR DESCRIPTION
### Update on `GET api/review?<query-args>`

- this PR support additional and optional `only` query arg

- possible values: `only=resources` or `only=stakeholders`

eg: `review-status=PENDING&page=1&limit=10&only=resources`