### PR TITLE
Refactor topic query to improve performance

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -517,7 +517,8 @@
   :gpml.handler.country/get {:db #ig/ref :duct.database/sql}
   :gpml.handler.country-group/get {:db #ig/ref :duct.database/sql}
 
-  :gpml.handler.browse/get {:db #ig/ref :duct.database/sql}
+  :gpml.handler.browse/get {:db #ig/ref :duct.database/sql
+                            :logger #ig/ref :duct/logger}
   :gpml.handler.browse/query-params {}
 
   :gpml.handler.archive/get {:db #ig/ref :duct.database/sql}

--- a/backend/src/gpml/db/landing.clj
+++ b/backend/src/gpml/db/landing.clj
@@ -77,14 +77,11 @@
   Stakeholder, etc.) by country. The result of this
   counting is grouped by countries."
   [conn opts]
-  (let [counts (map-counts conn (merge opts {:count-name "counts"
-                                             :distinct-on-geo-coverage? false}
+  (let [counts (map-counts conn (merge opts {:count-name "counts"}
                                        (when (= :topic (:entity-group opts))
-                                         {:geo-coverage-types non-transnational-geo-coverage-types
-                                          :distinct-on-geo-coverage? true})))
+                                         {:geo-coverage-types non-transnational-geo-coverage-types})))
         transnational-counts-by-country (map-counts conn (merge opts {:geo-coverage-types transnational-geo-coverage-types
-                                                                      :count-name "transnational_counts"
-                                                                      :distinct-on-geo-coverage? true}))]
+                                                                      :count-name "transnational_counts"}))]
     (reduce
      (fn [acc [_ counts]]
        (conj acc (merge-with into topic-counts (apply merge counts))))

--- a/backend/src/gpml/db/topic.clj
+++ b/backend/src/gpml/db/topic.clj
@@ -625,7 +625,14 @@
      UNION ALL
      SELECT 'gpml_member_entities' AS topic, COUNT(*)
      FROM organisation
-     WHERE review_status='APPROVED' AND is_member=true
+     WHERE review_status='APPROVED' AND is_member IS TRUE
+     GROUP BY topic
+     UNION ALL
+     SELECT 'capacity_building' AS topic, COUNT(*)
+     FROM cte_results
+     WHERE (SELECT COUNT(t.*)
+            FROM json_array_elements((CASE WHEN (json->>'tags'::TEXT = '') IS NOT FALSE THEN '[]'::JSON
+                                    ELSE (json->>'tags')::JSON END)) t WHERE t->>'tag' = 'capacity building') > 0
      GROUP BY topic"
     (str/join
      " "

--- a/backend/src/gpml/db/topic.clj
+++ b/backend/src/gpml/db/topic.clj
@@ -333,9 +333,10 @@
 (defn generic-entity-geo-coverage-query
   [entity-name]
   (format
-   "SELECT e.id, c.id AS geo_coverage
+   "SELECT e.id, json_agg(c.id) AS geo_coverage
     FROM %s e
-    LEFT JOIN country c ON e.country = c.id"
+    LEFT JOIN country c ON e.country = c.id
+    GROUP BY e.id"
    entity-name))
 
 ;;======================= Search Text queries =================================

--- a/backend/src/gpml/handler/browse.clj
+++ b/backend/src/gpml/handler/browse.clj
@@ -143,7 +143,7 @@
                               (map #(Integer/parseInt %))))
 
     (seq transnational)
-    (assoc :transnational (set (map str (str/split transnational #","))))
+    (assoc :transnational (set (map #(Integer/parseInt %) (str/split transnational #","))))
 
     (seq topic)
     (assoc :topic (set (str/split topic #",")))
@@ -208,13 +208,12 @@
                            (let [country-group-countries (flatten
                                                           (conj
                                                            (map #(db.country-group/get-country-group-countries
-                                                                  db {:id (Integer/parseInt %)})
+                                                                  db {:id %})
                                                                 (:transnational modified-filters))))
-                                 geo-coverage-countries (map (comp str :id) country-group-countries)
-                                 geo-coverage (map str geo-coverage)
+                                 geo-coverage-countries (map :id country-group-countries)
                                  transnational (->> (map #(db.country-group/get-country-groups-by-country db {:id %}) (:geo-coverage modified-filters))
                                                     (apply concat)
-                                                    (map (comp str :id))
+                                                    (map :id)
                                                     set)]
                              (assoc modified-filters :geo-coverage-countries (set (concat geo-coverage-countries geo-coverage))
                                     :transnational transnational))
@@ -222,7 +221,7 @@
                            (seq geo-coverage)
                            (let [transnational (->> (map #(db.country-group/get-country-groups-by-country db {:id %}) (:geo-coverage modified-filters))
                                                     (apply concat)
-                                                    (map (comp str :id))
+                                                    (map :id)
                                                     set)]
                              (assoc modified-filters :transnational transnational))
 
@@ -230,11 +229,10 @@
                            (let [country-group-countries (flatten
                                                           (conj
                                                            (map #(db.country-group/get-country-group-countries
-                                                                  db {:id (Integer/parseInt %)})
+                                                                  db {:id %})
                                                                 (:transnational modified-filters))))
-                                 geo-coverage-countries (map (comp str :id) country-group-countries)]
+                                 geo-coverage-countries (map :id country-group-countries)]
                              (assoc modified-filters :geo-coverage-countries (set geo-coverage-countries)))
-
                            :else
                            modified-filters)
         results (->> modified-filters

--- a/backend/src/gpml/handler/landing.clj
+++ b/backend/src/gpml/handler/landing.clj
@@ -114,7 +114,8 @@
                               (map #(Integer/parseInt %))))
 
     (seq transnational)
-    (assoc :transnational (set (map str (str/split transnational #","))))
+    (assoc :transnational (->> (set (str/split transnational #","))
+                               (map #(Integer/parseInt %))))
 
     (seq topic)
     (assoc :topic (set (str/split topic #",")))
@@ -146,7 +147,7 @@
   (let [opts (api-opts->opts query)
         modified-opts (let [country-group-countries (->> (get opts :transnational)
                                                          (map #(db.country-group/get-country-group-countries
-                                                                conn {:id (Integer/parseInt %)}))
+                                                                conn {:id %}))
                                                          (apply concat))
                             geo-coverage-countries (map :id country-group-countries)]
                         (assoc opts :geo-coverage (set (concat


### PR DESCRIPTION
* Slightly improve topic query performance by removing duplicated rows in the result set.
* Add count for capacity building.
* Add logging in the browse API to check query performance.