### PR TITLE
Fix landing API favorites/bookmark filter

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -247,6 +247,7 @@
                                         ["/landing"
                                          [""
                                           {:get {:summary "End-point for the landing page"
+                                                 :middleware [#ig/ref :gpml.auth/auth-middleware]
                                                  :swagger {:tags ["landing"]}
                                                  :parameters {:query #ig/ref :gpml.handler.landing/get-query-params}
                                                  :handler #ig/ref :gpml.handler.landing/get}}]]

--- a/backend/src/gpml/handler/landing.clj
+++ b/backend/src/gpml/handler/landing.clj
@@ -164,9 +164,10 @@
                     :summary summary-data})))
 
 (defmethod ig/init-key :gpml.handler.landing/get [_ {:keys [db]}]
-  (fn [{{:keys [query]} :parameters}]
+  (fn [{{:keys [query]} :parameters
+        user :user}]
     (let [conn (:spec db)]
-      (landing-response conn query))))
+      (landing-response conn (assoc query :user-id (:id user))))))
 
 (defmethod ig/init-key :gpml.handler.landing/get-query-params [_ _]
   query-params)


### PR DESCRIPTION
* We were not getting the user details from the request. Therefore we
couldn't find the user specific bookmarks.