### PR TITLE
Fix update profile PUT endpoint for stakeholders

### DIFF
--- a/backend/src/gpml/handler/stakeholder.clj
+++ b/backend/src/gpml/handler/stakeholder.clj
@@ -203,7 +203,7 @@
       (assoc profile :non_member_organisation (-> profile :org :id) :affiliation nil))))
 
 (defn update-stakeholder [db mailjet-config {:keys [id] :as body-params} old-profile]
-  (let [tags (into [] (concat (:tags body-params) (:offering body-params) (:seeking body-params)))
+  (let [tags (:tags body-params)
         org (:org body-params)
         new-profile (merge (dissoc old-profile :non_member_organisation)
                            (if (:non_member_organisation body-params)


### PR DESCRIPTION
[Closes #1265]

Fix of update profile functionality for stakeholders by only looking into the
agreed canonical representation of "tags" property in the API request,
instead of merging "seeking" and "offering" properties, that should all be
sent as "tags" by FE.

We still cannot provide a params spec for the endpoint, since we need to agree
with FE not to sent optional properties as "null" in order to comply with the
Spec.