### PR TITLE
1121-1147 Non-member to member org conversion in sign up

### DIFF
--- a/backend/src/gpml/db/organisation.sql
+++ b/backend/src/gpml/db/organisation.sql
@@ -141,3 +141,16 @@ values :t*:tags RETURNING id;
 -- :name delete-organisation-tags :! :n
 -- :doc remove organisation-tags
 delete from organisation_tag where organisation = :id
+
+-- :name delete-organisation :!
+-- :doc Deletes an organisation
+DELETE FROM organisation WHERE id = :id;
+
+-- :name get-organisations
+-- :doc Gets all organisations. It accepts filters and can be extend to support more
+SELECT * FROM organisation
+WHERE 1=1
+--~(when (get-in params [:filters :id]) " AND :filters.id = id")
+--~(when (get-in params [:filters :name]) " AND LOWER(:filters.name) = LOWER(name)")
+--~(when (true? (get-in params [:filters :is_member])) " AND is_member IS TRUE")
+--~(when (false? (get-in params [:filters :is_member])) " AND is_member IS FALSE")

--- a/backend/src/gpml/handler/stakeholder.clj
+++ b/backend/src/gpml/handler/stakeholder.clj
@@ -15,9 +15,12 @@
    [gpml.handler.resource.tag :as handler.resource.tag]
    [gpml.handler.tag :as handler.tag]
    [gpml.handler.util :as handler.util]
+   [gpml.pg-util :as pg-util]
    [gpml.util :as util]
    [integrant.core :as ig]
