### PR TITLE
[#1362] Improve error handling for resources POST endpoints

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -581,27 +581,22 @@
   :gpml.handler.landing/get-query-params {}
   :gpml.handler.nav/get {:db #ig/ref :duct.database/sql}
 
-  :gpml.handler.event/post {:db #ig/ref :duct.database/sql
-                            :mailjet-config #ig/ref :gpml.config/mailjet}
+  :gpml.handler.event/post #ig/ref :gpml.config/common
 
   :gpml.handler.event/post-params {}
 
-  :gpml.handler.resource/post {:db #ig/ref :duct.database/sql
-                               :mailjet-config #ig/ref :gpml.config/mailjet}
+  :gpml.handler.resource/post #ig/ref :gpml.config/common
 
   :gpml.handler.resource/post-params {}
 
-  :gpml.handler.policy/post {:db #ig/ref :duct.database/sql
-                             :mailjet-config #ig/ref :gpml.config/mailjet}
+  :gpml.handler.policy/post #ig/ref :gpml.config/common
   :gpml.handler.policy/post-params {}
 
-  :gpml.handler.technology/post {:db #ig/ref :duct.database/sql
-                                 :mailjet-config #ig/ref :gpml.config/mailjet}
+  :gpml.handler.technology/post #ig/ref :gpml.config/common
   :gpml.handler.technology/post-params {}
 
   :gpml.handler.initiative/get {:db #ig/ref :duct.database/sql}
-  :gpml.handler.initiative/post {:db #ig/ref :duct.database/sql
-                                 :mailjet-config #ig/ref :gpml.config/mailjet}
+  :gpml.handler.initiative/post #ig/ref :gpml.config/common
   :gpml.handler.initiative/post-params {}
 
   :gpml.handler.stakeholder/get-params {}

--- a/backend/src/gpml/handler/initiative.clj
+++ b/backend/src/gpml/handler/initiative.clj
@@ -1,5 +1,6 @@
 (ns gpml.handler.initiative
   (:require [clojure.java.jdbc :as jdbc]
+            [duct.logger :refer [log]]
             [gpml.db.favorite :as db.favorite]
             [gpml.db.initiative :as db.initiative]
             [gpml.db.resource.connection :as db.resource.connection]
@@ -13,7 +14,8 @@
             [gpml.handler.util :as util]
             [gpml.util.email :as email]
             [integrant.core :as ig]
-            [ring.util.response :as resp]))
+            [ring.util.response :as resp])
+  (:import [java.sql SQLException]))
 
 (defn- add-geo-initiative [conn initiative-id {:keys [geo_coverage_country_groups geo_coverage_countries] :as data}]
   (when (or (not-empty geo_coverage_country_groups)
@@ -104,14 +106,27 @@
      {:type "initiative" :title (:q2 data)})
     initiative-id))
 
-(defmethod ig/init-key :gpml.handler.initiative/post [_ {:keys [db mailjet-config]}]
+(defmethod ig/init-key :gpml.handler.initiative/post
+  [_ {:keys [db logger mailjet-config]}]
   (fn [{:keys [jwt-claims body-params] :as req}]
-    (jdbc/with-db-transaction [conn (:spec db)]
-      (let [user (db.stakeholder/stakeholder-by-email conn jwt-claims)
-            initiative-id (create-initiative conn (assoc body-params
-                                                         :created_by (:id user)
-                                                         :mailjet-config mailjet-config))]
-        (resp/created (:referrer req) {:message "New initiative created" :id initiative-id})))))
+    (try
+      (jdbc/with-db-transaction [conn (:spec db)]
+        (let [user (db.stakeholder/stakeholder-by-email conn jwt-claims)
+              initiative-id (create-initiative conn (assoc body-params
+                                                           :created_by (:id user)
+                                                           :mailjet-config mailjet-config))]
+          (resp/created (:referrer req) {:success? true
+                                         :message "New initiative created"
+                                         :id initiative-id})))
+      (catch Exception e
+        (log logger :error ::failed-to-create-initiative {:exception-message (.getMessage e)})
+        (let [response {:status 500
+                        :body {:success? false
+                               :reason :could-not-create-event}}]
+
+          (if (instance? SQLException e)
+            response
+            (assoc response :error-details {:error (.getMessage e)})))))))
 
 (defn expand-related-initiative-content [conn initiative-id]
   (let [related_content (handler.resource.related-content/get-related-contents conn initiative-id "initiative")]

--- a/backend/src/gpml/handler/resource.clj
+++ b/backend/src/gpml/handler/resource.clj
@@ -1,5 +1,6 @@
 (ns gpml.handler.resource
   (:require [clojure.java.jdbc :as jdbc]
+            [duct.logger :refer [log]]
             [gpml.auth :as auth]
             [gpml.constants :as constants]
             [gpml.db.activity :as db.activity]
@@ -16,7 +17,8 @@
             [gpml.util :as util]
             [gpml.util.email :as email]
             [integrant.core :as ig]
-            [ring.util.response :as resp]))
+            [ring.util.response :as resp])
+  (:import [java.sql SQLException]))
 
 (defn expand-entity-associations
   [entity-connections resource-id]
@@ -121,19 +123,32 @@
      (merge data {:type resource_type}))
     resource-id))
 
-(defmethod ig/init-key :gpml.handler.resource/post [_ {:keys [db mailjet-config]}]
+(defmethod ig/init-key :gpml.handler.resource/post
+  [_ {:keys [db logger mailjet-config]}]
   (fn [{:keys [jwt-claims body-params] :as req}]
-    (jdbc/with-db-transaction [conn (:spec db)]
-      (let [user (db.stakeholder/stakeholder-by-email conn jwt-claims)
-            resource-id (create-resource conn mailjet-config (assoc body-params
-                                                                    :created_by (:id user)))
-            activity {:id (util/uuid)
-                      :type "create_resource"
-                      :owner_id (:id user)
-                      :metadata {:resource_id resource-id
-                                 :resource_type (:resource_type body-params)}}]
-        (db.activity/create-activity conn activity)
-        (resp/created (:referrer req) {:message "New resource created" :id resource-id})))))
+    (try
+      (jdbc/with-db-transaction [conn (:spec db)]
+        (let [user (db.stakeholder/stakeholder-by-email conn jwt-claims)
+              resource-id (create-resource conn mailjet-config (assoc body-params
+                                                                      :created_by (:id user)))
+              activity {:id (util/uuid)
+                        :type "create_resource"
+                        :owner_id (:id user)
+                        :metadata {:resource_id resource-id
+                                   :resource_type (:resource_type body-params)}}]
+          (db.activity/create-activity conn activity)
+          (resp/created (:referrer req) {:success? true
+                                         :message "New resource created"
+                                         :id resource-id})))
+      (catch Exception e
+        (log logger :error ::failed-to-create-resource {:exception-message (.getMessage e)})
+        (let [response {:status 500
+                        :body {:success? false
+                               :reason :could-not-create-event}}]
+
+          (if (instance? SQLException e)
+            response
+            (assoc response :error-details {:error (.getMessage e)})))))))
 
 (defn or-and [resource_type validator]
   (or (= "Action Plan" resource_type)

--- a/backend/src/gpml/handler/technology.clj
+++ b/backend/src/gpml/handler/technology.clj
@@ -1,5 +1,6 @@
 (ns gpml.handler.technology
   (:require [clojure.java.jdbc :as jdbc]
+            [duct.logger :refer [log]]
             [gpml.auth :as auth]
             [gpml.constants :as constants]
             [gpml.db.country :as db.country]
@@ -16,7 +17,8 @@
             [gpml.util :as util]
             [gpml.util.email :as email]
             [integrant.core :as ig]
-            [ring.util.response :as resp]))
+            [ring.util.response :as resp])
+  (:import [java.sql SQLException]))
 
 (defn expand-entity-associations
   [entity-connections resource-id]
@@ -122,13 +124,26 @@
      (merge data {:type "technology"}))
     technology-id))
 
