### PR TITLE
[#1368] Implement focal-points auth role validation

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -402,7 +402,9 @@
                                                                      [:topic-type #ig/ref :gpml.handler.detail/topics]
                                                                      [:topic-id int?]]}
                                                  :handler #ig/ref :gpml.handler.detail/get}
-                                           :delete {:middleware [#ig/ref :gpml.auth/auth-middleware]
+                                           :delete {:middleware [#ig/ref :gpml.auth/auth-middleware
+                                                                 #ig/ref :gpml.auth/auth-required
+                                                                 #ig/ref :gpml.auth/approved-user]
                                                     :summary "remove specific resource"
                                                     :swagger {:tags ["resource detail"]}
                                                     :parameters {:path [:map

--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -366,57 +366,32 @@
                                           [""
                                            {:get {:summary "Get auth details for a specific topic"
                                                   :swagger {:tags ["topic auth detail"]}
-                                                  :parameters {:path [:map
-                                                                      [:topic-type #ig/ref :gpml.handler.detail/topics]
-                                                                      [:topic-id int?]]}
+                                                  :parameters #ig/ref :gpml.handler.auth/get-topic-auth-params
                                                   :handler #ig/ref :gpml.handler.auth/get-topic-auth}
                                             :post {:summary "Add stakeholders auth roles to topic"
                                                    :swagger {:tags ["topic auth stakeholder"]
                                                              :security [{:id_token []}]}
-                                                   :parameters {:path [:map
-                                                                       [:topic-type #ig/ref :gpml.handler.detail/topics]
-                                                                       [:topic-id int?]]
-                                                                :body [:map
-                                                                       [:stakeholders
-                                                                        [:vector [:map
-                                                                                  [:id int?]
-                                                                                  [:roles [:vector [:enum "owner"]]]]]]]}
+                                                   :parameters #ig/ref :gpml.handler.auth/post-topic-auth-params
                                                    :handler #ig/ref :gpml.handler.auth/post-topic-auth}}]
                                           ["/{stakeholder}"
                                            {:put {:summary "Update stakeholder auth roles"
                                                   :swagger {:tags ["topic auth stakeholder"]
                                                             :security [{:id_token []}]}
-                                                  :parameters {:path [:map
-                                                                      [:topic-type #ig/ref :gpml.handler.detail/topics]
-                                                                      [:topic-id int?]
-                                                                      [:stakeholder int?]]
-                                                               :body [:map
-                                                                      [:roles [:vector [:enum "owner"]]]]}
+                                                  :parameters #ig/ref :gpml.handler.auth/update-roles-params
                                                   :handler #ig/ref :gpml.handler.auth/update-roles}
                                             :post {:summary "Add stakeholder auth roles to topic"
                                                    :swagger {:tags ["topic auth stakeholder"]
                                                              :security [{:id_token []}]}
-                                                   :parameters {:path [:map
-                                                                       [:topic-type #ig/ref :gpml.handler.detail/topics]
-                                                                       [:topic-id int?]
-                                                                       [:stakeholder int?]]
-                                                                :body [:map
-                                                                       [:roles [:vector [:enum "owner"]]]]}
+                                                   :parameters #ig/ref :gpml.handler.auth/new-roles-params
                                                    :handler #ig/ref :gpml.handler.auth/new-roles}
                                             :delete {:summary "Delete auth details for a specific resource and stakeholder"
                                                      :swagger {:tags ["topic stakeholder auth detail"]
                                                                :security [{:id_token []}]}
-                                                     :parameters {:path [:map
-                                                                         [:topic-type #ig/ref :gpml.handler.detail/topics]
-                                                                         [:topic-id int?]
-                                                                         [:stakeholder int?]]}
+                                                     :parameters #ig/ref :gpml.handler.auth/delete-params
                                                      :handler #ig/ref :gpml.handler.auth/delete}
                                             :get {:summary "Get auth details for a specific resource and stakeholder"
                                                   :swagger {:tags ["topic stakeholder auth detail"]}
-                                                  :parameters {:path [:map
-                                                                      [:topic-type #ig/ref :gpml.handler.detail/topics]
-                                                                      [:topic-id int?]
-                                                                      [:stakeholder int?]]}
+                                                  :parameters #ig/ref :gpml.handler.auth/get-topic-stakeholder-auth-params
                                                   :handler #ig/ref :gpml.handler.auth/get-topic-stakeholder-auth}}]]]
                                         ["/detail"
                                          ["/{topic-type}/{topic-id}"
@@ -661,12 +636,19 @@
                          :sentry {:dsn #duct/env "SENTRY_DSN"
                                   :environment #duct/env "ENV_NAME"}}
 
-  :gpml.handler.auth/get-topic-stakeholder-auth {:conn #ig/ref :gpml.db/spec}
-  :gpml.handler.auth/get-topic-auth {:conn #ig/ref :gpml.db/spec}
-  :gpml.handler.auth/post-topic-auth {:conn #ig/ref :gpml.db/spec}
-  :gpml.handler.auth/new-roles {:conn #ig/ref :gpml.db/spec}
-  :gpml.handler.auth/update-roles {:conn #ig/ref :gpml.db/spec}
-  :gpml.handler.auth/delete {:conn #ig/ref :gpml.db/spec}
+  :gpml.handler.auth/get-topic-stakeholder-auth #ig/ref :gpml.config/common
+  :gpml.handler.auth/get-topic-auth #ig/ref :gpml.config/common
+  :gpml.handler.auth/post-topic-auth #ig/ref :gpml.config/common
+  :gpml.handler.auth/new-roles #ig/ref :gpml.config/common
+  :gpml.handler.auth/update-roles #ig/ref :gpml.config/common
+  :gpml.handler.auth/delete #ig/ref :gpml.config/common
+  :gpml.handler.auth/get-topic-stakeholder-auth-params {}
+  :gpml.handler.auth/get-topic-auth-params {}
+  :gpml.handler.auth/post-topic-auth-params {}
+  :gpml.handler.auth/new-roles-params {}
+  :gpml.handler.auth/update-roles-params {}
+  :gpml.handler.auth/delete-params {}
+
   :gpml.handler.comment/post {:db #ig/ref :duct.database/sql
                               :mailjet-config #ig/ref :gpml.config/mailjet}
   :gpml.handler.comment/post-params {}

--- a/backend/src/gpml/auth.clj
+++ b/backend/src/gpml/auth.clj
@@ -2,6 +2,7 @@
   (:require [gpml.db.comment :as db.comment]
             [gpml.db.organisation :as db.organisation]
             [gpml.db.stakeholder :as db.stakeholder]
+            [gpml.db.topic-stakeholder-auth :as db.ts-auth]
             [gpml.util :as util]
             [integrant.core :as ig]
             [malli.core :as malli])
@@ -193,11 +194,17 @@
 (defmethod ig/init-key :gpml.auth/restrict-to-organisation-admin-or-owner
   [_ {:keys [db]}]
   (fn [handler]
-    (fn [{:keys [user] :as request}]
-      (let [organisation (first (db.organisation/get-organisations (:spec db) {:filters {:created_by (:id user)}}))
-            owner? (= (:id user) (:created_by organisation))]
+    (fn [{{:keys [path]} :parameters user :user :as request}]
+      (let [stakeholder-auth (db.ts-auth/get-auth-by-topic-and-stakeholder (:spec db)
+                                                                           {:topic-type "organisation"
+                                                                            :topic-id (:id path)
+                                                                            :stakeholder (:id user)})
+            organisation (first (db.organisation/get-organisations (:spec db)
+                                                                   {:filters {:created_by (:id user)}}))
+            org-creator? (= (:id user) (:created_by organisation))]
         (if (or (= (:role user) "ADMIN")
-                owner?)
+                org-creator?
+                (some #(get (set (:roles stakeholder-auth)) %) ["focal-point"]))
           (handler request)
           {:status 403
            :headers {"content-type" "application/json"}
@@ -207,5 +214,3 @@
 (def owners-schema
   [:owners {:optional true}
    [:vector integer?]])
-
-(def authz-roles #{"owner"})

--- a/backend/src/gpml/auth.clj
+++ b/backend/src/gpml/auth.clj
@@ -195,10 +195,13 @@
   [_ {:keys [db]}]
   (fn [handler]
     (fn [{{:keys [path]} :parameters user :user :as request}]
-      (let [stakeholder-auth (db.ts-auth/get-auth-by-topic-and-stakeholder (:spec db)
-                                                                           {:topic-type "organisation"
-                                                                            :topic-id (:id path)
-                                                                            :stakeholder (:id user)})
+      (let [stakeholder-auth
+            (->> (db.ts-auth/get-topic-stakeholder-auths (:spec db)
+                                                         {:topic-type "organisation"
+                                                          :topic-id (:id path)
+                                                          :stakeholder (:id user)})
+                 (first)
+                 (set))
             organisation (first (db.organisation/get-organisations (:spec db)
                                                                    {:filters {:created_by (:id user)}}))
             org-creator? (= (:id user) (:created_by organisation))]

--- a/backend/src/gpml/auth.clj
+++ b/backend/src/gpml/auth.clj
@@ -207,7 +207,7 @@
             org-creator? (= (:id user) (:created_by organisation))]
         (if (or (= (:role user) "ADMIN")
                 org-creator?
-                (some #(get (set (:roles stakeholder-auth)) %) ["focal-point"]))
+                (some #(get (set (:roles stakeholder-auth)) %) ["owner" "focal-point"]))
           (handler request)
           {:status 403
            :headers {"content-type" "application/json"}

--- a/backend/src/gpml/db/resource/association.clj
+++ b/backend/src/gpml/db/resource/association.clj
@@ -2,4 +2,4 @@
   {:ns-tracker/resource-deps ["resource/association.sql"]}
   (:require [hugsql.core :as hugsql]))
 
-(hugsql/def-db-fns "gpml/db/resource/association.sql")
+(hugsql/def-db-fns "gpml/db/resource/association.sql" {:quoting :ansi})

--- a/backend/src/gpml/db/resource/association.clj
+++ b/backend/src/gpml/db/resource/association.clj
@@ -1,0 +1,5 @@
+(ns gpml.db.resource.association
+  {:ns-tracker/resource-deps ["resource/association.sql"]}
+  (:require [hugsql.core :as hugsql]))
+
+(hugsql/def-db-fns "gpml/db/resource/association.sql")

--- a/backend/src/gpml/db/resource/association.sql
+++ b/backend/src/gpml/db/resource/association.sql
@@ -1,0 +1,7 @@
+-- :name get-resource-associations
+-- :doc Get the organisation association details for a specific resource.
+SELECT *
+FROM :i:table
+WHERE :i:resource-col = :filters.resource-id
+--~ (when (get-in params [:filters :entity-id]) " AND :i:entity-col = :filters.entity-id")
+--~ (when (get-in params [:filters :associations]) " AND association = ANY(CAST(ARRAY[:v*:filters.associations] AS :i:resource-assoc-type[])) ")

--- a/backend/src/gpml/db/resource/association.sql
+++ b/backend/src/gpml/db/resource/association.sql
@@ -1,4 +1,4 @@
--- :name get-resource-associations
+-- :name get-resource-associations :query :many
 -- :doc Get the organisation association details for a specific resource.
 SELECT *
 FROM :i:table

--- a/backend/src/gpml/db/topic_stakeholder_auth.clj
+++ b/backend/src/gpml/db/topic_stakeholder_auth.clj
@@ -2,4 +2,4 @@
   {:ns-tracker/resource-deps ["topic_stakeholder_auth.sql"]}
   (:require [hugsql.core :as hugsql]))
 
-(hugsql/def-db-fns "gpml/db/topic_stakeholder_auth.sql")
+(hugsql/def-db-fns "gpml/db/topic_stakeholder_auth.sql" {:quoting :ansi})

--- a/backend/src/gpml/db/topic_stakeholder_auth.sql
+++ b/backend/src/gpml/db/topic_stakeholder_auth.sql
@@ -1,3 +1,12 @@
+-- :name get-topic-stakeholder-auths
+-- :doc Generic get topic stakeholder auths supporting filters.
+SELECT *
+FROM topic_stakeholder_auth
+WHERE 1=1
+--~(when (seq (get-in params [:filters :topics-ids])) " AND topic_id IN (:v*:filters.topics-ids)")
+--~(when (seq (get-in params [:filters :topic-types])) " AND topic_type = ANY(CAST(ARRAY[:v*:filters.topic-types] AS topic_type[]))")
+--~(when (seq (get-in params [:filters :stakeholders-ids])) " AND stakeholder IN (:v*:filters.stakeholders-ids)")
+
 -- :name get-auth-by-topic :? :*
 -- :doc Get details about a particular topic
 select * from topic_stakeholder_auth where topic_id=:topic-id and topic_type=:topic-type::topic_type;

--- a/backend/src/gpml/db/topic_stakeholder_auth.sql
+++ b/backend/src/gpml/db/topic_stakeholder_auth.sql
@@ -1,4 +1,4 @@
--- :name get-topic-stakeholder-auths
+-- :name get-topic-stakeholder-auths :query :many
 -- :doc Generic get topic stakeholder auths supporting filters.
 SELECT *
 FROM topic_stakeholder_auth
@@ -6,6 +6,7 @@ WHERE 1=1
 --~(when (seq (get-in params [:filters :topics-ids])) " AND topic_id IN (:v*:filters.topics-ids)")
 --~(when (seq (get-in params [:filters :topic-types])) " AND topic_type = ANY(CAST(ARRAY[:v*:filters.topic-types] AS topic_type[]))")
 --~(when (seq (get-in params [:filters :stakeholders-ids])) " AND stakeholder IN (:v*:filters.stakeholders-ids)")
+--~(when (seq (get-in params [:filters :roles])) " AND :filters.role IN roles")
 
 -- :name get-auth-by-topic :? :*
 -- :doc Get details about a particular topic

--- a/backend/src/gpml/db/topic_stakeholder_auth.sql
+++ b/backend/src/gpml/db/topic_stakeholder_auth.sql
@@ -6,7 +6,7 @@ WHERE 1=1
 --~(when (seq (get-in params [:filters :topics-ids])) " AND topic_id IN (:v*:filters.topics-ids)")
 --~(when (seq (get-in params [:filters :topic-types])) " AND topic_type = ANY(CAST(ARRAY[:v*:filters.topic-types] AS topic_type[]))")
 --~(when (seq (get-in params [:filters :stakeholders-ids])) " AND stakeholder IN (:v*:filters.stakeholders-ids)")
---~(when (seq (get-in params [:filters :roles])) " AND :filters.role IN roles")
+--~(when (seq (get-in params [:filters :roles])) " AND roles ??| CAST(ARRAY[:v*:filters.roles] AS text[])")
 
 -- :name get-auth-by-topic :? :*
 -- :doc Get details about a particular topic

--- a/backend/src/gpml/domain/topic_stakeholder_auth.clj
+++ b/backend/src/gpml/domain/topic_stakeholder_auth.clj
@@ -1,0 +1,25 @@
+(ns gpml.domain.topic-stakeholder-auth
+  (:require [malli.core :as m]))
+
+(def ^:const role-types
+  "Topic Stakeholder Auth possible role types"
+  #{"owner" "focal-point"})
+
+(def ^:const resource-types
+  "Topic Stakeholder Auth possible resource types with applicable
+  roles/permissions. This does not refer to the `resource` entity but
+  to the platform's resources in general."
+  #{"stakeholder" "organisation" "resource" "initiative" "event"
+    "technology" "policy" "tag"})
+
+(def TopicStakeholderAuth
+  "Topic Stakeholder Auth entity model."
+  (m/schema
+   [:map
+    [:id [:int {:min 0}]]
+    [:stakeholder [:int {:min 0}]]
+    [:topic_id [:int {:min 0}]]
+    [:topic_type (apply conj [:enum] resource-types)]
+    [:roles [:sequential (apply conj [:enum] role-types)]]
+    [:created inst?]
+    [:modified inst?]]))

--- a/backend/src/gpml/domain/topic_stakeholder_auth.clj
+++ b/backend/src/gpml/domain/topic_stakeholder_auth.clj
@@ -1,6 +1,14 @@
 (ns gpml.domain.topic-stakeholder-auth
   (:require [malli.core :as m]))
 
+(def ^:const max-focal-points
+  "The maximum amount of `focal-point` stakeholder in a single
+  resource. If resource already have 2 `focal-point` stakeholders the
+  system must not allow a third `focal-point` role
+  assigment. Currently this restriction is only applied to
+  `organisation` resources."
+  2)
+
 (def ^:const role-types
   "Topic Stakeholder Auth possible role types"
   #{"owner" "focal-point"})

--- a/backend/src/gpml/handler/auth.clj
+++ b/backend/src/gpml/handler/auth.clj
@@ -36,7 +36,7 @@
                                                 {:filters {:roles ["focal-point"]
                                                            :topics-ids [topic-id]
                                                            :topics-type [topic-type]}})]
-    (< (count stakeholder-auths) dom.ts-auth/max-focal-points)))
+    (= (count stakeholder-auths) dom.ts-auth/max-focal-points)))
 
 (defmethod ig/init-key :gpml.handler.auth/get-topic-auth
   [_ {:keys [db logger]}]

--- a/backend/src/gpml/handler/auth.clj
+++ b/backend/src/gpml/handler/auth.clj
@@ -1,82 +1,193 @@
 (ns gpml.handler.auth
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.set :as set]
-            [gpml.auth :as auth]
+            [duct.logger :refer [log]]
+            [gpml.constants :as constants]
             [gpml.db.topic-stakeholder-auth :as db.ts-auth]
+            [gpml.domain.stakeholder :as dom.stakeholder]
+            [gpml.domain.topic-stakeholder-auth :as dom.ts-auth]
             [gpml.handler.util :as util]
             [integrant.core :as ig]
-            [ring.util.response :as resp]))
+            [malli.util :as mu]
+            [ring.util.response :as resp])
+  (:import [java.sql SQLException]))
 
-(defn grant-topic-to-stakeholder! [conn {:keys [topic-id topic-type stakeholder-id roles]}]
-  {:pre [(empty? (set/difference (set roles)  auth/authz-roles))]}
+(def ^:private shared-path-params
+  [:map
+   [:topic-type (apply conj [:enum] constants/topics)]
+   [:topic-id [:int {:min 0}]]
+   [:stakeholder [:int {:min 0}]]])
+
+(defn grant-topic-to-stakeholder!
+  [conn {:keys [topic-id topic-type stakeholder-id roles]}]
+  {:pre [(empty? (set/difference (set roles) dom.ts-auth/role-types))]}
   (let [opts {:topic-id    topic-id
               :topic-type  topic-type
               :stakeholder stakeholder-id
               :roles       roles}]
     (db.ts-auth/new-auth conn opts)))
 
-(defmethod ig/init-key ::get-topic-auth [_ {:keys [conn]}]
+(defmethod ig/init-key :gpml.handler.auth/get-topic-auth
+  [_ {:keys [db logger]}]
   (fn [{{:keys [path]} :parameters user :user}]
-    (let [authorized? user
-          path (update path :topic-type util/get-internal-topic-type)]
-      (if authorized?
-        (if-let [data (db.ts-auth/get-auth-by-topic conn path)]
-          (resp/response (merge path {:auth-stakeholders data}))
-          util/not-found)
-        util/unauthorized))))
+    (try
+      (let [conn (:spec db)
+            authorized? user
+            path (update path :topic-type util/get-internal-topic-type)]
+        (if authorized?
+          (if-let [data (db.ts-auth/get-auth-by-topic conn path)]
+            (resp/response (assoc (merge path {:auth-stakeholders data}) :success? true))
+            util/not-found)
+          util/unauthorized))
+      (catch Exception e
+        (log logger :error ::failed-to-get-topic-auth {:exception-message (.getMessage e)
+                                                       :context-data path})
+        (let [response {:status 500
+                        :body {:success? false
+                               :reason :failed-to-get-topic-auth}}]
+          (if (instance? SQLException e)
+            response
+            (assoc-in response [:body :error-details :error] (.getMessage e))))))))
 
-(defmethod ig/init-key ::post-topic-auth [_ {:keys [conn]}]
+(defmethod ig/init-key :gpml.handler.auth/post-topic-auth
+  [_ {:keys [db logger]}]
   (fn [{{:keys [path body]} :parameters user :user}]
-    (let [authorized? user
-          path        (update path :topic-type util/get-internal-topic-type)]
-      (if authorized?
-        (do
-          (jdbc/with-db-transaction [tx-conn conn]
-            (db.ts-auth/delete-auth-by-topic tx-conn path)
-            (doseq [s (:stakeholders body)]
-              (grant-topic-to-stakeholder! tx-conn
-                                           (assoc path
-                                                  :stakeholder-id (:id s)
-                                                  :roles (:roles s)))))
-          (resp/response (merge path body)))
-        util/unauthorized))))
+    (try
+      (let [conn (:spec db)
+            authorized? user
+            path        (update path :topic-type util/get-internal-topic-type)]
+        (if authorized?
+          (do
+            (jdbc/with-db-transaction [tx-conn conn]
+              (db.ts-auth/delete-auth-by-topic tx-conn path)
+              (doseq [s (:stakeholders body)]
+                (grant-topic-to-stakeholder! tx-conn
+                                             (assoc path
+                                                    :stakeholder-id (:id s)
+                                                    :roles (:roles s)))))
+            (resp/response (assoc (merge path body) :success? true)))
+          util/unauthorized))
+      (catch Exception e
+        (log logger :error ::failed-to-grant-topic-to-stakeholder {:exception-message (.getMessage e)
+                                                                   :context-data path})
+        (let [response {:status 500
+                        :body {:success? false
+                               :reason :failed-to-grant-topic-to-stakeholder}}]
+          (if (instance? SQLException e)
+            response
+            (assoc-in response [:body :error-details :error] (.getMessage e))))))))
 
-(defmethod ig/init-key ::get-topic-stakeholder-auth [_ {:keys [conn]}]
+(defmethod ig/init-key :gpml.handler.auth/get-topic-stakeholder-auth
+  [_ {:keys [db logger]}]
   (fn [{{:keys [path]} :parameters user :user}]
-    (let [authorized? user
-          path (update path :topic-type util/get-internal-topic-type)]
-      (if authorized?
-        (if-let [data (db.ts-auth/get-auth-by-topic-and-stakeholder conn path)]
-          (resp/response (merge path data))
-          util/not-found)
-        util/unauthorized))))
+    (try
+      (let [conn (:spec db)
+            authorized? user
+            path (update path :topic-type util/get-internal-topic-type)]
+        (if authorized?
+          (if-let [data (db.ts-auth/get-auth-by-topic-and-stakeholder conn path)]
+            (resp/response (assoc (merge path data) :success? true))
+            util/not-found)
+          util/unauthorized))
+      (catch Exception e
+        (log logger :error ::failed-to-get-stakeholder-auth {:exception-message (.getMessage e)
+                                                             :context-data path})
+        (let [response {:status 500
+                        :body {:success? false
+                               :reason :failed-to-get-topic-stakeholder-auth}}]
+          (if (instance? SQLException e)
+            response
+            (assoc-in response [:body :error-details :error] (.getMessage e))))))))
 
-(defmethod ig/init-key ::new-roles [_ {:keys [conn]}]
+(defmethod ig/init-key :gpml.handler.auth/new-roles [_ {:keys [db logger]}]
   (fn [{{:keys [path body]} :parameters user :user}]
-    (let [authorized? user
-          path (update path :topic-type util/get-internal-topic-type)]
-      (if authorized?
-        (do
-          (db.ts-auth/new-auth conn (merge path body))
-          (resp/response (merge path body)))
-        util/unauthorized))))
+    (try
+      (let [conn (:spec db)
+            authorized? user
+            path (update path :topic-type util/get-internal-topic-type)]
+        (if authorized?
+          (do
+            (db.ts-auth/new-auth conn (merge path body))
+            (resp/response (assoc (merge path body) :success? true)))
+          util/unauthorized))
+      (catch Exception e
+        (log logger :error ::failed-to-add-new-roles-to-stakeholder {:exception-message (.getMessage e)
+                                                                     :context-data {:path path
+                                                                                    :body body}})
+        (let [response {:status 500
+                        :body {:success? false
+                               :reason :failed-to-add-new-roles-to-stakeholder}}]
+          (if (instance? SQLException e)
+            response
+            (assoc-in response [:body :error-details :error] (.getMessage e))))))))
 
-(defmethod ig/init-key ::update-roles [_ {:keys [conn]}]
+(defmethod ig/init-key :gpml.handler.auth/update-roles
+  [_ {:keys [db logger]}]
   (fn [{{:keys [path body]} :parameters user :user}]
-    (let [authorized? user
-          path (update path :topic-type util/get-internal-topic-type)]
-      (if authorized?
-        (do
-          (db.ts-auth/update-auth conn (merge path body))
-          (resp/response (merge path body)))
-        util/unauthorized))))
+    (try
+      (let [conn (:spec db)
+            authorized? user
+            path (update path :topic-type util/get-internal-topic-type)]
+        (if authorized?
+          (do
+            (db.ts-auth/update-auth conn (merge path body))
+            (resp/response (assoc (merge path body) :success? true)))
+          util/unauthorized))
+      (catch Exception e
+        (log logger :error ::failed-to-update-roles {:exception-message (.getMessage e)
+                                                     :context-data {:path path
+                                                                    :body body}})
+        (let [response {:status 500
+                        :body {:success? false
+                               :reason :failed-to-update-roles}}]
+          (if (instance? SQLException e)
+            response
+            (assoc-in response [:body :error-details :error] (.getMessage e))))))))
 
-(defmethod ig/init-key ::delete [_ {:keys [conn]}]
+(defmethod ig/init-key :gpml.handler.auth/delete
+  [_ {:keys [db logger]}]
   (fn [{{:keys [path body]} :parameters user :user}]
-    (let [authorized? user
-          path (update path :topic-type util/get-internal-topic-type)]
-      (if authorized?
-        (do
-          (db.ts-auth/delete-auth conn path)
-          (resp/response (merge path body)))
-        util/unauthorized))))
+    (try
+      (let [conn (:spec db)
+            authorized? user
+            path (update path :topic-type util/get-internal-topic-type)]
+        (if authorized?
+          (do
+            (db.ts-auth/delete-auth conn path)
+            (resp/response (assoc (merge path body) :success? true)))
+          util/unauthorized))
+      (catch Exception e
+        (log logger :error ::failed-to-delete-topic-stakeholder-auth {:exception-message (.getMessage e)
+                                                                      :context-data {:path path
+                                                                                     :body body}})
+        (let [response {:status 500
+                        :body {:success? false
+                               :reason :failed-to-delete-topic-stakeholder-auth}}]
+          (if (instance? SQLException e)
+            response
+            (assoc-in response [:body :error-details :error] (.getMessage e))))))))
+
+(defmethod ig/init-key :gpml.handler.auth/get-topic-auth-params [_ _]
+  {:path (mu/dissoc shared-path-params :stakeholder)})
+
+(defmethod ig/init-key :gpml.handler.auth/post-topic-auth-params [_ _]
+  {:path (mu/dissoc shared-path-params :stakeholder)
+   :body [:map
+          [:stakeholders
+           [:vector (-> dom.stakeholder/Stakeholder
+                        (mu/select-keys [:id])
+                        (mu/assoc :roles (mu/get dom.ts-auth/TopicStakeholderAuth :roles)))]]]})
+
+(defmethod ig/init-key :gpml.handler.auth/delete-params [_ _]
+  {:path shared-path-params})
+
+(defmethod ig/init-key :gpml.handler.auth/new-roles-params [_ _]
+  {:path shared-path-params
+   :body (mu/select-keys dom.ts-auth/TopicStakeholderAuth [:roles])})
+
+(defmethod ig/init-key :gpml.handler.auth/get-topic-stakeholder-auth-params [_ _]
+  {:path shared-path-params})
+
+(defmethod ig/init-key :gpml.handler.auth/update-roles-params [_ _]
+  {:path shared-path-params
+   :body (mu/select-keys dom.ts-auth/TopicStakeholderAuth [:roles])})

--- a/backend/src/gpml/handler/auth.clj
+++ b/backend/src/gpml/handler/auth.clj
@@ -30,7 +30,7 @@
 (defn- max-focal-points?
   "Checks whether a resource has reached the maximum amount of focal
   points roles assignment."
-  [{:keys [db]} {:keys [topic-type topic-id] :as params}]
+  [{:keys [db]} {:keys [topic-type topic-id]}]
   (let [stakeholder-auths
         (db.ts-auth/get-topic-stakeholder-auths db
                                                 {:filters {:roles ["focal-point"]

--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -383,7 +383,7 @@
   (let [{:keys [topic-type topic-id] :as params} (update path :topic-type util/get-internal-topic-type)
         submission (->> {:table-name topic-type :id topic-id}
                         (db.submission/detail conn))]
-    ;; The following checks is mostly to avoid doing a lot of work
+    ;; The following checks are mostly to avoid doing a lot of work
     ;; when checking the user permissions on a specific resource.
     (cond
       ;; If the user is empty it means the caller doesn't have a

--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -14,11 +14,12 @@
             [gpml.db.organisation :as db.organisation]
             [gpml.db.policy :as db.policy]
             [gpml.db.project :as db.project]
+            [gpml.db.resource.association :as db.resource.association]
             [gpml.db.resource.connection :as db.resource.connection]
             [gpml.db.resource.tag :as db.resource.tag]
             [gpml.db.review :as db.review]
             [gpml.db.submission :as db.submission]
-            [gpml.db.topic-stakeholder-auth :as db.topic-stakeholder-auth]
+            [gpml.db.topic-stakeholder-auth :as db.ts-auth]
             [gpml.handler.geo :as handler.geo]
             [gpml.handler.image :as handler.image]
             [gpml.handler.initiative :as handler.initiative]
@@ -377,22 +378,66 @@
 (defmethod extra-details :nothing [_ _ _]
   nil)
 
-(defn- get-resource-if-allowed [conn path user]
-  (let [topic (:topic-type path)
-        submission (->> {:table-name (util/get-internal-topic-type topic) :id (:topic-id path)}
-                        (db.submission/detail conn))
-        review (first (db.review/reviews-filter conn (update path :topic-type resolve-resource-type)))
-        user-auth-roles (:roles (db.topic-stakeholder-auth/get-auth-by-topic-and-stakeholder conn {:topic-id (:topic-id path)
-                                                                                                   :topic-type (util/get-internal-topic-type topic)
-                                                                                                   :stakeholder (:id user)}))
-        access-allowed? (or (= (:review_status submission) "APPROVED")
-                            (and (= (:role user) "REVIEWER") (= (:id user) (:reviewer review)))
-                            (contains? (set user-auth-roles) "owner")
-                            (= (:role user) "ADMIN")
-                            (and (not (nil? (:id user)))
-                                 (= (:created_by submission) (:id user))))]
-    (when access-allowed?
-      submission)))
+(defn- get-resource-if-allowed
+  [conn path user read?]
+  (let [{:keys [topic-type topic-id] :as params} (update path :topic-type util/get-internal-topic-type)
+        submission (->> {:table-name topic-type :id topic-id}
+                        (db.submission/detail conn))]
+    ;; The following checks is mostly to avoid doing a lot of work
+    ;; when checking the user permissions on a specific resource.
+    (cond
+      ;; If the user is empty it means the caller doesn't have a
+      ;; session and is just making a read call on the resource. So no
+      ;; need to check extra permissions since platform resources are
+      ;; public in a read-only state.
+      (and (not (seq user))
+           (= (:review_status submission) "APPROVED"))
+      submission
+
+      ;; If it's a read attempt, the resource is approved and the user
+      ;; is logged in then we should allow without checking extra
+      ;; permissions.
+      (and read?
+           (= (:review_status submission) "APPROVED"))
+      submission
+
+      ;; If it's not a read operation the respective PUT, POST and
+      ;; DELETE endpoints should check if the user is approved in the
+      ;; platform to do the desired action for the specific resource.
+      :else
+      (let [review (first (db.review/reviews-filter conn params))
+            resource-org-associations
+            (when-not (get #{"organisation" "stakeholder"} topic-type)
+              (db.resource.association/get-resource-associations conn {:table (str "organisation_" topic-type)
+                                                                       :entity-col "organisation"
+                                                                       :resource-col topic-type
+                                                                       :resource-assoc-type (str topic-type "_association")
+                                                                       :filters {:resource-id topic-id
+                                                                                 :associations ["owner"]}}))
+            user-org-auth-roles
+            (when (and (:id user)
+                       (not (get #{"organisation" "stakeholder"} topic-type)))
+              (->> (db.ts-auth/get-topic-stakeholder-auths conn {:filters {:topics-ids (map :organisation resource-org-associations)
+                                                                           :topic-types ["organisation"]
+                                                                           :stakeholders-ids [(:id user)]}})
+                   (map :roles)
+                   (set)))
+
+            user-auth-roles
+            (->> (db.ts-auth/get-topic-stakeholder-auths conn {:filters {:topics-ids [topic-id]
+                                                                         :topic-types [topic-type]
+                                                                         :stakeholders-ids [(:id user)]}})
+                 (map :roles)
+                 (set))
+            access-allowed?
+            (or (and (= (:role user) "REVIEWER") (= (:id user) (:reviewer review)))
+                (contains? user-auth-roles "owner")
+                (and (not (nil? (:id user)))
+                     (= (:created_by submission) (:id user)))
+                (some #(get user-org-auth-roles %) ["owner" "focal-point"])
+                (= (:role user) "ADMIN"))]
+        (when access-allowed?
+          submission)))))
 
 (def not-nil-name #(vec (filter :name %)))
 
@@ -436,7 +481,7 @@
       (let [conn        (:spec db)
             topic       (resolve-resource-type (:topic-type path))
             authorized? (and (or (model.topic/public? topic) approved?)
-                             (some? (get-resource-if-allowed conn path user)))
+                             (some? (get-resource-if-allowed conn path user false)))
             sqls (condp = topic
                    "policy" (common-queries topic path true false true true)
                    "event" (common-queries topic path true true true true)
@@ -488,7 +533,7 @@
             topic (:topic-type path)
             id (:topic-id path)
             authorized? (and (or (model.topic/public? topic) approved?)
-                             (some? (get-resource-if-allowed conn path user)))]
+                             (some? (get-resource-if-allowed conn path user true)))]
         (if authorized?
           (if-let [data (get-detail conn topic id query)]
             (resp/response (merge
@@ -719,7 +764,7 @@
   (fn [{{{:keys [topic-type topic-id] :as path} :path body :body} :parameters
         user :user}]
     (try
-      (let [submission (get-resource-if-allowed (:spec db) path user)
+      (let [submission (get-resource-if-allowed (:spec db) path user false)
             review_status (:review_status submission)]
         (if (some? submission)
           (let [conn (:spec db)

--- a/backend/src/gpml/util/regular_expressions.clj
+++ b/backend/src/gpml/util/regular_expressions.clj
@@ -4,6 +4,7 @@
 (def ^:const uuid-regex #"^[0-9a-zA-Z]{8}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{12}$")
 (def ^:const date-iso-8601-re #"^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$")
 (def ^:const comma-separated-numbers-re #"^\d+(,\d+)*$")
+(def ^:const number-re #"[0-9]+$")
 
 (defn comma-separated-enums-re
   [enum-coll]

--- a/backend/test/gpml/handler/auth_test.clj
+++ b/backend/test/gpml/handler/auth_test.clj
@@ -1,0 +1,150 @@
+(ns gpml.handler.auth-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [gpml.db.stakeholder :as db.stakeholder]
+            [gpml.db.topic-stakeholder-auth :as db.ts-auth]
+            [gpml.fixtures :as fixtures]
+            [gpml.handler.auth :as auth]
+            [gpml.seeder.main :as seeder]
+            [integrant.core :as ig]
+            [ring.mock.request :as mock]))
+
+(use-fixtures :each fixtures/with-test-system)
+
+(defn- make-profile [first-name last-name email]
+  {:picture nil
+   :cv nil
+   :title "mr."
+   :first_name first-name
+   :last_name last-name
+   :affiliation nil
+   :email email
+   :linked_in nil
+   :twitter nil
+   :url nil
+   :country nil
+   :representation "test"
+   :about "Lorem Ipsum"
+   :geo_coverage_type "global"
+   :role "USER"
+   :idp_usernames ["auth0|123"]})
+
+(deftest post-topic-auth-handler-test
+  (let [system (ig/init fixtures/*system* [::auth/post-topic-auth])
+        handler (::auth/post-topic-auth system)
+        db (-> system :duct.database.sql/hikaricp :spec)
+        profile (make-profile "John" "Doe" "mail@org.com")
+        sth-id (:id (db.stakeholder/new-stakeholder db profile))]
+    (seeder/seed db {:organisation? true :resource? true})
+    (testing "Allow adding a focal point to an organisation"
+      (let [request (-> (mock/request :post "/")
+                        (assoc :parameters {:path {:topic-type "organisation" :topic-id 1}
+                                            :body {:stakeholders [{:id sth-id
+                                                                   :roles ["focal-point"]}]}}
+                               :user (select-keys profile [:email])))
+            {:keys [status body]} (handler request)]
+        (is (= 200 status))
+        (is (:success? body))))
+    (testing "More than two focal points in the same organisation should fail"
+      (let [profile-1 (make-profile "John1" "Doe1" "mail1@org.com")
+            sth-id-1 (:id (db.stakeholder/new-stakeholder db profile-1))
+            profile-2 (make-profile "John2" "Doe2" "mail2@org.com")
+            sth-id-2 (:id (db.stakeholder/new-stakeholder db profile-2))
+            profile-3 (make-profile "John3" "Doe3" "mail3@org.com")
+            sth-id-3 (:id (db.stakeholder/new-stakeholder db profile-3))
+            request (-> (mock/request :post "/")
+                        (assoc :parameters {:path {:topic-type "organisation" :topic-id 1}
+                                            :body {:stakeholders [{:id sth-id-1
+                                                                   :roles ["focal-point"]}
+                                                                  {:id sth-id-2
+                                                                   :roles ["focal-point"]}
+                                                                  {:id sth-id-3
+                                                                   :roles ["focal-point"]}]}}
+                               :user (select-keys profile [:email])))
+            {:keys [status body]} (handler request)]
+        (is (= 400 status))
+        (is (not (:success? body)))
+        (is (= :maximum-focal-points-reached (:reason body)))))))
+
+(deftest put-update-roles-handler-test
+  (let [system (ig/init fixtures/*system* [::auth/update-roles])
+        handler (::auth/update-roles system)
+        db (-> system :duct.database.sql/hikaricp :spec)
+        profile (make-profile "John" "Doe" "mail@org.com")
+        sth-id (:id (db.stakeholder/new-stakeholder db profile))
+        _ (seeder/seed db {:organisation? true :resource? true})]
+    (testing "Updating auth roles should work"
+      (let [_ (db.ts-auth/new-auth db {:topic-id 1
+                                       :topic-type "resource"
+                                       :stakeholder sth-id
+                                       :roles ["focal-point"]})
+            request (-> (mock/request :put "/")
+                        (assoc :parameters {:path {:topic-type "resource" :topic-id 1 :stakeholder sth-id}
+                                            :body {:roles ["owner"]}}
+                               :user (select-keys profile [:email])))
+            {:keys [status body]} (handler request)]
+        (is (= 200 status))
+        (is (:success? body))))
+    (testing "Updating should fail if topic is organisation and focal points is at maximum"
+      (let [profile-1 (make-profile "John1" "Doe1" "mail1@org.com")
+            sth-id-1 (:id (db.stakeholder/new-stakeholder db profile-1))
+            _ (db.ts-auth/new-auth db {:topic-id 1
+                                       :topic-type "organisation"
+                                       :stakeholder sth-id-1
+                                       :roles ["focal-point"]})
+            profile-2 (make-profile "John2" "Doe2" "mail2@org.com")
+            sth-id-2 (:id (db.stakeholder/new-stakeholder db profile-2))
+            _ (db.ts-auth/new-auth db {:topic-id 1
+                                       :topic-type "organisation"
+                                       :stakeholder sth-id-2
+                                       :roles ["focal-point"]})
+            profile-3 (make-profile "John3" "Doe3" "mail3@org.com")
+            sth-id-3 (:id (db.stakeholder/new-stakeholder db profile-3))
+            _ (db.ts-auth/new-auth db {:topic-id 1
+                                       :topic-type "organisation"
+                                       :stakeholder sth-id-3
+                                       :roles ["owner"]})
+            request (-> (mock/request :put "/")
+                        (assoc :parameters {:path {:topic-type "organisation" :topic-id 1 :stakeholder sth-id-3}
+                                            :body {:roles ["focal-point"]}}
+                               :user (select-keys profile-3 [:email])))
+            {:keys [status body]} (handler request)]
+        (is (= 400 status))
+        (is (not (:success? body)))
+        (is (= :maximum-focal-points-reached (:reason body)))))))
+
+(deftest post-new-roles-handler-test
+  (let [system (ig/init fixtures/*system* [::auth/new-roles])
+        handler (::auth/new-roles system)
+        db (-> system :duct.database.sql/hikaricp :spec)
+        profile (make-profile "John" "Doe" "mail@org.com")
+        sth-id (:id (db.stakeholder/new-stakeholder db profile))
+        _ (seeder/seed db {:organisation? true :resource? true})]
+    (testing "Adding new roles to a stakeholder should work"
+      (let [request (-> (mock/request :post "/")
+                        (assoc :parameters {:path {:topic-type "resource" :topic-id 1 :stakeholder sth-id}
+                                            :body {:roles ["owner"]}}
+                               :user (select-keys profile [:email])))
+            {:keys [status body]} (handler request)]
+        (is (= 200 status))
+        (is (:success? body))))
+    (testing "Adding new focal-point role to a stakeholdr should failed if organisation has reached maximum number of focal points"
+      (let [profile-1 (make-profile "John1" "Doe1" "mail1@org.com")
+            sth-id-1 (:id (db.stakeholder/new-stakeholder db profile-1))
+            _ (db.ts-auth/new-auth db {:topic-id 1
+                                       :topic-type "organisation"
+                                       :stakeholder sth-id-1
+                                       :roles ["focal-point"]})
+            profile-2 (make-profile "John2" "Doe2" "mail2@org.com")
+            sth-id-2 (:id (db.stakeholder/new-stakeholder db profile-2))
+            _ (db.ts-auth/new-auth db {:topic-id 1
+                                       :topic-type "organisation"
+                                       :stakeholder sth-id-2
+                                       :roles ["focal-point"]})
+            request (-> (mock/request :post "/")
+                        (assoc :parameters {:path {:topic-type "organisation" :topic-id 1 :stakeholder sth-id}
+                                            :body {:roles ["focal-point"]}}
+                               :user (select-keys profile [:email])))
+            {:keys [status body]} (handler request)]
+        (is (= 400 status))
+        (is (not (:success? body)))
+        (is (= :maximum-focal-points-reached (:reason body)))))))


### PR DESCRIPTION
* Refactored gpml.auth namespace to better handle errors (exceptions).
* Added the data model in domain for topic_stakeholder_auth.
* Added the new focal-point role logic to edit organisations auth
middleware. So we also check for that now.
* Handle maximum number of focal points per organisation.
* Added logic to check for organisation's resources that the focal points can edit.
* Closes #1368 