### PR TITLE
1237 refactor and fix resource detail tag retrieval

### DIFF
--- a/backend/src/gpml/db/event.sql
+++ b/backend/src/gpml/db/event.sql
@@ -165,11 +165,3 @@ select ev.id, ev.title, ev.description from event e
   left join event ev
   on ev.id = any(e.related_content)
 where e.id = :id
-
--- :name tags-by-id
--- :doc Get tags by id
-select t.id, t.tag from event_tag et
-  left join tag t
-  on et.tag = t.id
-  where et.event = :id
-  and t.review_status='APPROVED';

--- a/backend/src/gpml/db/initiative.sql
+++ b/backend/src/gpml/db/initiative.sql
@@ -109,11 +109,3 @@ select init.id, init.q2 as title, init.q3 as description from initiative i
   left join initiative init
   on init.id = ANY(i.related_content)
   where i.id = :id
-
--- :name tags-by-id
--- :doc Get tags by id
-select t.id, t.tag from initiative_tag it
-  left join tag t
-  on it.tag = t.id
-  where it.initiative = :id
-  and t.review_status = 'APPROVED';

--- a/backend/src/gpml/db/policy.sql
+++ b/backend/src/gpml/db/policy.sql
@@ -165,14 +165,6 @@ select pol.id, pol.title, pol.abstract as description from policy p
   on pol.id = ANY(p.related_content)
   where p.id = :id
 
--- :name tags-by-id
--- :doc Get tags by id
-select t.id, t.tag from policy_tag pt
-  left join tag t
-  on pt.tag = t.id
-  where pt.policy = :id
-  and t.review_status = 'APPROVED';
-
 -- :name add-language-to-policy :! :n
 -- :doc Add language to policy
 update policy
@@ -183,4 +175,3 @@ update policy
 -- :doc Get language by policy id
 select l.* from language l
   where id = (select p.language from policy p where p.id = :id)
-

--- a/backend/src/gpml/db/resource.sql
+++ b/backend/src/gpml/db/resource.sql
@@ -205,11 +205,3 @@ select res.id, res.title, res.summary as description from resource r
   left join resource res
   on res.id = ANY(r.related_content)
   where r.id = :id
-
--- :name tags-by-id
--- :doc Get tags by id
-select t.id, t.tag from resource_tag rt
-  left join tag t
-  on rt.tag = t.id
-  where rt.resource = :id
-  and t.review_status = 'APPROVED';

--- a/backend/src/gpml/db/technology.sql
+++ b/backend/src/gpml/db/technology.sql
@@ -199,4 +199,4 @@ select t.id, t.tag from technology_tag tt
   left join tag t
   on tt.tag = t.id
   where tt.technology = :id
-  and t.review_staus='APPROVED';
+  and t.review_status='APPROVED';

--- a/backend/src/gpml/db/technology.sql
+++ b/backend/src/gpml/db/technology.sql
@@ -192,11 +192,3 @@ select tech.id, tech.name as title, tech.remarks as description from technology 
   left join technology tech
   on tech.id = ANY(t.related_content)
   where t.id = :id
-
--- :name tags-by-id
--- :doc Get tags by id
-select t.id, t.tag from technology_tag tt
-  left join tag t
-  on tt.tag = t.id
-  where tt.technology = :id
-  and t.review_status='APPROVED';

--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -284,7 +284,9 @@
     :related_content (if (seq related_content)
                        (expand-related-project-content db project)
                        [])
-    :tags (db.initiative/tags-by-id db (select-keys project [:id]))
+    :tags (db.resource.tag/get-resource-tags db {:table "initiative_tag"
+                                                 :resource-col "initiative"
+                                                 :resource-id (:id project)})
     :type "Initiative"}
    (if (> (:id project) 10000)
      (db.initiative/initiative-detail-by-id db project)
@@ -304,7 +306,9 @@
     :related_content (if (seq related_content)
                        (expand-related-policy-content db policy)
                        [])
-    :tags (db.policy/tags-by-id db (select-keys policy [:id]))
+    :tags (db.resource.tag/get-resource-tags db {:table "policy_tag"
+                                                 :resource-col "policy"
+                                                 :resource-id (:id policy)})
     :language (db.policy/language-by-policy-id db (select-keys policy [:id]))
     :type "Policy"}
    (when-let [implementing-mea (:implementing_mea policy)]
@@ -324,7 +328,9 @@
     :related_content (if (seq related_content)
                        (expand-related-technology-content db technology)
                        [])
-    :tags (db.technology/tags-by-id db (select-keys technology [:id]))
+    :tags (db.resource.tag/get-resource-tags db {:table "technology_tag"
+                                                 :resource-col "technology"
+                                                 :resource-id (:id technology)})
     :type "Technology"}
    (when-let [headquarters-country (:country technology)]
      {:headquarters (gpml.db.country/country-by-id db {:id headquarters-country})})))
