### PR TITLE
1256 remove default stakeholder avatar and stop generating them

### DIFF
--- a/backend/resources/migrations/153-remove-default-avatar-pic-from-stakeholder.up.sql
+++ b/backend/resources/migrations/153-remove-default-avatar-pic-from-stakeholder.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+--;;
+UPDATE stakeholder SET picture = NULL
+WHERE picture ILIKE '%ui-avatars.com%' OR picture ILIKE '%s.gravatar.com%';
+--;;
+COMMIT;

--- a/backend/src/gpml/handler/stakeholder.clj
+++ b/backend/src/gpml/handler/stakeholder.clj
@@ -294,9 +294,7 @@
                                       :idp_usernames [(:sub jwt-claims)]
                                       :cv (or (assoc-cv db (:cv body-params))
                                               (:cv body-params))
-                                      :picture (or (handler.image/assoc-image db (:photo body-params) "profile")
-                                                   (let [{:keys [first_name last_name]} (select-keys body-params [:first_name :last_name])]
-                                                     (format "https://ui-avatars.com/api/?size=480&name=%s+%s" first_name last_name)))))
+                                      :picture (handler.image/assoc-image db (:photo body-params) "profile")))
          stakeholder-id (if-let [current-stakeholder (db.stakeholder/stakeholder-by-email db {:email (:email profile)})]
                           (let [idp-usernames (vec (-> current-stakeholder :idp_usernames (concat (:idp_usernames profile))))]
                             (db.stakeholder/update-stakeholder db (assoc (select-keys profile [:affiliation])

--- a/backend/test/gpml/handler/profile_test.clj
+++ b/backend/test/gpml/handler/profile_test.clj
@@ -171,9 +171,7 @@
       (is (= "Doe" (-> (:body resp) :last_name)))
       (is (= "SUBMITTED" (-> (:body resp) :review_status)))
       (testing "New incomplete profile is created"
-        (is (= "https://ui-avatars.com/api/?size=480&name=John+Doe" (-> (:body resp) :photo)))
         (is (= nil (-> (:body resp) :linkedin)))
-        (is (= "https://ui-avatars.com/api/?size=480&name=John+Doe" (-> (:body resp) :photo)))
         (is (= nil (-> (:body resp) :org)))))))
 
 (deftest handler-put-test


### PR DESCRIPTION
This PR contains:

- Stop of default avatar generation for stakeholders when creating them.
- DB Migration for removing default avatar images for existing stakeholders.

See #1256 for more details.