### PR TITLE
1338 refactor organisation creation logic

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -322,8 +322,7 @@
                                                   :swagger {:tags ["organisation"]
                                                             :security [{:id_token []}]}
                                                   :middleware [#ig/ref :gpml.auth/auth-middleware
-                                                               #ig/ref :gpml.auth/auth-required
-                                                               #ig/ref :gpml.auth/approved-user]
+                                                               #ig/ref :gpml.auth/auth-required]
                                                   :parameters {:body #ig/ref :gpml.handler.organisation/post-params}
                                                   :handler #ig/ref :gpml.handler.organisation/post}}]
                                          ["/{id}"

--- a/backend/src/gpml/handler/organisation.clj
+++ b/backend/src/gpml/handler/organisation.clj
@@ -66,7 +66,8 @@
   [_ {:keys [db mailjet-config logger]}]
   (fn [{:keys [body-params referrer jwt-claims]}]
     (try
-      (let [org-creator (db.stakeholder/stakeholder-by-email (:spec db) jwt-claims)
+      (let [org-creator (when (seq (:email jwt-claims))
+                          (db.stakeholder/stakeholder-by-email (:spec db) jwt-claims))
             gpml-member? (:is_member body-params)]
         (cond
           (and gpml-member? (not (:id org-creator)))

--- a/backend/src/gpml/pg_util.clj
+++ b/backend/src/gpml/pg_util.clj
@@ -45,6 +45,14 @@
           jdbc-array (.createArrayOf (.getConnection stmt) type-name as-array)]
       (.setArray stmt ix jdbc-array))))
 
+(deftype PGEnum [value type-name]
+  jdbc/ISQLParameter
+  (set-parameter [_ stmt ix]
+    (let [pg-object (doto (PGobject.)
+                      (.setType type-name)
+                      (.setValue (name value)))]
+      (.setObject stmt ix pg-object))))
+
 (extend-protocol jdbc/IResultSetReadColumn
   PGobject
   (result-set-read-column [value _ _]

--- a/backend/test/gpml/handler/organisation_test.clj
+++ b/backend/test/gpml/handler/organisation_test.clj
@@ -1,53 +1,123 @@
 (ns gpml.handler.organisation-test
-  (:require [clojure.test :refer [deftest testing is use-fixtures]]
-            [gpml.db.stakeholder :as db.stakeholder]
-            [gpml.fixtures :as fixtures]
-            [gpml.handler.organisation :as organisation]
-            [gpml.handler.stakeholder :as stakeholder]
-            [integrant.core :as ig]
-            [ring.mock.request :as mock]))
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [gpml.db.organisation :as db.organisation]
+   [gpml.db.stakeholder :as db.stakeholder]
+   [gpml.fixtures :as fixtures]
+   [gpml.handler.organisation :as organisation]
+   [gpml.handler.stakeholder :as stakeholder]
+   [gpml.pg-util :as pg-util]
+   [integrant.core :as ig]
+   [ring.mock.request :as mock]))
 
 (use-fixtures :each fixtures/with-test-system)
 
-(deftest handler-post-with-new-organisation-with-non-existent-second-contact-test
-  (testing "New profile is created with new organisation"
-    (let [system          (ig/init fixtures/*system* [::organisation/post ::stakeholder/post])
-          profile-handler (::stakeholder/post system)
-          org-handler     (::organisation/post system)
-          db              (-> system :duct.database.sql/hikaricp :spec)
-          created-by      (format "created_by_%s@akvo.org" (fixtures/uuid))
-          profile         {:email created-by
-                           :first_name "John"
-                           :geo_coverage_type nil
-                           :affiliation nil
-                           :title "Mr"
-                           :public_email false
-                           :public_database false
-                           :representation ""
-                           :picture nil
-                           :last_name "Doe"
-                           :country nil
-                           :idp_usernames ["auth0|123"]}
-          _ (db.stakeholder/new-stakeholder db profile)
-          stakeholder     (format "stakeholder_%s@akvo.org" (fixtures/uuid))
-          body-params     {:name              "test10001"
-                           :geo_coverage_type "regional"
-                           :country           nil
-                           :type              "Company"
-                           :url               "mycompany.org"
-                           :stakeholder       stakeholder}
-          jwt-claims      {:email "john@org" :picture "test.jpg"}
-          _               (profile-handler (-> (mock/request :post "/")
-                                               (assoc :jwt-claims jwt-claims)
-                                               (assoc :body-params profile)))
-          resp            (org-handler (-> (mock/request :post "/")
-                                           (assoc :jwt-claims jwt-claims)
-                                           (assoc :body-params body-params)))]
-      (is (= 201 (:status resp)))
-      (is (:success? (:body resp)))
-      (is (= (assoc body-params :id 10001) (-> resp :body :org)))
-      ;; (is (= 1 (count mails)))
-      ;; (is (= (-> mails first :receivers) (list {:Name stakeholder, :Email stakeholder})))
-      ;; (is (= (-> mails first :subject) "Mr. John Doe has invited you to join UNEP GPML Digital Platform"))
-      ;; (is (= (-> mails first :texts first) "Dear user,\n\nMr. John Doe has invited you to join http://localhost as part of entity test10001. Please visit http://localhost/stakeholder-signup and follow instructions to signup.\n\n- UNEP GPML Digital Platform\n"))
-      )))
+(defn- create-random-stakeholder
+  [db {:keys [first-name last-name review-status email]}]
+  (let [profile {:email email
+                 :first_name first-name
+                 :geo_coverage_type nil
+                 :affiliation nil
+                 :title "Mr"
+                 :public_email false
+                 :public_database false
+                 :picture nil
+                 :last_name last-name
+                 :country nil
+                 :review_status (pg-util/->PGEnum review-status "review_status")
+                 :idp_usernames ["auth0|123"]}
+        insert-cols (keys profile)
+        insert-values (vals (select-keys profile  (vec insert-cols)))]
+    (db.stakeholder/create-stakeholders db {:cols (map name insert-cols)
+                                            :values [insert-values]})
+    profile))
+
+(deftest create-organisation-test
+  (let [system          (ig/init fixtures/*system* [::organisation/post ::stakeholder/post])
+        profile-handler (::stakeholder/post system)
+        org-handler     (::organisation/post system)
+        db              (-> system :duct.database.sql/hikaricp :spec)]
+    (testing "New profile is created with new organisation"
+      (let [email (format "created_by_%s@akvo.org" (fixtures/uuid))
+            profile (create-random-stakeholder db {:first-name "John"
+                                                   :last-name "Doe"
+                                                   :email email
+                                                   :review-status "SUBMITTED"})
+            body-params     {:name              "test10001"
+                             :geo_coverage_type "regional"
+                             :country           nil
+                             :type              "Company"
+                             :url               "mycompany.org"}
+            jwt-claims      {:email "john@org" :picture "test.jpg"}
+            _               (profile-handler (-> (mock/request :post "/")
+                                                 (assoc :jwt-claims jwt-claims)
+                                                 (assoc :body-params profile)))
+            resp            (org-handler (-> (mock/request :post "/")
+                                             (assoc :jwt-claims jwt-claims)
+                                             (assoc :body-params body-params)))]
+        (is (= 201 (:status resp)))
+        (is (:success? (:body resp)))
+        (is (= (assoc body-params :id 10001) (-> resp :body :org)))))
+    (testing "Trying to create a member organisation with non-existent user should fail"
+      (let [body-params  {:name "test10002"
+                          :is_member true
+                          :geo_coverage_type "regional"
+                          :country nil
+                          :type "Company"
+                          :url "mycompany.org"}
+            {:keys [status body]} (org-handler (-> (mock/request :post "/")
+                                                   (assoc :jwt-claims {:email "i-dont-exist@org"})
+                                                   (assoc :body-params body-params)))]
+        (is (= 400 status))
+        (is (not (:success? body)))
+        (is (= :can-not-create-member-org-if-user-does-not-exist (:reason body)))))
+    (testing "Trying to create a member organisation with REJECTED user status should fail"
+      (let [email (format "created_by_%s@akvo.org" (fixtures/uuid))
+            _ (create-random-stakeholder db {:first-name "John"
+                                             :last-name "Doe"
+                                             :email email
+                                             :review-status "REJECTED"})
+            body-params  {:name "test10002"
+                          :is_member true
+                          :geo_coverage_type "regional"
+                          :country nil
+                          :type "Company"
+                          :url "mycompany.org"}
+            {:keys [status body]} (org-handler (-> (mock/request :post "/")
+                                                   (assoc :jwt-claims {:email email})
+                                                   (assoc :body-params body-params)))]
+        (is (= 400 status))
+        (is (not (:success? body)))
+        (is (= :can-not-create-member-org-if-user-is-in-rejected-state (:reason body)))))
+    (testing "Trying to create an organisation with an existing name should fail"
+      (let [email (format "created_by_%s@akvo.org" (fixtures/uuid))
+            _ (create-random-stakeholder db {:first-name "John"
+                                             :last-name "Doe"
+                                             :email email
+                                             :review-status "SUBMITTED"})
+            body-params  {:name "test10002"
+                          :is_member true
+                          :geo_coverage_type "regional"
+                          :country nil
+                          :type "Company"
+                          :url "mycompany.org"}
+            _ (db.organisation/new-organisation db body-params)
+            {:keys [status body]} (org-handler (-> (mock/request :post "/")
+                                                   (assoc :jwt-claims {:email email})
+                                                   (assoc :body-params body-params)))]
+        (is (= 409 status))
+        (is (not (:success? body)))
+        (is (= :organisation-name-already-exists (:reason body)))))
+    (testing "Trying to create a non-member organisation when caller user doesn't exist should work"
+      (let [body-params  {:name "test10003"
+                          :is_member false
+                          :geo_coverage_type "regional"
+                          :country nil
+                          :type "Company"
+                          :url "mycompany.org"}
+            {:keys [status body]} (org-handler (-> (mock/request :post "/")
+                                                   (assoc :jwt-claims {})
+                                                   (assoc :body-params body-params)))]
+        (is (= 201 status))
+        (is (:success? body))
+        (is (get-in body [:org :id]))))))


### PR DESCRIPTION
* For details about why this change, please refer to issue #1338.
* Add ISQLParameter conversion for PostgreSQL enum types
* Don't get stakeholder email if it's nil. If the user calling the API doesn't have an email (they should
because we inject the token claims in the request) we shouldn't try to
get the stakeholder. This will likely never happen but just in case
I'm adding this check.

* Closes #1338