### PR TITLE
[#997] Add orderBy param to browse API

### DIFF
--- a/backend/test/gpml/handler/browse_test.clj
+++ b/backend/test/gpml/handler/browse_test.clj
@@ -49,34 +49,35 @@
         false ",,"))))
 
 (deftest db-filter-based-on-query-params
-  (testing "Everything is empty"
-    (is (= (browse/get-db-filter {}) {}))
-    (is (= (browse/get-db-filter {:q "" :topic "" :country ""}) {})))
+  (testing "Default filter values"
+    (is (= (browse/get-db-filter {}) {:offset 0 :limit 50}))
+    (is (= (browse/get-db-filter {:q "" :topic "" :country ""}) {:offset 0 :limit 50})))
   (testing "Country is not empty"
     (is (= (browse/get-db-filter {:country "73,106,107"})
-           {:geo-coverage [107 73 106]})))
+           {:geo-coverage [107 73 106] :offset 0 :limit 50})))
   (testing "Topic is not empty"
     (is (= (browse/get-db-filter {:topic "technology"})
-           {:topic #{"technology"}})))
+           {:topic #{"technology"} :offset 0 :limit 50})))
   (testing "Search is not empty"
     (is (= (browse/get-db-filter {:q "act"})
-           {:search-text "act"})))
+           {:search-text "act" :offset 0 :limit 50})))
   (testing "Search multiple keywords"
     (is (= (browse/get-db-filter {:q "some test"})
-           {:search-text "some & test"})))
+           {:search-text "some & test" :offset 0 :limit 50})))
   (testing "Trailing/leading/double spaces are trimmed"
     (is (= (browse/get-db-filter {:q "  This   is a test  "})
-           {:search-text "This & is & a & test"})))
+           {:search-text "This & is & a & test" :offset 0 :limit 50})))
   (testing "Ampersand is removed"
     (is (= (browse/get-db-filter {:q "&&test&&"})
-           {:search-text "test"})))
+           {:search-text "test" :offset 0 :limit 50})))
   (testing "None is empty"
     (is (= (browse/get-db-filter {:q "eco"
                                   :country "253"
                                   :topic "project,event"})
            {:search-text "eco"
             :geo-coverage [253]
-            :topic #{"project" "event"}}))))
+            :topic #{"project" "event"}
+            :offset 0 :limit 50}))))
 
 (deftest browse-view-results
   (let [db (test-util/db-test-conn)
@@ -120,7 +121,7 @@
                          :user sth
                          :parameters {:query {:favorites true}}))
             resp (handler request)
-            body(-> resp :body)
+            body (-> resp :body)
             results (:results body)
             counts (:counts body)
             tech-count (first counts)]
@@ -140,8 +141,7 @@
 
     (testing "Testing query for existing tags"
       (let [resp (handler (-> (mock/request :get "/")
-                              (assoc :parameters {:query {:tag "waste management"}})
-                              ))
+                              (assoc :parameters {:query {:tag "waste management"}})))
             body (-> resp :body)
             results (:results body)]
         (is (= 16 (count results)))))))


### PR DESCRIPTION
* Supported fields: title, description and id. If not provided
defaults to start_data/created date.

Closes #997