### PR TITLE
1317 experts invitation and management

### DIFF
--- a/backend/src/gpml/db/stakeholder.sql
+++ b/backend/src/gpml/db/stakeholder.sql
@@ -352,7 +352,8 @@ filtered_experts AS (
   JOIN tag t ON st.tag = t.id
   JOIN tag_category tg ON t.tag_category = tg.id
   WHERE 1=1
-  --~(when (seq (get-in params [:filters :tags])) " AND LOWER(t.tag) IN (:v*:tags)")
+  --~(when (seq (get-in params [:filters :tags])) " AND LOWER(t.tag) IN (:v*:filters.tags)")
+  --~(when (seq (get-in params [:filters :ids])) " AND s.id IN (:v*:filters.ids)")
   GROUP BY s.id
 )
 /*~ (if (:count-only? params) */
@@ -362,6 +363,7 @@ SELECT * FROM filtered_experts
 LIMIT :page-size
 OFFSET :offset
 /*~ ) ~*/
+
 -- :name create-stakeholders :<! :*
 -- :doc Creates N stakeholders. Type conversions needs to be handled before calling this funtions.
 INSERT INTO stakeholder(:i*:cols)

--- a/backend/src/gpml/handler/stakeholder.clj
+++ b/backend/src/gpml/handler/stakeholder.clj
@@ -290,11 +290,9 @@
                   {:success? true
                    :org-id (make-affiliation* db mailjet-config org)})
                 {:success? false
-                 :reason reason
-                 :error-details {:message (.getMessage e)}})
+                 :reason reason})
               {:success? false
-               :reason reason
-               :error-details {:message (.getMessage e)}}))
+               :reason reason}))
           {:success? false
            :reason :could-not-create-org
            :error-details {:message (.getMessage e)}})))


### PR DESCRIPTION
* Remove SQLException details from the response map
* Update expert `review_status` when signing up. Experts are created by Administrators but they need to finish the onboarding (sign up) to be seen on the platform. So, when they do and we know they are an expert we update their `review_status`.