### PR TITLE
[#1255] Fix resource count per transnational group

### DIFF
--- a/backend/src/gpml/db/landing.sql
+++ b/backend/src/gpml/db/landing.sql
@@ -41,10 +41,17 @@ GROUP BY geo_coverage;
 -- :name map-counts-by-country-group :? :*
 -- :doc Get the entity count per country group.
 -- :require [gpml.db.landing]
---~(#'gpml.db.landing/generate-entity-count-by-country-group-query-cte {:cte-name "country_group_counts"} {})
-SELECT geo_coverage AS country_group_id, json_object_agg(entity, count) AS counts
-FROM country_group_counts
-GROUP BY geo_coverage;
+WITH country_group_counts AS (
+--~(#'gpml.db.landing/generate-entity-count-by-country-group-queries {} {})
+),
+aggregate_country_group_counts AS (
+  SELECT country_group_id, entity, SUM(entity_count) AS total_entity_count
+  FROM country_group_counts
+  GROUP BY country_group_id, entity
+)
+SELECT country_group_id, json_object_agg(COALESCE(entity, 'project'), total_entity_count) AS counts
+FROM aggregate_country_group_counts
+GROUP BY country_group_id;
 
 -- :name summary
 -- :doc Get summary of count of entities and number of countries


### PR DESCRIPTION
* I had to refactor the landing DB layer regarding this count as it
was doing some assumptions that weren't right. One and most important,
it wasn't considering multiple transnational groups for the same
resource and their countries. Because a resource can be directly
related to a transnational, mutiple or countries within them.

* Closes #1255