### PR TITLE
1317 Add more logging to email invitations and unwrap experts tags

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -210,6 +210,9 @@
                                                   :handler #ig/ref :gpml.handler.stakeholder.expert/get}}]
                                           ["/invite"
                                            {:post {:summary "Invite an expert"
+                                                   :middleware [#ig/ref :gpml.auth/auth-required
+                                                                #ig/ref :gpml.auth/approved-user
+                                                                #ig/ref :gpml.auth/admin-required-middleware]
                                                    :swagger {:tags ["stakeholder" "expert"]}
                                                    :parameters #ig/ref :gpml.handler.stakeholder.expert/post-params
                                                    :responses #ig/ref :gpml.handler.stakeholder.expert/post-response

--- a/backend/src/gpml/auth.clj
+++ b/backend/src/gpml/auth.clj
@@ -147,7 +147,7 @@
       (if (:authenticated? request)
         (handler request)
         {:status (:status request)
-         :message (:auth-error-message request)}))))
+         :body {:message (:auth-error-message request)}}))))
 
 (defmethod ig/init-key :gpml.auth/approved-user [_ _]
   (fn [handler]

--- a/backend/src/gpml/db/stakeholder.sql
+++ b/backend/src/gpml/db/stakeholder.sql
@@ -340,7 +340,7 @@ LIMIT :limit;
 -- :name get-experts :? :*
 -- :doc Get stakeholders based on the passed filters.
 WITH experts AS (
-  SELECT s.*
+  SELECT DISTINCT ON (s.id) s.*
   FROM stakeholder s
   JOIN stakeholder_tag st ON s.id = st.stakeholder AND st.tag_relation_category = 'expertise'
 ),
@@ -348,7 +348,7 @@ filtered_experts AS (
   SELECT s.*, json_agg(json_build_object('id', t.id, 'tag', t.tag, 'tag_relation_category', st.tag_relation_category, 'tag_category', tg.category)) FILTER (WHERE t.id IS NOT NULL) AS tags
   FROM stakeholder s
   JOIN experts e ON e.id = s.id
-  JOIN stakeholder_tag st ON e.id = st.stakeholder
+  JOIN stakeholder_tag st ON s.id = st.stakeholder
   JOIN tag t ON st.tag = t.id
   JOIN tag_category tg ON t.tag_category = tg.id
   WHERE 1=1

--- a/backend/src/gpml/db/stakeholder.sql
+++ b/backend/src/gpml/db/stakeholder.sql
@@ -354,6 +354,7 @@ filtered_experts AS (
   WHERE 1=1
   --~(when (seq (get-in params [:filters :tags])) " AND LOWER(t.tag) IN (:v*:filters.tags)")
   --~(when (seq (get-in params [:filters :ids])) " AND s.id IN (:v*:filters.ids)")
+  --~(when (seq (get-in params [:filters :countries])) " AND s.country IN (:v*:filters.countries)")
   GROUP BY s.id
 )
 /*~ (if (:count-only? params) */

--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -3,7 +3,6 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
    [clojure.string :as string]
-   [clojure.walk :as w]
    [gpml.constants :as constants]
    [gpml.db.action :as db.action]
    [gpml.db.action-detail :as db.action-detail]
@@ -26,6 +25,7 @@
    [gpml.handler.organisation :as handler.org]
    [gpml.handler.resource.related-content :as handler.resource.related-content]
    [gpml.handler.resource.tag :as handler.resource.tag]
+   [gpml.handler.stakeholder.tag :as handler.stakeholder.tag]
    [gpml.handler.util :as util]
    [gpml.model.topic :as model.topic]
    [gpml.pg-util :as pg-util]
@@ -369,12 +369,7 @@
                                                                  :stakeholder-connections? false
                                                                  :related-content? false
                                                                  :affiliation? true})]
-    (merge details (reduce (fn [acc [k v]]
-                             (assoc acc k (map :tag v)))
-                           {}
-                           (-> (group-by :tag_relation_category (:tags details))
-                               (w/keywordize-keys)
-                               (select-keys [:seeking :offering :expertise]))))))
+    (merge details (handler.stakeholder.tag/unwrap-tags details))))
 
 (defmethod extra-details :nothing [_ _ _]
   nil)

--- a/backend/src/gpml/handler/stakeholder/expert.clj
+++ b/backend/src/gpml/handler/stakeholder/expert.clj
@@ -98,7 +98,7 @@
     (assoc-in [:filters :tags] (map str/lower-case (str/split tags #",")))
 
     (seq countries)
-    (assoc-in [:filters :countries] (map (comp #(Integer/parseInt %) str/lower-case) (str/split tags #",")))
+    (assoc-in [:filters :countries] (map #(Integer/parseInt %) (str/split countries #",")))
 
     true
     (assoc-in [:filters :experts?] true)))

--- a/backend/src/gpml/handler/stakeholder/expert.clj
+++ b/backend/src/gpml/handler/stakeholder/expert.clj
@@ -160,7 +160,9 @@
       (if (instance? SQLException e)
         {:status 500
          :body {:success? false
-                :reason (pg-util/get-sql-state e)}}
+                :reason (if (= :unique-constraint-violation (pg-util/get-sql-state e))
+                          :stakeholder-email-already-exists
+                          (pg-util/get-sql-state e))}}
         {:status 500
          :body {:success? false
                 :reason :could-not-create-expert}}))))

--- a/backend/src/gpml/handler/stakeholder/expert.clj
+++ b/backend/src/gpml/handler/stakeholder/expert.clj
@@ -21,6 +21,11 @@
      :swagger {:description "Comma separated list of tags."
                :type "string"}}
     [:string {:min 1}]]
+   [:countries
+    {:optional true
+     :swagger {:description "Comma separated list of countries' IDs."
+               :type "string"}}
+    [:string {:min 1}]]
    [:page_size
     {:optional true
      :default 12
@@ -81,7 +86,7 @@
        [:string {:min 1}]]]]]])
 
 (defn- api-opts->opts
-  [{:keys [page_size page_n tags]}]
+  [{:keys [page_size page_n tags countries]}]
   (cond-> {}
     page_size
     (assoc :page-size page_size)
@@ -91,6 +96,9 @@
 
     (seq tags)
     (assoc-in [:filters :tags] (map str/lower-case (str/split tags #",")))
+
+    (seq countries)
+    (assoc-in [:filters :countries] (map (comp #(Integer/parseInt %) str/lower-case) (str/split tags #",")))
 
     true
     (assoc-in [:filters :experts?] true)))

--- a/backend/src/gpml/handler/stakeholder/tag.clj
+++ b/backend/src/gpml/handler/stakeholder/tag.clj
@@ -1,0 +1,14 @@
+(ns gpml.handler.stakeholder.tag
+  (:require
+   [clojure.walk :as w]))
+
+(defn unwrap-tags
+  "Unwrap `:tags` key into three different keys `seeking`, `offering`
+  and `expertise`. Returns a map with the three keys."
+  [stakeholder]
+  (reduce (fn [acc [k v]]
+            (assoc acc k (map :tag v)))
+          {}
+          (-> (group-by :tag_relation_category (:tags stakeholder))
+              (w/keywordize-keys)
+              (select-keys [:seeking :offering :expertise]))))


### PR DESCRIPTION
* Add more logging when sending email invitations. We need to know if they are sent properly or not.
* Unwrap expert tags.