### PR TITLE
Revert "Allow `featured` prop in PUT Submission API" #1404

### DIFF
--- a/backend/src/gpml/db/submission.sql
+++ b/backend/src/gpml/db/submission.sql
@@ -108,5 +108,4 @@ update :i:table-name
 set reviewed_at = now(),
     review_status = :v:review_status::review_status
 --~ (when (contains? params :reviewed_by) ",reviewed_by = :reviewed_by::integer")
---~ (when (contains? params :featured) ",featured = :featured")
 where id = :id;

--- a/backend/src/gpml/handler/submission.clj
+++ b/backend/src/gpml/handler/submission.clj
@@ -180,6 +180,5 @@
 (defmethod ig/init-key :gpml.handler.submission/put-params [_ _]
   [:map
    [:id int?]
-   [:featured {:optional true} boolean?]
    [:item_type [:enum "stakeholder", "event", "policy", "technology", "resource", "organisation", "initiative" "tag"]]
    [:review_status [:enum "APPROVED", "REJECTED"]]])


### PR DESCRIPTION
This reverts commit 1e8c2e1958a2e7dc65dad976401af7e046013df3.

This revert is needed as the endpoint to allow setting this flag should be different (already moved to `/api/detail/{topic-type}/{topic-id}` PUT endpoint).