### PR TITLE
[#764] Submission endpoint for non member orgs

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -70,7 +70,8 @@
                                           {:get {:summary "Get the list of submissions"
                                                  :swagger {:tags ["submission"] :security [{:id_token []}]}
                                                  :parameters {:query [:map
-                                                                      [:only {:optional true} [:enum "resources" "stakeholders" "tags" "entities"]]
+                                                                      [:only {:optional true}
+                                                                       [:enum "resources" "stakeholders" "tags" "entities" "non-member-entities"]]
                                                                       [:review_status
                                                                        {:optional true #_#_:default "SUBMITTED"}
                                                                        [:enum "SUBMITTED" "APPROVED" "REJECTED"]]

--- a/backend/resources/migrations/141-add-non-member-organisation-to-topic-type-enum.up.sql
+++ b/backend/resources/migrations/141-add-non-member-organisation-to-topic-type-enum.up.sql
@@ -1,0 +1,1 @@
+ALTER TYPE topic_type ADD VALUE 'non_member_organisation';

--- a/backend/src/gpml/db/submission.sql
+++ b/backend/src/gpml/db/submission.sql
@@ -11,6 +11,11 @@ submission AS (
     WHERE is_member = true
 --~ (when (:review_status params) " AND review_status = :review_status::review_status ")
     UNION
+    SELECT id, 'organisation' AS type, 'non_member_organisation' AS topic, name as title, id as created_by, created, 'USER' as role, review_status, logo as image
+    FROM organisation
+    WHERE is_member = false
+--~ (when (:review_status params) " AND review_status = :review_status::review_status ")
+    UNION
     SELECT id, 'tag' AS type, 'tag' AS topic, tag as title, NULL as created_by, NULL as created, NULL as role, review_status, NULL as image
     FROM tag
 --~ (when (:review_status params) " WHERE review_status = :review_status::review_status ")
@@ -53,6 +58,7 @@ data AS (
     LEFT JOIN reviewers r on s.id=r.id and s.type=r.type
     WHERE 1=1
 --~ (when (= "entities" (:only params)) " AND  s.type IN ( 'organisation') ")
+--~ (when (= "non-member-entities" (:only params)) " AND  s.type IN ( 'organisation') AND s.topic IN ('non_member_organisation')")
 --~ (when (= "stakeholders" (:only params)) " AND  s.type IN ('stakeholder') ")
 --~ (when (= "tags" (:only params)) " AND  s.type IN ('tag') ")
 --~ (when (= "resources" (:only params)) " AND  s.type NOT IN ('stakeholder', 'organisation') ")
@@ -67,6 +73,7 @@ SELECT json_build_object(
     SELECT COUNT(*) FROM submission
     WHERE 1=1
 --~ (when (= "entities" (:only params)) " AND type IN ('organisation') ")
+--~ (when (= "non-member-entities" (:only params)) " AND  type IN ( 'organisation') AND topic IN ('non_member_organisation')")
 --~ (when (= "stakeholders" (:only params)) " AND type IN ('stakeholder') ")
 --~ (when (= "resources" (:only params)) " AND type NOT IN ('stakeholder', 'organisation') ")
 --~ (when (:title params) (str " AND title ILIKE '%" (:title params) "%' ") )
@@ -76,6 +83,7 @@ SELECT json_build_object(
     SELECT COUNT(*) FROM submission
     WHERE 1=1
 --~ (when (= "entities" (:only params)) " AND type IN ( 'organisation') ")
+--~ (when (= "non-member-entities" (:only params)) " AND  type IN ( 'organisation') AND topic IN ('non_member_organisation')")
 --~ (when (= "stakeholders" (:only params)) " AND type IN ('stakeholder') ")
 --~ (when (= "resources" (:only params)) " AND type NOT IN ('stakeholder', 'organisation') ")
 --~ (when (:title params) (str " AND title ILIKE '%" (:title params) "%' ") )


### PR DESCRIPTION
NOTE:
Even though `topic` in application level only refers to the knowledge
library topics, the `topic_type` enum seems to have been referenced
by a lot of tables and is used in queries like submissions and
reviews. For this reason, `non_member_organisation` has also been
added here even though it's not a real topic type. (And neither are
tags, stakeholders, organisations etc.. that already exist there
for the same reason.)