### PR TITLE
Fix resources POST endpoints error responses

### DIFF
--- a/backend/src/gpml/handler/event.clj
+++ b/backend/src/gpml/handler/event.clj
@@ -186,7 +186,7 @@
 
           (if (instance? SQLException e)
             response
-            (assoc response :error-details {:error (.getMessage e)})))))))
+            (assoc-in response [:body :error-details :error] (.getMessage e))))))))
 
 (defmethod ig/init-key :gpml.handler.event/post-params [_ _]
   post-params)

--- a/backend/src/gpml/handler/initiative.clj
+++ b/backend/src/gpml/handler/initiative.clj
@@ -126,7 +126,7 @@
 
           (if (instance? SQLException e)
             response
-            (assoc response :error-details {:error (.getMessage e)})))))))
+            (assoc-in response [:body :error-details :error] (.getMessage e))))))))
 
 (defn expand-related-initiative-content [conn initiative-id]
   (let [related_content (handler.resource.related-content/get-related-contents conn initiative-id "initiative")]

--- a/backend/src/gpml/handler/policy.clj
+++ b/backend/src/gpml/handler/policy.clj
@@ -145,7 +145,7 @@
 
           (if (instance? SQLException e)
             response
-            (assoc response :error-details {:error (.getMessage e)})))))))
+            (assoc-in response [:body :error-details :error] (.getMessage e))))))))
 
 (def post-params
   (->

--- a/backend/src/gpml/handler/resource.clj
+++ b/backend/src/gpml/handler/resource.clj
@@ -148,7 +148,7 @@
 
           (if (instance? SQLException e)
             response
-            (assoc response :error-details {:error (.getMessage e)})))))))
+            (assoc-in response [:body :error-details :error] (.getMessage e))))))))
 
 (defn or-and [resource_type validator]
   (or (= "Action Plan" resource_type)

--- a/backend/src/gpml/handler/technology.clj
+++ b/backend/src/gpml/handler/technology.clj
@@ -143,7 +143,7 @@
 
           (if (instance? SQLException e)
             response
-            (assoc response :error-details {:error (.getMessage e)})))))))
+            (assoc-in response [:body :error-details :error] (.getMessage e))))))))
 
 (def post-params
   (into [:map


### PR DESCRIPTION
* There was a typo when associating the :error-details key.