### PR TITLE
1174 Fix detail API tags update deleting existing tags when creating new ones

### DIFF
--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -6,7 +6,7 @@
    [gpml.constants :as constants]
    [gpml.db.action :as db.action]
    [gpml.db.action-detail :as db.action-detail]
-   gpml.db.country
+   [gpml.db.country]
    [gpml.db.country-group :as db.country-group]
    [gpml.db.detail :as db.detail]
    [gpml.db.event :as db.event]


### PR DESCRIPTION
* Fix tag update when new tag creation is required as part of the update.
* Only update tags if there are tags to update.