### PR TITLE
Fix submission creator email

### DIFF
--- a/backend/src/gpml/handler/submission.clj
+++ b/backend/src/gpml/handler/submission.clj
@@ -57,7 +57,7 @@
 
 (defn- submission-detail [conn params]
   (let [data (db.submission/detail conn params)
-        creator-id (:id data)
+        creator-id (:created_by data)
         creator (db.stakeholder/stakeholder-by-id conn {:id creator-id})]
     (assoc data
            :created_by_email (:email creator)


### PR DESCRIPTION
* We should use the :created_by key and not the id. This bug was
introduced during a refactor to remove the `v_stakeholder_data` view
where the `id` was the actual stakeholder `id` but that is not the
case anymore.