### PR TITLE
1317 Experts API improvements and bugfixes

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -210,6 +210,9 @@
                                                   :handler #ig/ref :gpml.handler.stakeholder.expert/get}}]
                                           ["/invite"
                                            {:post {:summary "Invite an expert"
+                                                   :middleware [#ig/ref :gpml.auth/auth-required
+                                                                #ig/ref :gpml.auth/approved-user
+                                                                #ig/ref :gpml.auth/admin-required-middleware]
                                                    :swagger {:tags ["stakeholder" "expert"]}
                                                    :parameters #ig/ref :gpml.handler.stakeholder.expert/post-params
                                                    :responses #ig/ref :gpml.handler.stakeholder.expert/post-response

--- a/backend/src/gpml/auth.clj
+++ b/backend/src/gpml/auth.clj
@@ -147,7 +147,7 @@
       (if (:authenticated? request)
         (handler request)
         {:status (:status request)
-         :message (:auth-error-message request)}))))
+         :body {:message (:auth-error-message request)}}))))
 
 (defmethod ig/init-key :gpml.auth/approved-user [_ _]
   (fn [handler]

--- a/backend/src/gpml/db/stakeholder.sql
+++ b/backend/src/gpml/db/stakeholder.sql
@@ -354,6 +354,7 @@ filtered_experts AS (
   WHERE 1=1
   --~(when (seq (get-in params [:filters :tags])) " AND LOWER(t.tag) IN (:v*:filters.tags)")
   --~(when (seq (get-in params [:filters :ids])) " AND s.id IN (:v*:filters.ids)")
+  --~(when (seq (get-in params [:filters :countries])) " AND s.country IN (:v*:filters.countries)")
   GROUP BY s.id
 )
 /*~ (if (:count-only? params) */

--- a/backend/src/gpml/handler/stakeholder/expert.clj
+++ b/backend/src/gpml/handler/stakeholder/expert.clj
@@ -98,7 +98,7 @@
     (assoc-in [:filters :tags] (map str/lower-case (str/split tags #",")))
 
     (seq countries)
-    (assoc-in [:filters :countries] (map (comp #(Integer/parseInt %) str/lower-case) (str/split tags #",")))
+    (assoc-in [:filters :countries] (map #(Integer/parseInt %) (str/split countries #",")))
 
     true
     (assoc-in [:filters :experts?] true)))

--- a/backend/src/gpml/handler/stakeholder/expert.clj
+++ b/backend/src/gpml/handler/stakeholder/expert.clj
@@ -160,7 +160,9 @@
       (if (instance? SQLException e)
         {:status 500
          :body {:success? false
-                :reason (pg-util/get-sql-state e)}}
+                :reason (if (= :unique-constraint-violation (pg-util/get-sql-state e))
+                          :stakeholder-email-already-exists
+                          (pg-util/get-sql-state e))}}
         {:status 500
          :body {:success? false
                 :reason :could-not-create-expert}}))))

--- a/backend/src/gpml/handler/stakeholder/expert.clj
+++ b/backend/src/gpml/handler/stakeholder/expert.clj
@@ -21,6 +21,11 @@
      :swagger {:description "Comma separated list of tags."
                :type "string"}}
     [:string {:min 1}]]
+   [:countries
+    {:optional true
+     :swagger {:description "Comma separated list of countries' IDs."
+               :type "string"}}
+    [:string {:min 1}]]
    [:page_size
     {:optional true
      :default 12
@@ -81,7 +86,7 @@
        [:string {:min 1}]]]]]])
 
 (defn- api-opts->opts
-  [{:keys [page_size page_n tags]}]
+  [{:keys [page_size page_n tags countries]}]
   (cond-> {}
     page_size
     (assoc :page-size page_size)
@@ -91,6 +96,9 @@
 
     (seq tags)
     (assoc-in [:filters :tags] (map str/lower-case (str/split tags #",")))
+
+    (seq countries)
+    (assoc-in [:filters :countries] (map (comp #(Integer/parseInt %) str/lower-case) (str/split tags #",")))
 
     true
     (assoc-in [:filters :experts?] true)))


### PR DESCRIPTION
* Restrict invite endpoint to admins only.
* Add `countries` filter to `/list` endpoint.
* Return `:stakeholder-email-already-exists` when trying to create a stakeholder with an existing email address.