@@ -348,7 +354,9 @@
    :related_content (if (seq related_content)
                       (expand-related-resource-content db resource)
                       [])
-   :tags (db.resource/tags-by-id db (select-keys resource [:id]))})
+   :tags (db.resource.tag/get-resource-tags db {:table "resource_tag"
+                                                :resource-col "resource"
+                                                :resource-id (:id resource)})})
 
 (defmethod extra-details "financing_resource" [_ db {:keys [related_content] :as resource}]
   {:entity_connections (db.resource/entity-connections-by-id db (select-keys resource [:id]))
@@ -356,7 +364,9 @@
    :related_content (if (seq related_content)
                       (expand-related-resource-content db resource)
                       [])
-   :tags (db.resource/tags-by-id db (select-keys resource [:id]))})
+   :tags (db.resource.tag/get-resource-tags db {:table "resource_tag"
+                                                :resource-col "resource"
+                                                :resource-id (:id resource)})})
 
 (defmethod extra-details "action_plan" [_ db {:keys [related_content] :as resource}]
   {:entity_connections (db.resource/entity-connections-by-id db (select-keys resource [:id]))
@@ -364,7 +374,9 @@
    :related_content (if (seq related_content)
                       (expand-related-resource-content db resource)
                       [])
-   :tags (db.resource/tags-by-id db (select-keys resource [:id]))})
+   :tags (db.resource.tag/get-resource-tags db {:table "resource_tag"
+                                                :resource-col "resource"
+                                                :resource-id (:id resource)})})
 
 (defn expand-related-entity-content [db event]
   (let [related_content (db.event/related-content-by-id db (select-keys event [:id]))]
@@ -379,7 +391,9 @@
    :related_content (if (seq related_content)
                       (expand-related-entity-content db event)
                       [])
-   :tags (db.event/tags-by-id db (select-keys event [:id]))
+   :tags (db.resource.tag/get-resource-tags db {:table "event_tag"
+                                                :resource-col "event"
+                                                :resource-id (:id event)})
    :type "Event"})
 
 (defmethod extra-details :nothing [_ _ _]

--- a/backend/src/gpml/handler/initiative.clj
+++ b/backend/src/gpml/handler/initiative.clj
@@ -1,17 +1,19 @@
 (ns gpml.handler.initiative
-  (:require [clojure.java.jdbc :as jdbc]
-            [gpml.db.favorite :as db.favorite]
-            [gpml.db.initiative :as db.initiative]
-            [gpml.db.stakeholder :as db.stakeholder]
-            [gpml.db.tag :as db.tag]
-            [gpml.email-util :as email]
-            [gpml.handler.geo :as handler.geo]
-            [gpml.handler.auth :as h.auth]
-            [gpml.handler.image :as handler.image]
-            [gpml.handler.util :as util]
-            [gpml.pg-util :as pg-util]
-            [integrant.core :as ig]
-            [ring.util.response :as resp]))
+  (:require
+   [clojure.java.jdbc :as jdbc]
+   [gpml.db.favorite :as db.favorite]
+   [gpml.db.initiative :as db.initiative]
+   [gpml.db.resource.tag :as db.resource.tag]
+   [gpml.db.stakeholder :as db.stakeholder]
+   [gpml.db.tag :as db.tag]
+   [gpml.email-util :as email]
+   [gpml.handler.auth :as h.auth]
+   [gpml.handler.geo :as handler.geo]
+   [gpml.handler.image :as handler.image]
+   [gpml.handler.util :as util]
+   [gpml.pg-util :as pg-util]
+   [integrant.core :as ig]
+   [ring.util.response :as resp]))
 
 (defn- add-geo-initiative [conn initiative-id {:keys [geo_coverage_country_groups geo_coverage_countries] :as data}]
   (when (or (not-empty geo_coverage_country_groups)
@@ -120,7 +122,9 @@
           data (db.initiative/initiative-by-id conn {:id id})
           extra-details (merge {:entity_connections (db.initiative/entity-connections-by-id conn {:id id})
                                 :stakeholder_connections (db.initiative/stakeholder-connections-by-id conn {:id id})
-                                :tags (db.initiative/tags-by-id conn {:id id})
+                                :tags (db.resource.tag/get-resource-tags conn {:table "initiative_tag"
+                                                                               :resource-col "initiative"
+                                                                               :resource-id id})
                                 :type "Initiative"}
                                (when-not (empty? (:related_content data))
                                  {:related_content (expand-related-initiative-content conn id)}))]


### PR DESCRIPTION
* Refactor tags retrieval in detail API and initiative GET handler to use the generic `get-resource-tags` DB function. That makes maintenance and bug fixes easier.
* Remove legacy `tags-by-id` DB functions (they were replaced by `get-resource-tags`).