### PR TITLE
[#601] Fix auth0 misconfiguration for gmpl.handler.env/get

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -481,7 +481,8 @@
   :gpml.handler.favorite/post {:db #ig/ref :duct.database/sql}
   :gpml.handler.favorite/post-params {}
 
-  :gpml.handler.env/get {:auth0 #ig/ref :gpml.config/auth0
+  :gpml.handler.env/get {:auth0 {:domain #duct/env "OIDC_ISSUER"
+                                 :clientId #duct/env "OIDC_AUDIENCE"}
                          :sentry {:dsn #duct/env "SENTRY_DSN"
                                   :environment #duct/env "ENV_NAME"}}
 


### PR DESCRIPTION
This integrant key doesn't use the same set of credentials as the
auth0 constant. Reverting.