### PR TITLE
Revert "[#60] Added rolling strategy"

### DIFF
--- a/ci/k8s/deployment.yml.template
+++ b/ci/k8s/deployment.yml.template
@@ -4,11 +4,6 @@ metadata:
   name: unep-gpml
 spec:
   replicas: 1
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-    type: RollingUpdate
   selector:
     matchLabels:
         run: unep-gpml


### PR DESCRIPTION
This reverts commit 01ace6e96cc808249190f249eb7667638aad7cd6.

I'm not yet quite sure why, but deploying to production has recently been failing because the new pod can't connect to the DB.
The solution has been to delete the new pod, which somehow leads K8 to believe that the rolling update is done.
It still recreates the pod for the new version because the new deployment revision demands it and the old one is removed.
When the new pod is the only one starting, then the update goes over smoothly.

At the moment, I cannot explain why this is happening only in production and not on test.
I assume it has to do with test being less active, but due to a lack of logs to debug, and since it looks like running a singular pod is the solution (or workaround, depends on how you look at it), hopefully,
 this'll resolve our issue.

Having an old version writing to the DB during or after a migration, probably doesn't leave the application in a good state either, so this might be cleanest way to start a new version.