### PR TITLE
Fix get-submission-detail using wrong internal resource type name

### DIFF
--- a/backend/src/gpml/handler/submission.clj
+++ b/backend/src/gpml/handler/submission.clj
@@ -8,6 +8,7 @@
             [gpml.db.stakeholder :as db.stakeholder]
             [gpml.db.submission :as db.submission]
             [gpml.handler.stakeholder.tag :as handler.stakeholder.tag]
+            [gpml.handler.util :as handler.util]
             [gpml.util.auth0 :as auth0]
             [gpml.util.email :as email]
             [gpml.util.postgresql :as pg-util]
@@ -125,13 +126,7 @@
   (let [conn (:spec db)
         submission (:submission params)
         initiative? (and (= submission "project") (> (:id params) 10000))
-        table-name (cond
-                     (contains? constants/resource-types submission)
-                     "resource"
-                     initiative?
-                     "initiative"
-                     :else
-                     submission)
+        table-name (handler.util/get-internal-topic-type submission)
         params (conj params {:table-name table-name})
         detail (submission-detail conn params)
         detail (if (= submission "stakeholder")
@@ -149,7 +144,7 @@
         (get-detail config path)
         (let [topic-type (:submission path)
               topic-id (:id path)
-              review (first (db.review/reviews-filter (:spec db) {:topic-type topic-type
+              review (first (db.review/reviews-filter (:spec db) {:topic-type (handler.util/get-internal-topic-type topic-type)
                                                                   :topic-id topic-id}))]
           (if (= (:id user) (:reviewer review))
             (get-detail config path)


### PR DESCRIPTION
* We should refactor the code base to remove this `project` ->
`initiative` conversions.