### PR TITLE
Fix submission and resources details unauthorized for reviewer

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -62,21 +62,23 @@
                                                  :handler #ig/ref :gpml.handler.archive/get}}]]
                                         ["/submission" {:middleware [#ig/ref :gpml.auth/auth-middleware
                                                                      #ig/ref :gpml.auth/auth-required
-                                                                     #ig/ref :gpml.auth/approved-user
-                                                                     #ig/ref :gpml.auth/admin-required-middleware]
+                                                                     #ig/ref :gpml.auth/approved-user]
                                                         :responses {401 {:description "Need authentication"}
                                                                     403 {:description "Insufficient permissions"}}}
                                          [""
                                           {:get {:summary "Get the list of submissions"
+                                                 :middleware [#ig/ref :gpml.auth/admin-required-middleware]
                                                  :swagger {:tags ["submission"] :security [{:id_token []}]}
                                                  :parameters #ig/ref :gpml.handler.submission/get-params
                                                  :handler #ig/ref :gpml.handler.submission/get}
                                            :put {:summary "Approve or reject a pending submission"
+                                                 :middleware [#ig/ref :gpml.auth/admin-required-middleware]
                                                  :swagger {:tags ["submission"] :security [{:id_token []}]}
                                                  :parameters {:body #ig/ref :gpml.handler.submission/put-params}
                                                  :handler #ig/ref :gpml.handler.submission/put}}]
                                          ["/{submission}/{id}"
                                           {:get {:summary "Get the details of a submission"
+                                                 :middleware [#ig/ref :gpml.auth/admin-or-reviewer-required-middleware]
                                                  :swagger {:tags ["submission"] :security [{:id_token []}]}
                                                  :parameters {:path [:map [:submission string?] [:id int?]]}
                                                  :handler #ig/ref :gpml.handler.submission/get-detail}}]]
@@ -94,7 +96,7 @@
                                                                  #ig/ref :gpml.auth/approved-user]}
                                          [""
                                           {:get {:summary "Get list of reviews assigned to current user"
-                                                 :middleware [#ig/ref :gpml.auth/reviewer-required-middleware]
+                                                 :middleware [#ig/ref :gpml.auth/admin-or-reviewer-required-middleware]
                                                  :swagger {:tags ["review"]
                                                            :security [{:id_token []}]}
                                                  :parameters #ig/ref :gpml.handler.review/list-user-reviews-params
@@ -119,7 +121,7 @@
                                                                       [:reviewers [:vector int?]]]}
                                                   :handler #ig/ref :gpml.handler.review/new-multiple-review}
                                            :patch {:summary "Update review for a submission"
-                                                   :middleware [#ig/ref :gpml.auth/reviewer-required-middleware]
+                                                   :middleware [#ig/ref :gpml.auth/admin-or-reviewer-required-middleware]
                                                    :swagger {:tags ["review"]
                                                              :security [{:id_token []}]}
                                                    :parameters {:path [:map
@@ -555,7 +557,7 @@
   :gpml.handler.submission/get {:db #ig/ref :duct.database/sql
                                 :auth0 #ig/ref :gpml.config/auth0}
   :gpml.handler.submission/get-params {}
-  :gpml.handler.submission/get-detail {:db #ig/ref :duct.database/sql}
+  :gpml.handler.submission/get-detail #ig/ref :gpml.config/common
   :gpml.handler.submission/put {:db #ig/ref :duct.database/sql
                                 :mailjet-config #ig/ref :gpml.config/mailjet}
   :gpml.handler.submission/put-params {}
@@ -736,7 +738,7 @@
   :gpml.auth/restrict-to-organisation-admin-or-owner {:db #ig/ref :duct.database/sql}
   :gpml.auth/approved-user {:db #ig/ref :duct.database/sql}
   :gpml.auth/admin-required-middleware {:db #ig/ref :duct.database/sql}
-  :gpml.auth/reviewer-required-middleware {:db #ig/ref :duct.database/sql}
+  :gpml.auth/admin-or-reviewer-required-middleware {:db #ig/ref :duct.database/sql}
 
   :gpml.handler.monitoring/collector {}
 

--- a/backend/src/gpml/auth.clj
+++ b/backend/src/gpml/auth.clj
@@ -172,7 +172,7 @@
         {:status 403
          :body {:message "Unauthorized"}}))))
 
-(defmethod ig/init-key :gpml.auth/reviewer-required-middleware [_ _]
+(defmethod ig/init-key :gpml.auth/admin-or-reviewer-required-middleware [_ _]
   (fn [handler]
     (fn [{:keys [user approved?] :as request}]
       (if (and approved? (contains? #{"ADMIN" "REVIEWER"} (:role user)))

--- a/backend/src/gpml/handler/submission.clj
+++ b/backend/src/gpml/handler/submission.clj
@@ -2,16 +2,21 @@
   (:require
    [clojure.set :as set]
    [clojure.walk :as w]
+   [duct.logger :refer [log]]
    [gpml.auth0-util :as auth0]
    [gpml.constants :as constants]
    [gpml.db.organisation :as db.organisation]
    [gpml.db.resource.tag :as db.resource.tag]
+   [gpml.db.review :as db.review]
    [gpml.db.stakeholder :as db.stakeholder]
    [gpml.db.submission :as db.submission]
    [gpml.handler.stakeholder.tag :as handler.stakeholder.tag]
+   [gpml.pg-util :as pg-util]
    [gpml.util.email :as email]
    [integrant.core :as ig]
-   [ring.util.response :as resp]))
+   [ring.util.response :as resp])
+  (:import
+   [java.sql SQLException]))
 
 (defn remap-initiative [{:keys [q1 q1_1 q16 q18
                                 q20 q23 q24 q24_1 q24_2
@@ -110,31 +115,59 @@
               (w/keywordize-keys)
               (select-keys [:seeking :offering :expertise]))))
 
-(defmethod ig/init-key :gpml.handler.submission/get-detail [_ {:keys [db]}]
-  (fn [{{:keys [path]} :parameters}]
-    (let [conn (:spec db)
-          submission (:submission path)
-          initiative? (and (= submission "project") (> (:id path) 10000))
-          table-name (cond
-                       (contains? constants/resource-types submission)
-                       "resource"
-                       initiative?
-                       "initiative"
-                       :else
-                       submission)
-          params (conj path {:table-name table-name})
-          detail (submission-detail conn params)
-          detail (if (= submission "stakeholder")
-                   (merge detail
-                          (select-keys (db.stakeholder/stakeholder-by-id conn path) [:email])
-                          (->> (db.resource.tag/get-resource-tags conn {:table "stakeholder_tag"
-                                                                        :resource-col "stakeholder"
-                                                                        :resource-id (:id path)})
-                               (prep-stakeholder-tags)))
-                   detail)
-          detail (if initiative? (remap-initiative detail conn)
-                     detail)]
-      (resp/response detail))))
+(defn- get-detail
+  [{:keys [db]} params]
+  (let [conn (:spec db)
+        submission (:submission params)
+        initiative? (and (= submission "project") (> (:id params) 10000))
+        table-name (cond
+                     (contains? constants/resource-types submission)
+                     "resource"
+                     initiative?
+                     "initiative"
+                     :else
+                     submission)
+        params (conj params {:table-name table-name})
+        detail (submission-detail conn params)
+        detail (if (= submission "stakeholder")
+                 (merge detail
+                        (select-keys (db.stakeholder/stakeholder-by-id conn params) [:email])
+                        (->> (db.resource.tag/get-resource-tags conn {:table "stakeholder_tag"
+                                                                      :resource-col "stakeholder"
+                                                                      :resource-id (:id params)})
+                             (prep-stakeholder-tags)))
+                 detail)
+        detail (if initiative? (remap-initiative detail conn)
+                   detail)]
+    (resp/response detail)))
+
+(defmethod ig/init-key :gpml.handler.submission/get-detail
+  [_ {:keys [db logger] :as config}]
+  (fn [{{:keys [path]} :parameters user :user}]
+    (try
+      (if-not (= "REVIEWER" (:role user))
+        (get-detail config path)
+        (let [topic-type (:submission path)
+              topic-id (:id path)
+              review (first (db.review/reviews-filter (:spec db) {:topic-type topic-type
+                                                                  :topic-id topic-id}))]
+          (if (= (:id user) (:reviewer review))
+            (get-detail config path)
+            {:status 403
+             :body {:success? false
+                    :reason :unauthorized}})))
+      (catch Exception e
+        (log logger :error ::failed-to-get-submission-detail {:exception-message (.getMessage e)
+                                                              :context-data {:params path
+                                                                             :user user}})
+        (if (instance? SQLException e)
+          {:status 500
+           :body {:success? false
+                  :reason (pg-util/get-sql-state e)}}
+          {:status 500
+           :body {:success? false
+                  :reason :could-not-submission-get-details
+                  :error-details {:error (.getMessage e)}}})))))
 
 (defmethod ig/init-key :gpml.handler.submission/get-params [_ _]
   {:query


### PR DESCRIPTION
* Apart of fixing the logic to also consider reviewer permissions, I
also improved the error handling on the submission details
API. Following the same pattern as we've been doing lately of handling
exceptions and returning the correct status code depending on the
error. Including error details in the response body.

* See #1354
* Closes #1354