### PR TITLE
[#567] Auth multiple stakeholders to one resource

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -284,32 +284,32 @@
                                                   :parameters {:body #ig/ref :gpml.handler.favorite/post-params}
                                                   :handler #ig/ref :gpml.handler.favorite/post}}]]
                                         ["/detail"
-                                        ["/{topic-type}/{topic-id}"
-                                         {:get {:middleware [#ig/ref :gpml.auth/auth-middleware]
-                                                :summary "Get the details for a specific resource"
-                                                :swagger {:tags ["resource detail"]}
-                                                :parameters {:path [:map
-                                                                    [:topic-type #ig/ref :gpml.handler.detail/topics]
-                                                                    [:topic-id int?]]}
-                                                :handler #ig/ref :gpml.handler.detail/get}
-                                          :delete {:middleware [#ig/ref :gpml.auth/auth-middleware]
-                                                   :summary "remove specific resource"
-                                                   :swagger {:tags ["resource detail"]}
-                                                   :parameters {:path [:map
-                                                                       [:topic-type #ig/ref :gpml.handler.detail/topics]
-                                                                       [:topic-id int?]]}
-                                                   :handler #ig/ref :gpml.handler.detail/delete}
-                                          :put {:middleware [#ig/ref :gpml.auth/auth-middleware
-                                                             #ig/ref :gpml.auth/auth-required
-                                                             #ig/ref :gpml.auth/approved-user]
-                                                :summary "Edit the details for a specific resource"
-                                                :swagger {:tags ["resource detail"]
-                                                          :security[{:id_token []}]}
-                                                :parameters {:path [:map
-                                                                    [:topic-type #ig/ref :gpml.handler.detail/topics]
-                                                                    [:topic-id int?]]
-                                                             :body #ig/ref :gpml.handler.detail/put-params}
-                                                :handler #ig/ref :gpml.handler.detail/put}}]]]]
+                                         ["/{topic-type}/{topic-id}"
+                                          {:get {:middleware [#ig/ref :gpml.auth/auth-middleware]
+                                                 :summary "Get the details for a specific resource"
+                                                 :swagger {:tags ["resource detail"]}
+                                                 :parameters {:path [:map
+                                                                     [:topic-type #ig/ref :gpml.handler.detail/topics]
+                                                                     [:topic-id int?]]}
+                                                 :handler #ig/ref :gpml.handler.detail/get}
+                                           :delete {:middleware [#ig/ref :gpml.auth/auth-middleware]
+                                                    :summary "remove specific resource"
+                                                    :swagger {:tags ["resource detail"]}
+                                                    :parameters {:path [:map
+                                                                        [:topic-type #ig/ref :gpml.handler.detail/topics]
+                                                                        [:topic-id int?]]}
+                                                    :handler #ig/ref :gpml.handler.detail/delete}
+                                           :put {:middleware [#ig/ref :gpml.auth/auth-middleware
+                                                              #ig/ref :gpml.auth/auth-required
+                                                              #ig/ref :gpml.auth/approved-user]
+                                                 :summary "Edit the details for a specific resource"
+                                                 :swagger {:tags ["resource detail"]
+                                                           :security[{:id_token []}]}
+                                                 :parameters {:path [:map
+                                                                     [:topic-type #ig/ref :gpml.handler.detail/topics]
+                                                                     [:topic-id int?]]
+                                                              :body #ig/ref :gpml.handler.detail/put-params}
+                                                 :handler #ig/ref :gpml.handler.detail/put}}]]]]
                               :logger #ig/ref :duct.logger/timbre}
 
   :duct.server.http/jetty {:handler #ig/ref :gpml.handler.main/handler}

--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -293,13 +293,13 @@
                                                                       [:topic-type #ig/ref :gpml.handler.detail/topics]
                                                                       [:topic-id int?]]}
                                                   :handler #ig/ref :gpml.handler.auth/get-topic-auth}}]
-                                          ["/{stakeholder-id}"
+                                          ["/{stakeholder}"
                                            {:get {:summary "Get auth details for a specific resource and stakeholder"
                                                   :swagger {:tags ["topic stakeholder auth detail"]}
                                                   :parameters {:path [:map
                                                                       [:topic-type #ig/ref :gpml.handler.detail/topics]
                                                                       [:topic-id int?]
-                                                                      [:stakeholder-id int?]]}
+                                                                      [:stakeholder int?]]}
                                                   :handler #ig/ref :gpml.handler.auth/get-topic-stakeholder-auth}}]]]
                                         ["/detail"
                                          ["/{topic-type}/{topic-id}"

--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -431,8 +431,8 @@
                          :sentry {:dsn #duct/env "SENTRY_DSN"
                                   :environment #duct/env "ENV_NAME"}}
 
-  :gpml.handler.auth/get-topic-stakeholder-auth {:db #ig/ref :duct.database/sql}
-  :gpml.handler.auth/get-topic-auth {:db #ig/ref :duct.database/sql}
+  :gpml.handler.auth/get-topic-stakeholder-auth {:conn #ig/ref :gpml.db/spec}
+  :gpml.handler.auth/get-topic-auth {:conn #ig/ref :gpml.db/spec}
 
   :gpml.handler.detail/topics {}
   :gpml.handler.detail/get {:db #ig/ref :duct.database/sql}

--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -287,14 +287,42 @@
                                          ["/{topic-type}/{topic-id}"
                                           [""
                                            {:get {
-                                                  :summary "Get auth details for a specific resource"
+                                                  :summary "Get auth details for a specific topic"
                                                   :swagger {:tags ["topic auth detail"]}
                                                   :parameters {:path [:map
                                                                       [:topic-type #ig/ref :gpml.handler.detail/topics]
                                                                       [:topic-id int?]]}
                                                   :handler #ig/ref :gpml.handler.auth/get-topic-auth}}]
                                           ["/{stakeholder}"
-                                           {:get {:summary "Get auth details for a specific resource and stakeholder"
+                                           {:put {:summary "Update stakeholder auth roles"
+                                                   :swagger {:tags ["topic auth stakeholder"]
+                                                             :security [{:id_token []}]}
+                                                   :parameters {:path [:map
+                                                                      [:topic-type #ig/ref :gpml.handler.detail/topics]
+                                                                      [:topic-id int?]
+                                                                      [:stakeholder int?]]
+                                                                :body [:map
+                                                                       [:roles [:vector [:enum "owner"]]]]}
+                                                   :handler #ig/ref :gpml.handler.auth/update-roles}
+                                            :post {:summary "Add stakeholder auth roles to topic"
+                                                   :swagger {:tags ["topic auth stakeholder"]
+                                                             :security [{:id_token []}]}
+                                                   :parameters {:path [:map
+                                                                      [:topic-type #ig/ref :gpml.handler.detail/topics]
+                                                                      [:topic-id int?]
+                                                                      [:stakeholder int?]]
+                                                                :body [:map
+                                                                       [:roles [:vector [:enum "owner"]]]]}
+                                                   :handler #ig/ref :gpml.handler.auth/new-roles}
+                                            :delete {:summary "Delete auth details for a specific resource and stakeholder"
+                                                     :swagger {:tags ["topic stakeholder auth detail"]
+                                                               :security [{:id_token []}]}
+                                                     :parameters {:path [:map
+                                                                         [:topic-type #ig/ref :gpml.handler.detail/topics]
+                                                                         [:topic-id int?]
+                                                                         [:stakeholder int?]]}
+                                                     :handler #ig/ref :gpml.handler.auth/delete}
+                                            :get {:summary "Get auth details for a specific resource and stakeholder"
                                                   :swagger {:tags ["topic stakeholder auth detail"]}
                                                   :parameters {:path [:map
                                                                       [:topic-type #ig/ref :gpml.handler.detail/topics]
@@ -433,7 +461,9 @@
 
   :gpml.handler.auth/get-topic-stakeholder-auth {:conn #ig/ref :gpml.db/spec}
   :gpml.handler.auth/get-topic-auth {:conn #ig/ref :gpml.db/spec}
-
+  :gpml.handler.auth/new-roles {:conn #ig/ref :gpml.db/spec}
+  :gpml.handler.auth/update-roles {:conn #ig/ref :gpml.db/spec}
+  :gpml.handler.auth/delete {:conn #ig/ref :gpml.db/spec}
   :gpml.handler.detail/topics {}
   :gpml.handler.detail/get {:db #ig/ref :duct.database/sql}
   :gpml.handler.detail/delete {:db #ig/ref :duct.database/sql

--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -286,13 +286,24 @@
                                         ["/auth" {:middleware [#ig/ref :gpml.auth/auth-middleware]}
                                          ["/{topic-type}/{topic-id}"
                                           [""
-                                           {:get {
-                                                  :summary "Get auth details for a specific topic"
+                                           {:get {:summary "Get auth details for a specific topic"
                                                   :swagger {:tags ["topic auth detail"]}
                                                   :parameters {:path [:map
                                                                       [:topic-type #ig/ref :gpml.handler.detail/topics]
                                                                       [:topic-id int?]]}
-                                                  :handler #ig/ref :gpml.handler.auth/get-topic-auth}}]
+                                                  :handler #ig/ref :gpml.handler.auth/get-topic-auth}
+                                            :post {:summary "Add stakeholders auth roles to topic"
+                                                   :swagger {:tags ["topic auth stakeholder"]
+                                                             :security [{:id_token []}]}
+                                                   :parameters {:path [:map
+                                                                      [:topic-type #ig/ref :gpml.handler.detail/topics]
+                                                                      [:topic-id int?]]
+                                                                :body [:map
+                                                                       [:stakeholders
+                                                                        [:vector [:map
+                                                                                  [:id int?]
+                                                                                  [:roles [:vector [:enum "owner"]]]]]]]}
+                                                   :handler #ig/ref :gpml.handler.auth/post-topic-auth}}]
                                           ["/{stakeholder}"
                                            {:put {:summary "Update stakeholder auth roles"
                                                    :swagger {:tags ["topic auth stakeholder"]
@@ -461,6 +472,7 @@
 
   :gpml.handler.auth/get-topic-stakeholder-auth {:conn #ig/ref :gpml.db/spec}
   :gpml.handler.auth/get-topic-auth {:conn #ig/ref :gpml.db/spec}
+  :gpml.handler.auth/post-topic-auth {:conn #ig/ref :gpml.db/spec}
   :gpml.handler.auth/new-roles {:conn #ig/ref :gpml.db/spec}
   :gpml.handler.auth/update-roles {:conn #ig/ref :gpml.db/spec}
   :gpml.handler.auth/delete {:conn #ig/ref :gpml.db/spec}

--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -283,6 +283,24 @@
                                                             :security [{:id_token []}]}
                                                   :parameters {:body #ig/ref :gpml.handler.favorite/post-params}
                                                   :handler #ig/ref :gpml.handler.favorite/post}}]]
+                                        ["/auth" {:middleware [#ig/ref :gpml.auth/auth-middleware]}
+                                         ["/{topic-type}/{topic-id}"
+                                          [""
+                                           {:get {
+                                                  :summary "Get auth details for a specific resource"
+                                                  :swagger {:tags ["topic auth detail"]}
+                                                  :parameters {:path [:map
+                                                                      [:topic-type #ig/ref :gpml.handler.detail/topics]
+                                                                      [:topic-id int?]]}
+                                                  :handler #ig/ref :gpml.handler.auth/get-topic-auth}}]
+                                          ["/{stakeholder-id}"
+                                           {:get {:summary "Get auth details for a specific resource and stakeholder"
+                                                  :swagger {:tags ["topic stakeholder auth detail"]}
+                                                  :parameters {:path [:map
+                                                                      [:topic-type #ig/ref :gpml.handler.detail/topics]
+                                                                      [:topic-id int?]
+                                                                      [:stakeholder-id int?]]}
+                                                  :handler #ig/ref :gpml.handler.auth/get-topic-stakeholder-auth}}]]]
                                         ["/detail"
                                          ["/{topic-type}/{topic-id}"
                                           {:get {:middleware [#ig/ref :gpml.auth/auth-middleware]
@@ -412,6 +430,9 @@
                                  :clientId #duct/env "OIDC_AUDIENCE"}
                          :sentry {:dsn #duct/env "SENTRY_DSN"
                                   :environment #duct/env "ENV_NAME"}}
+
+  :gpml.handler.auth/get-topic-stakeholder-auth {:db #ig/ref :duct.database/sql}
+  :gpml.handler.auth/get-topic-auth {:db #ig/ref :duct.database/sql}
 
   :gpml.handler.detail/topics {}
   :gpml.handler.detail/get {:db #ig/ref :duct.database/sql}

--- a/backend/resources/migrations/107-topic-stakeholder-auth-table.down.sql
+++ b/backend/resources/migrations/107-topic-stakeholder-auth-table.down.sql
@@ -1,0 +1,2 @@
+drop INDEX IF EXISTS topic_stakeholder_auth_topic_type_id_idx;
+drop TABLE IF EXISTS topic_stakeholder_auth;

--- a/backend/resources/migrations/107-topic-stakeholder-auth-table.up.sql
+++ b/backend/resources/migrations/107-topic-stakeholder-auth-table.up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE topic_stakeholder_auth (
+   id serial PRIMARY KEY,
+   stakeholder integer NOT NULL REFERENCES stakeholder(id),
+   topic_id integer NOT NULL,
+   topic_type topic_type NOT NULL,
+   roles jsonb NOT NULL DEFAULT '[]',
+   created timestamptz NOT NULL DEFAULT now(),
+   modified timestamptz NOT NULL DEFAULT now(),
+   UNIQUE(stakeholder, topic_id, topic_type)
+);
+
+CREATE INDEX topic_stakeholder_auth_topic_type_id_idx ON topic_stakeholder_auth (topic_type, topic_id);
+
+DO $$
+BEGIN
+    PERFORM install_update_modified('topic_stakeholder_auth');
+END$$;

--- a/backend/src/gpml/db/topic_stakeholder_auth.clj
+++ b/backend/src/gpml/db/topic_stakeholder_auth.clj
@@ -1,0 +1,4 @@
+(ns gpml.db.topic-stakeholder-auth
+  (:require [hugsql.core :as hugsql]))
+
+(hugsql/def-db-fns "gpml/db/topic_stakeholder_auth.sql")

--- a/backend/src/gpml/db/topic_stakeholder_auth.sql
+++ b/backend/src/gpml/db/topic_stakeholder_auth.sql
@@ -16,7 +16,11 @@ INSERT INTO topic_stakeholder_auth(stakeholder, topic_id, topic_type, roles)
 values (:stakeholder, :topic-id, :topic-type::topic_type, :roles)
 
 -- :name delete-auth :! :n
-delete from topic_stakeholder_auth where id=:id
+delete from topic_stakeholder_auth
+where stakeholder=:stakeholder and
+topic_id=:topic-id and
+topic_type=:topic-type::topic_type
+
 
 -- :name update-auth :! :n
 update topic_stakeholder_auth set roles = :roles

--- a/backend/src/gpml/db/topic_stakeholder_auth.sql
+++ b/backend/src/gpml/db/topic_stakeholder_auth.sql
@@ -1,0 +1,25 @@
+-- :name get-auth-by-topic :? :*
+-- :doc Get details about a particular topic
+select * from topic_stakeholder_auth where topic_id=:topic-id and topic_type=:topic-type::topic_type;
+
+-- :name get-auth-by-topic-and-stakeholder :? :1
+-- :doc Get details about a particular topic
+select * from topic_stakeholder_auth where topic_id=:topic-id and topic_type=:topic-type::topic_type and stakeholder=:stakeholder;
+
+-- :name get-auth-by-stakeholder :? :*
+-- :doc Get details about a particular topic
+select * from topic_stakeholder_auth where stakeholder=:stakeholder;
+
+
+-- :name new-auth :! :1
+INSERT INTO topic_stakeholder_auth(stakeholder, topic_id, topic_type, roles)
+values (:stakeholder, :topic-id, :topic-type::topic_type, :roles)
+
+-- :name delete-auth :! :n
+delete from topic_stakeholder_auth where id=:id
+
+-- :name update-auth :! :n
+update topic_stakeholder_auth set roles = :roles
+where stakeholder=:stakeholder and
+topic_id=:topic-id and
+topic_type=:topic-type::topic_type

--- a/backend/src/gpml/handler/auth.clj
+++ b/backend/src/gpml/handler/auth.clj
@@ -1,0 +1,33 @@
+(ns gpml.handler.auth
+  (:require
+   ;;   [clojure.java.jdbc :as jdbc]
+   ;;   [clojure.string :as str]
+   ;;   [gpml.constants :as constants]
+   [gpml.handler.util :as util]
+   ;;   [gpml.model.topic :as model.topic]
+   [integrant.core :as ig]
+   [ring.util.response :as resp]))
+
+
+(defmethod ig/init-key ::get-topic-auth [_ {:keys [db]}]
+  (fn [{{:keys [path]} :parameters approved? :approved? user :user}]
+    (let [conn        (:spec db)
+  ;;        topic       (:topic-type path)
+          ]
+      (if-let [data {}]
+        (resp/response (merge path
+
+                              {:message "topic auth"
+                               :user user}))
+        util/not-found))))
+
+(defmethod ig/init-key ::get-topic-stakeholder-auth [_ {:keys [db]}]
+  (fn [{{:keys [path]} :parameters approved? :approved? user :user}]
+    (let [conn        (:spec db)
+;;          topic       (:topic-type path)
+          ]
+      (if-let [data {}]
+        (resp/response (merge path
+                              {:message "topic auth"
+                               :user user}))
+        util/not-found))))

--- a/backend/src/gpml/handler/auth.clj
+++ b/backend/src/gpml/handler/auth.clj
@@ -9,16 +9,12 @@
    [integrant.core :as ig]
    [ring.util.response :as resp]))
 
-
 (defmethod ig/init-key ::get-topic-auth [_ {:keys [conn]}]
   (fn [{{:keys [path]} :parameters user :user}]
     (let [authorized? user]
       (if authorized?
-        (if-let [data {}]
-         (resp/response (merge path
-                               data
-                               {:message "topic auth"
-                                :user user}))
+        (if-let [data (db.ts-auth/get-auth-by-topic conn path)]
+         (resp/response (merge path {:auth-stakeholders data}))
          util/not-found)
         util/unauthorized))))
 
@@ -26,10 +22,7 @@
   (fn [{{:keys [path]} :parameters user :user}]
     (let [authorized? user]
       (if authorized?
-        (if-let [data {}]
-          (resp/response (merge path
-                                data
-                               {:message "topic auth"
-                                :user user}))
+        (if-let [data (db.ts-auth/get-auth-by-topic-and-stakeholder conn path)]
+          (resp/response (merge path data))
          util/not-found)
         util/unauthorized))))

--- a/backend/src/gpml/handler/auth.clj
+++ b/backend/src/gpml/handler/auth.clj
@@ -14,8 +14,8 @@
     (let [authorized? user]
       (if authorized?
         (if-let [data (db.ts-auth/get-auth-by-topic conn path)]
-         (resp/response (merge path {:auth-stakeholders data}))
-         util/not-found)
+          (resp/response (merge path {:auth-stakeholders data}))
+          util/not-found)
         util/unauthorized))))
 
 (defmethod ig/init-key ::get-topic-stakeholder-auth [_ {:keys [conn]}]
@@ -24,5 +24,32 @@
       (if authorized?
         (if-let [data (db.ts-auth/get-auth-by-topic-and-stakeholder conn path)]
           (resp/response (merge path data))
-         util/not-found)
+          util/not-found)
+        util/unauthorized))))
+
+(defmethod ig/init-key ::new-roles [_ {:keys [conn]}]
+  (fn [{{:keys [path body]} :parameters user :user}]
+    (let [authorized? user]
+      (if authorized?
+        (do
+          (db.ts-auth/new-auth conn (merge path body))
+          (resp/response (merge path body)))
+        util/unauthorized))))
+
+(defmethod ig/init-key ::update-roles [_ {:keys [conn]}]
+  (fn [{{:keys [path body]} :parameters user :user}]
+    (let [authorized? user]
+      (if authorized?
+        (do
+          (db.ts-auth/update-auth conn (merge path body))
+          (resp/response (merge path body)))
+        util/unauthorized))))
+
+(defmethod ig/init-key ::delete [_ {:keys [conn]}]
+  (fn [{{:keys [path body]} :parameters user :user}]
+    (let [authorized? user]
+      (if authorized?
+        (do
+          (db.ts-auth/delete-auth conn path)
+          (resp/response (merge path body)))
         util/unauthorized))))

--- a/backend/src/gpml/handler/auth.clj
+++ b/backend/src/gpml/handler/auth.clj
@@ -4,30 +4,32 @@
    ;;   [clojure.string :as str]
    ;;   [gpml.constants :as constants]
    [gpml.handler.util :as util]
+   [gpml.db.topic-stakeholder-auth :as db.ts-auth]
    ;;   [gpml.model.topic :as model.topic]
    [integrant.core :as ig]
    [ring.util.response :as resp]))
 
 
-(defmethod ig/init-key ::get-topic-auth [_ {:keys [db]}]
-  (fn [{{:keys [path]} :parameters approved? :approved? user :user}]
-    (let [conn        (:spec db)
-  ;;        topic       (:topic-type path)
-          ]
-      (if-let [data {}]
-        (resp/response (merge path
+(defmethod ig/init-key ::get-topic-auth [_ {:keys [conn]}]
+  (fn [{{:keys [path]} :parameters user :user}]
+    (let [authorized? user]
+      (if authorized?
+        (if-let [data {}]
+         (resp/response (merge path
+                               data
+                               {:message "topic auth"
+                                :user user}))
+         util/not-found)
+        util/unauthorized))))
 
-                              {:message "topic auth"
-                               :user user}))
-        util/not-found))))
-
-(defmethod ig/init-key ::get-topic-stakeholder-auth [_ {:keys [db]}]
-  (fn [{{:keys [path]} :parameters approved? :approved? user :user}]
-    (let [conn        (:spec db)
-;;          topic       (:topic-type path)
-          ]
-      (if-let [data {}]
-        (resp/response (merge path
-                              {:message "topic auth"
-                               :user user}))
-        util/not-found))))
+(defmethod ig/init-key ::get-topic-stakeholder-auth [_ {:keys [conn]}]
+  (fn [{{:keys [path]} :parameters user :user}]
+    (let [authorized? user]
+      (if authorized?
+        (if-let [data {}]
+          (resp/response (merge path
+                                data
+                               {:message "topic auth"
+                                :user user}))
+         util/not-found)
+        util/unauthorized))))


### PR DESCRIPTION
- `GET api/auth/<topic-type>/<topic-id>`
List of stakeholders-auth-details for a specific topic

- `POST api/auth/<topic-type>/<topic-id>`
body `{"stakeholders": [{"id": 10001, "roles": ["owner"]}, {"id": 10002, "roles": ["owner"]}]}`  
For a specific topic, add auth roles for each stakeholder included in body payload

- `GET api/auth/<topic-type>/<topic-id>/<stakeholder-id>`
stakeholder-auth-details for a specific topic and stakeholder

- `POST api/auth/<topic-type>/<topic-id>/<stakeholder-id> `
body `{"roles": ["owner"]}`  
Add roles for a specific stakeholder and topic

- `PUT api/auth/<topic-type>/<topic-id>/<stakeholder-id> `
 body `{"roles": ["owner"]}`  ||  `{"roles": []}`  
Update roles for a specific topic

- `DELETE api/auth/<topic-type>/<topic-id>/<stakeholder-id>`
Delete stakeholder-auth-details for a specific topic and stakeholder


### "owner" is so far the only role allowed
