### PR TITLE
[#1209] Fix populate tag_relation_category update

### DIFF
--- a/backend/resources/migrations/150-fix-populate-stakeholder-tag-relation-category.down.sql
+++ b/backend/resources/migrations/150-fix-populate-stakeholder-tag-relation-category.down.sql
@@ -1,0 +1,13 @@
+BEGIN;
+--;;
+UPDATE stakeholder_tag SET tag_relation_category IS NULL
+FROM tag
+WHERE stakeholder_tag.tag = tag.id
+AND tag.tag_category = 1;
+--;;
+UPDATE stakeholder_tag SET tag_relation_category IS NULL
+FROM tag
+WHERE stakeholder_tag.tag = tag.id
+AND tag.tag_category = 10;
+--;;
+COMMIT;

--- a/backend/resources/migrations/150-fix-populate-stakeholder-tag-relation-category.down.sql
+++ b/backend/resources/migrations/150-fix-populate-stakeholder-tag-relation-category.down.sql
@@ -1,11 +1,11 @@
 BEGIN;
 --;;
-UPDATE stakeholder_tag SET tag_relation_category IS NULL
+UPDATE stakeholder_tag SET tag_relation_category = NULL
 FROM tag
 WHERE stakeholder_tag.tag = tag.id
 AND tag.tag_category = 1;
 --;;
-UPDATE stakeholder_tag SET tag_relation_category IS NULL
+UPDATE stakeholder_tag SET tag_relation_category = NULL
 FROM tag
 WHERE stakeholder_tag.tag = tag.id
 AND tag.tag_category = 10;

--- a/backend/resources/migrations/150-fix-populate-stakeholder-tag-relation-category.up.sql
+++ b/backend/resources/migrations/150-fix-populate-stakeholder-tag-relation-category.up.sql
@@ -1,0 +1,15 @@
+BEGIN;
+--;;
+UPDATE stakeholder_tag SET tag_relation_category = 'seeking'
+FROM tag
+WHERE stakeholder_tag.tag = tag.id
+AND tag.tag_category = 1
+AND stakeholder_tag.tag_relation_category IS NULL;
+--;;
+UPDATE stakeholder_tag SET tag_relation_category = 'offering'
+FROM tag
+WHERE stakeholder_tag.tag = tag.id
+AND tag.tag_category = 10
+AND stakeholder_tag.tag_relation_category IS NULL;
+--;;
+COMMIT;


### PR DESCRIPTION
* The previous migration(149) had an incorrect statement that makes the
UPDATE miss all the existing rows.
* See #1209
Closes #1209