### PR TITLE
[#1296] Add platform links to entities export

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -664,7 +664,8 @@
   :gpml.handler.community/get {:db #ig/ref :duct.database/sql}
   :gpml.handler.community/get-params {}
 
-  :gpml.handler.export/get {:db #ig/ref :duct.database/sql}
+  :gpml.handler.export/get {:db #ig/ref :duct.database/sql
+                            :app-domain #duct/env ["APP_DOMAIN" Str]}
   :gpml.handler.export/get-params {}
 
   :duct.migrator/ragtime {:migrations #ig/ref :duct.migrator.ragtime/resources}

--- a/backend/src/gpml/constants.clj
+++ b/backend/src/gpml/constants.clj
@@ -107,7 +107,8 @@
    "Reviewed at"
    "Created"
    "Created by"
-   "Modified"])
+   "Modified"
+   "Platform Link"])
 
 (def ^:const entities-key-map
   {:id "ID"
@@ -132,7 +133,8 @@
    :reviewed_at "Reviewed at"
    :created_by "Created by"
    :created "Created"
-   :modified "Modified"})
+   :modified "Modified"
+   :platform-link "Platform Link"})
 
 (def ^:const sorted-tag-columns
   ["ID"


### PR DESCRIPTION
* I also refactored a bit the arguments of each function to accept a
configuration map including the db-spec and the app-domain. That is
just in case we need to implement the same for other tables.

* Closes #1296