-(defmethod ig/init-key :gpml.handler.technology/post [_ {:keys [db mailjet-config]}]
+(defmethod ig/init-key :gpml.handler.technology/post
+  [_ {:keys [db logger mailjet-config]}]
   (fn [{:keys [jwt-claims body-params] :as req}]
-    (jdbc/with-db-transaction [conn (:spec db)]
-      (let [user (db.stakeholder/stakeholder-by-email conn jwt-claims)
-            technology-id (create-technology conn mailjet-config (assoc body-params
-                                                                        :created_by (:id user)))]
-        (resp/created (:referrer req) {:message "New technology created" :id technology-id})))))
+    (try
+      (jdbc/with-db-transaction [conn (:spec db)]
+        (let [user (db.stakeholder/stakeholder-by-email conn jwt-claims)
+              technology-id (create-technology conn mailjet-config (assoc body-params
+                                                                          :created_by (:id user)))]
+          (resp/created (:referrer req) {:success? true
+                                         :message "New technology created"
+                                         :id technology-id})))
+      (catch Exception e
+        (log logger :error ::failed-to-create-technology {:exception-message (.getMessage e)})
+        (let [response {:status 500
+                        :body {:success? false
+                               :reason :could-not-create-event}}]
+
+          (if (instance? SQLException e)
+            response
+            (assoc response :error-details {:error (.getMessage e)})))))))
 
 (def post-params
   (into [:map


### PR DESCRIPTION
* Handling exceptions, checking for SQLExceptions and adding extra
details in case the error is not a SQLException (the exception
message, might disclose sensitive information). In any case, this can
be improved by isolating each step when creating a new resource and
fail as fast, and as soon as possible.