### PR TITLE
Add image to organization's related content info

### DIFF
--- a/backend/src/gpml/db/organisation_detail.sql
+++ b/backend/src/gpml/db/organisation_detail.sql
@@ -107,7 +107,7 @@ SELECT
 -- :doc Get all content types belonging to a particular organisation
 WITH associated_content AS (
 SELECT
-  r.id, r.title, r.type, r.summary, ores.association::text AS association,
+  r.id, r.title, r.type, r.summary, r.image, ores.association::text AS association,
   json_agg(json_build_object('id', sr.id, 'stakeholder_id', sr.stakeholder, 'role', sr.association, 'stakeholder',
     concat_ws(' ', s.first_name, s.last_name), 'image', s.picture,  'stakeholder_role', s.role)) AS stakeholder_connections,
   json_agg(json_build_object('id', orgr.id, 'entity_id', orgr.organisation, 'role', orgr.association, 'entity', o.name,
@@ -126,7 +126,7 @@ SELECT
   GROUP BY r.id,ores.association
 UNION ALL
 SELECT
-  e.id, e.title, 'Event' AS type, e.description AS summary, orge.association::text AS association,
+  e.id, e.title, 'Event' AS type, e.description AS summary, e.image, orge.association::text AS association,
   json_agg(json_build_object('id', se.id, 'stakeholder_id', se.stakeholder, 'role', se.association, 'stakeholder',
     concat_ws(' ', s.first_name, s.last_name), 'image', s.picture,  'stakeholder_role', s.role)) AS stakeholder_connections,
   json_agg(json_build_object('id', oe.id, 'entity_id', oe.organisation, 'role', oe.association, 'entity', o.name,
@@ -145,7 +145,7 @@ SELECT
   GROUP BY e.id, orge.association
 UNION ALL
 SELECT
-  i.id, i.q2::text AS title, 'Initiative' AS type, i.q3::text AS summary, orgi.association::text AS association,
+  i.id, i.q2::text AS title, 'Initiative' AS type, i.q3::text AS summary, i.qimage AS image, orgi.association::text AS association,
   json_agg(json_build_object('id', si.id, 'stakeholder_id', si.stakeholder, 'role', si.association, 'stakeholder',
     concat_ws(' ', s.first_name, s.last_name), 'image', s.picture,  'stakeholder_role', s.role)) AS stakeholder_connections,
   json_agg(json_build_object('id', oi.id, 'entity_id', oi.organisation, 'role', oi.association, 'entity', o.name,
@@ -164,7 +164,7 @@ SELECT
   GROUP BY i.id, orgi.association
 UNION ALL
 SELECT
-  p.id, p.title, 'Policy' AS type, p.abstract AS summary, orgp.association::text AS association,
+  p.id, p.title, 'Policy' AS type, p.abstract AS summary, p.image, orgp.association::text AS association,
   json_agg(json_build_object('id', sp.id, 'stakeholder_id', sp.stakeholder, 'role', sp.association, 'stakeholder',
     concat_ws(' ', s.first_name, s.last_name), 'image', s.picture,  'stakeholder_role', s.role)) AS stakeholder_connections,
   json_agg(json_build_object('id', op.id, 'entity_id', op.organisation, 'role', op.association, 'entity', o.name,
@@ -183,7 +183,7 @@ SELECT
   GROUP BY p.id, orgp.association
 UNION ALL
 SELECT
-  t.id, t.name AS title, 'Technology' AS type, t.remarks AS summary, orgt.association::text AS association,
+  t.id, t.name AS title, 'Technology' AS type, t.remarks AS summary, t.image, orgt.association::text AS association,
   json_agg(json_build_object('id', st.id, 'stakeholder_id', st.stakeholder, 'role', st.association, 'stakeholder',
     concat_ws(' ', s.first_name, s.last_name), 'image', s.picture,  'stakeholder_role', s.role)) AS stakeholder_connections,
   json_agg(json_build_object('id', ot.id, 'entity_id', ot.organisation, 'role', ot.association, 'entity', o.name,


### PR DESCRIPTION
[Closes #1280]

Added image property for the query to retrieve each related resource belonging
to an organization. The relationship can be set directly to the organization
or an stakeholder belonging to a given organization, but we cover both cases.
This allows FE to display the image when viewing the related resources of an
organization.

We keep using same "image" property name returned by the query in order to
keep consistence and be able to use this as stable/expected property name
regardless of the resource type.