### PR TITLE
Remove storage of local deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 * Start the development environment: `docker-compose up -d`
 * Stop dev environment: `docker-compose down`
 * If you want to clean up all the stored data use `-v`: `docker-compose down -v`
+* For rebuilding the backend image when deps change: `docker-compose build`
 
 Website will be available at [http://localhost:3001](http://localhost:3001).
 

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,2 +1,3 @@
 **
 !target
+!project.clj

--- a/backend/dev.Dockerfile
+++ b/backend/dev.Dockerfile
@@ -1,0 +1,5 @@
+FROM akvo/akvo-clojure-lein:20210124.114043.4437caf
+
+COPY project.clj .
+
+RUN lein deps

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -17,7 +17,10 @@ services:
     depends_on:
       - db
   backend:
-    image: akvo/akvo-clojure-lein:20210124.114043.4437caf
+    build:
+      context: backend
+      dockerfile: dev.Dockerfile
+    entrypoint: ""
     command: ["lein", "repl", ":headless"]
     environment:
       - GOOGLE_APPLICATION_CREDENTIALS=/credentials/cloud-database-service-account.json
@@ -28,10 +31,6 @@ services:
       - 47481:47481
     volumes:
       - ./backend:/app
-      - ~/.m2:/home/akvo/.m2
-      - ~/.lein:/home/akvo/.lein
-      - ~/.m2:/root/.m2:delegated
-      - ~/.lein:/root/.lein:delegated
 
   frontend:
     image: akvo/akvo-node-14-alpine:20210106.152005.1864760


### PR DESCRIPTION
The backend starts up really slowly on Macs (20-30 minutes).
Part of the reason are the volumes which are known to have terrible performance.

In order to make it liveable for developers on macs, the deps are moved into the image.
The virtual machine that runs the container will thus only have to share the backend code on the host.
The deps will be available in the virtual machine with less overhead.