### PR TITLE
[#1299] Add programmatic access auth middleware for auth0 actions

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -196,7 +196,8 @@
                                         ["/stakeholder" {:middleware [#ig/ref :gpml.auth/auth-middleware]}
                                          [""
                                           {:get {:summary "List Stakeholders"
-                                                 :middleware [#ig/ref :gpml.auth/auth-middleware-ckan]
+                                                 :middleware [#ig/ref :gpml.auth/auth-middleware-ckan
+                                                              #ig/ref :gpml.auth/auth-middleware-auth0-actions]
                                                  :swagger {:tags ["stakeholder"]}
                                                  :parameters #ig/ref :gpml.handler.stakeholder/get-params
                                                  :handler #ig/ref :gpml.handler.stakeholder/get}}]
@@ -678,6 +679,11 @@
   :gpml.auth/auth-middleware-ckan {:issuer #duct/env "OIDC_ISSUER"
                                    :audience #duct/env "OIDC_AUDIENCE_CKAN"
                                    :db #ig/ref :duct.database/sql}
+
+  :gpml.auth/auth-middleware-auth0-actions {:issuer #duct/env "OIDC_ISSUER"
+                                            :audience #duct/env "OIDC_AUDIENCE_AUTH0_ACTIONS"
+                                            :db #ig/ref :duct.database/sql}
+
   :gpml.auth/auth-required {}
   :gpml.auth/restrict-to-admin-and-comment-author-middleware {:db #ig/ref :duct.database/sql}
   :gpml.auth/restrict-to-organisation-admin-or-owner {:db #ig/ref :duct.database/sql}

--- a/backend/src/gpml/handler/stakeholder.clj
+++ b/backend/src/gpml/handler/stakeholder.clj
@@ -45,7 +45,8 @@
 (defmethod ig/init-key :gpml.handler.stakeholder/get [_ {:keys [db]}]
   (fn [{{{:keys [page limit email-like roles] :as query} :query} :parameters
         user :user approved? :approved?}]
-    (resp/response (if (and approved? (= (:role user) "ADMIN"))
+    (resp/response (if (or (and approved? (= (:role user) "ADMIN"))
+                           (= (:role user) :programmatic-access))
                      ;; FIXME: Currently hard-coded to allow only for ADMINS.
                      (let [search (and email-like (format "%%%s%%" email-like))
                            roles (and roles (str/split roles #","))

--- a/ci/k8s/deployment.template.yml
+++ b/ci/k8s/deployment.template.yml
@@ -57,6 +57,11 @@ spec:
             secretKeyRef:
               name: unep-gpml
               key: oidc-audience-ckan
+        - name: OIDC_AUDIENCE_AUTH0_ACTIONS
+          valueFrom:
+            secretKeyRef:
+              name: unep-gpml
+              key: oidc-audience-actions
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - OIDC_ISSUER=https://unep-gpml-test.eu.auth0.com/
       - OIDC_AUDIENCE=dxfYNPO4D9ovQr5NHFkOU3jwJzXhcq5J
       - OIDC_AUDIENCE_CKAN=https://unep-gpml-test.eu.auth0.com/api/v2/
+      - OIDC_AUDIENCE_AUTH0_ACTIONS=ftSrE1lYDbpvnWKJkdoT8nfO1ewTdxxh
       - APP_NAME=UNEP GPML (test)
       - APP_USER_ADMIN=caroline.kamau@un.org
       - APP_DOMAIN=http://localhost


### PR DESCRIPTION
* This middleware will be used to validate the tokens with Auth0
Actions application client's audience. The caller you have permissions
to use the Stakeholder API to retrieve sensitive information about the
users registered in the platform. It will be used by Auth0 Actions to
inject custom JWT claims in the IdToken to enhance the token
information in single sign-ons.

* Closes #1299