### PR TITLE
592 resource counting mismatch

### DIFF
--- a/backend/src/gpml/db/landing.sql
+++ b/backend/src/gpml/db/landing.sql
@@ -111,17 +111,17 @@ country_counts AS (
 ),
 totals AS (
     SELECT COUNT(*) as total, 'project' as data, 1 as o
-    FROM initiative where review_status = 'APPROVED'    
+    FROM initiative where review_status = 'APPROVED'
     UNION
     SELECT COUNT(*) as total, replace(lower(type),' ','_') as data, 2 as o
-    FROM resource WHERE type IS NOT NULL GROUP BY data
+    FROM resource WHERE review_status = 'APPROVED' AND type IS NOT NULL GROUP BY data
     UNION
     SELECT COUNT(*) as total, 'event' as data, 3 as o FROM event
     WHERE event.review_status = 'APPROVED'
     UNION
-    SELECT COUNT(*) as total, 'policy' as data, 4 as o FROM policy
+    SELECT COUNT(*) as total, 'policy' as data, 4 as o FROM policy WHERE review_status = 'APPROVED'
     UNION
-    SELECT COUNT(*) as total, 'technology' as data, 5 as o FROM technology
+    SELECT COUNT(*) as total, 'technology' as data, 5 as o FROM technology WHERE review_status = 'APPROVED'
     UNION
     SELECT COUNT(*) as total, 'organisation' as data, 6 as o FROM organisation WHERE review_status = 'APPROVED'
     UNION

--- a/backend/src/gpml/sql_util.clj
+++ b/backend/src/gpml/sql_util.clj
@@ -80,9 +80,7 @@
       "JOIN json_array_elements(t.json->'tags') tags ON true JOIN json_each_text(tags) tag ON LOWER(tag.value) = ANY(ARRAY[:v*:tag]::varchar[])")
     (when (seq (:transnational params))
       "join lateral json_array_elements(t.json->'geo_coverage_values') j on true")
-    "WHERE 1=1"
-    (when-not (:admin params)
-      " AND t.json->>'review_status'='APPROVED' ")
+    "WHERE t.json->>'review_status'='APPROVED'"
     (when (seq (:search-text params)) " AND t.search_text @@ to_tsquery(:search-text)")
     (when (seq (:geo-coverage params)) " AND t.geo_coverage IN (:v*:geo-coverage) ")
     (when (seq (:transnational params)) " AND t.json->>'geo_coverage_type'='transnational' AND t.json->>'geo_coverage_values' != '' AND j.value::varchar IN (:v*:transnational)")

--- a/backend/test/gpml/sql_util_test.clj
+++ b/backend/test/gpml/sql_util_test.clj
@@ -7,14 +7,14 @@
   (testing "Testing filter-topic snippet with no params"
     (let [snippet (str/trim (util/generate-filter-topic-snippet nil))]
       (is (str/starts-with? snippet "SELECT DISTINCT ON"))
-      (is (str/includes? snippet "WHERE 1=1"))
+      (is (str/includes? snippet "WHERE t.json->>'review_status'='APPROVED'"))
       (is (not (str/includes? snippet "JOIN")))))
 
   (testing "Testing filter-topic snippet with favorites"
     (let [params {:favorites true :user-id 1 :resource-types []}
           snippet (str/trim (util/generate-filter-topic-snippet params))]
       (is (str/starts-with? snippet "SELECT DISTINCT ON"))
-      (is (str/includes? snippet "WHERE 1=1"))
+      (is (str/includes? snippet "WHERE t.json->>'review_status'='APPROVED'"))
       (is (str/includes? snippet "JOIN v_stakeholder_association"))))
 
   (testing "Testing filter-topic snippet with tags"


### PR DESCRIPTION
We should only show approved topics for end users. Therefore we are modifying the topic queries to consider only the topics with `review_status=APPROVED`. 