### PR TITLE
Implement country_groups filter in the experts list API

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -617,13 +617,10 @@
   :gpml.handler.stakeholder/suggested-profiles {:db #ig/ref :duct.database/sql}
   :gpml.handler.stakeholder/suggested-profiles-params {}
 
-  :gpml.handler.stakeholder.expert/get {:db #ig/ref :duct.database/sql}
+  :gpml.handler.stakeholder.expert/get #ig/ref :gpml.config/common
   :gpml.handler.stakeholder.expert/get-params {}
   :gpml.handler.stakeholder.expert/get-response {}
-  :gpml.handler.stakeholder.expert/post {:db #ig/ref :duct.database/sql
-                                         :mailjet-config #ig/ref :gpml.config/mailjet
-                                         :app-domain #duct/env ["APP_DOMAIN" Str]
-                                         :logger #ig/ref :duct/logger}
+  :gpml.handler.stakeholder.expert/post #ig/ref :gpml.config/common
   :gpml.handler.stakeholder.expert/post-params {}
   :gpml.handler.stakeholder.expert/post-response {}
 

--- a/backend/src/gpml/db/country-group.sql
+++ b/backend/src/gpml/db/country-group.sql
@@ -67,8 +67,16 @@ select country_group.id, country_group.name from country_group
 left join country_group_country on country_group_country.country_group= country_group.id
 where country_group_country.country= :id
 
+-- FIXME: we should deprecate this function in favor of `get-country-groups-countries`
 -- :name get-country-group-countries :? :*
 -- :doc get country group countries by country group id
 select cgc.country as id from country_group_country cgc
 left join country_group cg on cgc.country_group = cg.id
-where cg.id = :id
+where 1=1
+
+-- :name get-country-groups-countries :query :many
+-- :doc Get country groups countries by country groups ids.
+SELECT cgc.country AS id
+FROM country_group_country cgc
+LEFT JOIN country_group cg ON cgc.country_group = cg.id
+WHERE cg.id IN (:v*:filters.country-groups)


### PR DESCRIPTION
* Implement `country_groups` filter in the experts list API.
* Also fixed the scope of reponse and params schemas.
* Fixed the error handling typos.