### PR TITLE
ci: Use Recreate deployment strategy

### DIFF
--- a/ci/k8s/deployment.yml.template
+++ b/ci/k8s/deployment.yml.template
@@ -4,6 +4,8 @@ metadata:
   name: unep-gpml
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
         run: unep-gpml


### PR DESCRIPTION
Removing the strategy definition just applied default values,
 which wasn't very helpful and didn't solve the problem
 we were facing of the inability to connect to the DB with 2 instances.