### PR TITLE
Enforce `tag_relation_category` in DB model #1409

### DIFF
--- a/backend/resources/migrations/164-remove-invalid-stakeholder-tags-enforcing-tag-relation-category.up.sql
+++ b/backend/resources/migrations/164-remove-invalid-stakeholder-tags-enforcing-tag-relation-category.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+--;;
+DELETE FROM stakeholder_tag WHERE tag_relation_category IS NULL;
+--;;
+ALTER TABLE IF EXISTS stakeholder_tag
+  ALTER COLUMN tag_relation_category SET NOT NULL;
+--;;
+COMMIT;


### PR DESCRIPTION
[Closes #1409]

On one hand we have removed corrupted stakeholder tags that were missing
`tag_relation_category` property, as specified in the issue.

Then, in order to avoid this issue to happen again, we have enforced the
missing property in the corrupt data, to fullfil backend expectations.