### PR TITLE
[#601] Remove unnecessary column in stakeholder-by-email

### DIFF
--- a/backend/src/gpml/db/stakeholder.sql
+++ b/backend/src/gpml/db/stakeholder.sql
@@ -61,7 +61,6 @@ select
     s.last_name,
     s.email,
     s.idp_usernames,
-    s.affiliation as non_member_organisation,
     s.public_email,
     s.public_database,
     s.picture as photo,


### PR DESCRIPTION
This was added by mistake due to merge conflict. This line doesn't
exist in the main branch.