### PR TITLE
[#607] Fix initiative associations

### DIFF
--- a/backend/resources/migrations/124-fix-initiative-association.down.sql
+++ b/backend/resources/migrations/124-fix-initiative-association.down.sql
@@ -1,0 +1,49 @@
+ALTER TABLE stakeholder_initiative
+RENAME TO stakeholder_project;
+--;;
+ALTER TABLE stakeholder_project
+DROP COLUMN initiative CASCADE;
+--;;
+ALTER TABLE stakeholder_project
+ADD COLUMN project integer NOT NULL REFERENCES project(id);
+--;;
+CREATE VIEW v_stakeholder_association AS
+SELECT 'resource' AS topic, stakeholder, resource AS id, association::text AS association, remarks
+ FROM stakeholder_resource
+UNION ALL
+SELECT 'event' AS topic, stakeholder, event AS id, association::text AS association, remarks
+ FROM stakeholder_event
+UNION ALL
+SELECT 'technology' AS topic, stakeholder, technology AS id, association::text AS association, remarks
+ FROM stakeholder_technology
+UNION ALL
+SELECT 'policy' AS topic, stakeholder, policy AS id, association::text AS association, remarks
+ FROM stakeholder_policy
+UNION ALL
+SELECT 'project' AS topic, stakeholder, project AS id, association::text AS association, remarks
+ FROM stakeholder_project;
+-- ;;
+ALTER TABLE organisation_initiative
+RENAME TO organisation_project;
+--;;
+ALTER TABLE organisation_project
+DROP COLUMN initiative CASCADE;
+--;;
+ALTER TABLE organisation_project
+ADD COLUMN project integer NOT NULL REFERENCES project(id);
+--;;
+CREATE VIEW v_organisation_association AS
+SELECT 'resource' AS topic, organisation, resource AS id, association::text AS association, remarks
+ FROM organisation_resource
+UNION ALL
+SELECT 'event' AS topic, organisation, event AS id, association::text AS association, remarks
+ FROM organisation_event
+UNION ALL
+SELECT 'technology' AS topic, organisation, technology AS id, association::text AS association, remarks
+ FROM organisation_technology
+UNION ALL
+SELECT 'policy' AS topic, organisation, policy AS id, association::text AS association, remarks
+ FROM organisation_policy
+UNION ALL
+SELECT 'project' AS topic, organisation, project AS id, association::text AS association, remarks
+ FROM organisation_project;

--- a/backend/resources/migrations/124-fix-initiative-association.up.sql
+++ b/backend/resources/migrations/124-fix-initiative-association.up.sql
@@ -1,0 +1,49 @@
+ALTER TABLE stakeholder_project
+RENAME TO stakeholder_initiative;
+--;;
+ALTER TABLE stakeholder_initiative
+DROP COLUMN project CASCADE;
+--;;
+ALTER TABLE stakeholder_initiative
+ADD COLUMN initiative integer NOT NULL REFERENCES initiative(id);
+--;;
+CREATE VIEW v_stakeholder_association AS
+SELECT 'resource' AS topic, stakeholder, resource AS id, association::text AS association, remarks
+ FROM stakeholder_resource
+UNION ALL
+SELECT 'event' AS topic, stakeholder, event AS id, association::text AS association, remarks
+ FROM stakeholder_event
+UNION ALL
+SELECT 'technology' AS topic, stakeholder, technology AS id, association::text AS association, remarks
+ FROM stakeholder_technology
+UNION ALL
+SELECT 'policy' AS topic, stakeholder, policy AS id, association::text AS association, remarks
+ FROM stakeholder_policy
+UNION ALL
+SELECT 'initiative' AS topic, stakeholder, initiative AS id, association::text AS association, remarks
+ FROM stakeholder_initiative;
+-- ;;
+ALTER TABLE organisation_project
+RENAME TO organisation_initiative;
+--;;
+ALTER TABLE organisation_initiative
+DROP COLUMN project CASCADE;
+--;;
+ALTER TABLE organisation_initiative
+ADD COLUMN initiative integer NOT NULL REFERENCES initiative(id);
+--;;
+CREATE VIEW v_organisation_association AS
+SELECT 'resource' AS topic, organisation, resource AS id, association::text AS association, remarks
+ FROM organisation_resource
+UNION ALL
+SELECT 'event' AS topic, organisation, event AS id, association::text AS association, remarks
+ FROM organisation_event
+UNION ALL
+SELECT 'technology' AS topic, organisation, technology AS id, association::text AS association, remarks
+ FROM organisation_technology
+UNION ALL
+SELECT 'policy' AS topic, organisation, policy AS id, association::text AS association, remarks
+ FROM organisation_policy
+UNION ALL
+SELECT 'initiative' AS topic, organisation, initiative AS id, association::text AS association, remarks
+ FROM organisation_initiative;

--- a/backend/src/gpml/handler/initiative.clj
+++ b/backend/src/gpml/handler/initiative.clj
@@ -29,8 +29,8 @@
 (defn expand-entity-associations
   [entity-connections resource-id]
   (vec (for [connection entity-connections]
-         {:column_name "project"
-          :topic "project"
+         {:column_name "initiative"
+          :topic "initiative"
           :topic_id resource-id
           :organisation (:entity connection)
           :association (:role connection)
@@ -39,8 +39,8 @@
 (defn expand-individual-associations
   [individual-connections resource-id]
   (vec (for [connection individual-connections]
-         {:column_name "project"
-          :topic "project"
+         {:column_name "initiative"
+          :topic "initiative"
           :topic_id resource-id
           :stakeholder (:stakeholder connection)
           :association (:role connection)


### PR DESCRIPTION
Initiative associations were using the table `project` for the
associations, which is deprecated. This commit references to the
table `initiative` and removes the link to `project`.