### PR TITLE
[#1073] Disable reitit responses coercion for GET comment

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -458,7 +458,7 @@
                                                   :handler #ig/ref :gpml.handler.comment/post}
                                            :get {:summary "Get comments for a specific resource"
                                                  :swagger {:tags ["comment"] :security [{:id_token []}]}
-                                                 :responses #ig/ref :gpml.handler.comment/get-response
+                                                 ;;:responses #ig/ref :gpml.handler.comment/get-response
                                                  :parameters #ig/ref :gpml.handler.comment/get-params
                                                  :handler #ig/ref :gpml.handler.comment/get}
                                            :put {:summary "Update a comment details"


### PR DESCRIPTION
* We need to think about how to interpret the tree like structure
return by this endpoint because the schema coercion is removing it
since it is not specified.