-   [ring.util.response :as resp]))
+   [ring.util.response :as resp])
+  (:import
+   [java.sql SQLException]))
 
 (def roles-re (->> constants/user-roles
                    (map name)
@@ -239,57 +242,72 @@
 
 (defn- make-affiliation [db mailjet-config org]
   (if-not (:id org)
-    (let [org-id (handler.org/create db mailjet-config org)]
-      (email/notify-admins-pending-approval db mailjet-config
-                                            {:title (:name org) :type "organisation"})
-      (when-let [tag-ids (seq (:expertise org))]
-        (db.organisation/add-organisation-tags db {:tags (map #(vector org-id %) tag-ids)}))
-      org-id)
-    (:id org)))
+    (try
+      (let [org-id (handler.org/create db mailjet-config org)]
+        (email/notify-admins-pending-approval db mailjet-config
+                                              {:title (:name org) :type "organisation"})
+        {:success? true
+         :org-id org-id})
+      (catch Exception e
+        (if (instance? SQLException e)
+          (let [reason (pg-util/get-sql-state e)]
+            {:success? false
+             :reason reason
+             :error-details {:message (.getMessage e)}})
+          {:success? false
+           :reason :could-not-create-org
+           :error-details {:message (.getMessage e)}})))
+    {:success? true
+     :org-id (:id org)}))
 
-(defn- make-organisation [db mailjet-config org]
-  (if-not (:id org)
-    (let [org-id (handler.org/create db mailjet-config (-> (if (:subnational_area_only org)
-                                                             (-> org
-                                                                 (dissoc :subnational_area_only)
-                                                                 (assoc :subnational_area (:subnational_area_only org)))
-                                                             org)
-                                                           (assoc :is_member false)))]
-      org-id)
-    (:id org)))
+(defn- save-stakeholder
+  ([config req]
+   (save-stakeholder config req nil))
+  ([{:keys [db mailjet-config]}
+    {:keys [jwt-claims body-params headers]}
+    new-affiliation]
+   (let [profile (make-profile (assoc body-params
+                                      :affiliation new-affiliation
+                                      :email (:email jwt-claims)
+                                      :idp_usernames [(:sub jwt-claims)]
+                                      :cv (or (assoc-cv db (:cv body-params))
+                                              (:cv body-params))
+                                      :picture (or (handler.image/assoc-image db (:photo body-params) "profile")
+                                                   (let [{:keys [first_name last_name]} (select-keys body-params [:first_name :last_name])]
+                                                     (format "https://ui-avatars.com/api/?size=480&name=%s+%s" first_name last_name)))))
+         stakeholder-id (if-let [current-stakeholder (db.stakeholder/stakeholder-by-email db {:email (:email profile)})]
+                          (let [idp-usernames (vec (-> current-stakeholder :idp_usernames (concat (:idp_usernames profile))))]
+                            (db.stakeholder/update-stakeholder db (assoc (select-keys profile [:affiliation])
+                                                                         :id (:id current-stakeholder)
+                                                                         :idp_usernames idp-usernames
+                                                                         :non_member_organisation nil))
+                            (:id current-stakeholder))
+                          (let [new-stakeholder (db.stakeholder/new-stakeholder db profile)]
+                            (email/notify-admins-pending-approval db mailjet-config
+                                                                  (merge profile {:type "stakeholder"}))
+                            (:id new-stakeholder)))
+         profile (db.stakeholder/stakeholder-by-id db {:id stakeholder-id})
+         res (-> (merge body-params profile)
+                 (dissoc :affiliation :picture :new_org)
+                 (assoc :org (db.organisation/organisation-by-id db {:id (:affiliation profile)})))]
+     (when-let [tags (seq (:tags body-params))]
+       (save-stakeholder-tags db mailjet-config tags stakeholder-id false))
+     (resp/created (:referer headers) res))))
 
-(defmethod ig/init-key :gpml.handler.stakeholder/post [_ {:keys [db mailjet-config]}]
-  (fn [{:keys [jwt-claims body-params headers]}]
-    (let [profile        (make-profile (merge  (assoc body-params
-                                                      :affiliation (when (:org body-params)
-                                                                     (make-affiliation db mailjet-config (:org body-params)))
-                                                      :email (:email jwt-claims)
-                                                      :idp_usernames [(:sub jwt-claims)]
-                                                      :cv (or (assoc-cv db (:cv body-params))
-                                                              (:cv body-params))
-                                                      :picture (or (handler.image/assoc-image db (:photo body-params) "profile")
-                                                                   (let [{:keys [first_name last_name]} (select-keys body-params [:first_name :last_name])]
-                                                                     (format "https://ui-avatars.com/api/?size=480&name=%s+%s" first_name last_name))))
-                                               (when (:new_org body-params)
-                                                 {:affiliation (make-organisation db mailjet-config (:new_org body-params))})))
-          stakeholder-id (if-let [current-stakeholder (db.stakeholder/stakeholder-by-email db {:email (:email profile)})]
-                           (let [idp-usernames (vec (-> current-stakeholder :idp_usernames (concat (:idp_usernames profile))))]
-                             (db.stakeholder/update-stakeholder db (assoc (select-keys profile [:affiliation])
-                                                                          :id (:id current-stakeholder)
-                                                                          :idp_usernames idp-usernames
-                                                                          :non_member_organisation nil))
-                             (:id current-stakeholder))
-                           (let [new-stakeholder (db.stakeholder/new-stakeholder db profile)]
-                             (email/notify-admins-pending-approval db mailjet-config
-                                                                   (merge profile {:type "stakeholder"}))
-                             (:id new-stakeholder)))
-          profile        (db.stakeholder/stakeholder-by-id db {:id stakeholder-id})
-          res            (-> (merge body-params profile)
-                             (dissoc :affiliation :picture :new_org)
-                             (assoc :org (db.organisation/organisation-by-id db {:id (:affiliation profile)})))]
-      (when-let [tags (seq (:tags body-params))]
-        (save-stakeholder-tags db mailjet-config tags stakeholder-id false))
-      (resp/created (:referer headers) res))))
+(defmethod ig/init-key :gpml.handler.stakeholder/post [_ {:keys [db mailjet-config] :as config}]
+  (fn [{:keys [body-params] :as req}]
+    (if-not (seq (:org body-params))
+      (save-stakeholder config req)
+      (let [result (make-affiliation db mailjet-config (:org body-params))]
+        (if (:success? result)
+          (save-stakeholder config req (:org-id result))
+          (if (= :unique-constraint-violation (:reason result))
+            {:status 409
+             :headers {"content-type" "application/json"}
+             :body (assoc result :reason :organisation-name-already-exists)}
+            {:status 500
+             :headers {"content-type" "application/json"}
+             :body result}))))))
 
 (defmethod ig/init-key :gpml.handler.stakeholder/put [_ {:keys [db mailjet-config]}]
   (fn [{:keys [jwt-claims body-params]}]

--- a/backend/src/gpml/pg_util.clj
+++ b/backend/src/gpml/pg_util.clj
@@ -3,6 +3,22 @@
             [jsonista.core :as j])
   (:import org.postgresql.util.PGobject))
 
+(defn get-sql-state
+  "Gets the SQL state from a SQLException object and returns the keyword
+  representation of the state which are described as error codes in
+  PostgreSQL[1].
+
+  [1] - https://www.postgresql.org/docs/12/errcodes-appendix.html"
+  [sql-exception]
+  (if-let [sql-state (.getSQLState sql-exception)]
+    (case sql-state
+      "23000" :integrity-constraint-violation
+      "23502" :not-null-violation
+      "23503" :foreign-key-violation
+      "23505" :unique-constraint-violation
+      :other-sql-error)
+    :other-sql-error))
+
 (defn- parse-json
   [s]
   (j/read-value s j/keyword-keys-object-mapper))


### PR DESCRIPTION
* Handle `unique-violation-constraint` exception when creating an organisation with a name that already exists.
* If the existing organisation is a `non-member` we replace it with the new organisation which is a member.