### PR TITLE
Fix duplicated tags and ensure new tags are stored respecting the case #1416

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -595,7 +595,8 @@
   :gpml.handler.stakeholder/get {:db #ig/ref :duct.database/sql}
   :gpml.handler.stakeholder/get-by-id {:db #ig/ref :duct.database/sql}
   :gpml.handler.stakeholder/post {:db #ig/ref :gpml.db/spec
-                                  :mailjet-config #ig/ref :gpml.config/mailjet}
+                                  :mailjet-config #ig/ref :gpml.config/mailjet
+                                  :logger #ig/ref :duct/logger}
   :gpml.handler.stakeholder/post-params {}
   :gpml.handler.stakeholder/put #ig/ref :gpml.config/common
   :gpml.handler.stakeholder/put-by-admin #ig/ref :gpml.config/common

--- a/backend/resources/migrations/165-fix-duplicated-tags.up.sql
+++ b/backend/resources/migrations/165-fix-duplicated-tags.up.sql
@@ -1,0 +1,243 @@
+BEGIN;
+--;;
+--;; 1. Remove rejected tags as they are not needed and simplify this process.
+DELETE FROM tag WHERE review_status = 'REJECTED';
+--;;
+--;; 2. Change duplicate tags refs that don't have any approved tag as reference to get rid of that case
+--;; (it could happen from Leap API or because a user has typed his own tag duplicating it, but it has not been
+--;; approved yet).
+--;;
+--;; Delete the view in case it existed already (should not happen but as a safety system).
+DROP VIEW IF EXISTS duplicated_tags_for_review;
+--;; Find duplicate tags given all of them need to be under SUBMITTED status (REJECTED ones have been deleted previously)
+CREATE VIEW duplicated_tags_for_review AS (
+  SELECT MIN(id) AS original_id,
+         ARRAY_REMOVE(ARRAY_AGG(id), MIN(id)) AS duplicate_ids
+    FROM tag
+    GROUP BY LOWER(tag)
+    HAVING COUNT(LOWER(tag)) > 1
+           AND
+           NOT ('APPROVED' = ANY(ARRAY_AGG(review_status)))
+);
+--;; Find duplicate tags given some of them need could be under SUBMITTED status but at least there is one tag there as
+--;; APPROVED, which will be used as reference to update duplicates.
+DROP VIEW IF EXISTS duplicated_tags;
+CREATE VIEW duplicated_tags AS (
+  SELECT MIN(id) FILTER (WHERE review_status = 'APPROVED') AS original_id,
+         ARRAY_REMOVE(ARRAY_AGG(id), MIN(id) FILTER (WHERE review_status = 'APPROVED')) AS duplicate_ids
+    FROM tag
+    GROUP BY LOWER(tag)
+    HAVING COUNT(LOWER(tag)) > 1
+           AND
+           'APPROVED' = ANY(ARRAY_AGG(review_status))
+);
+--;; This part is related to updating tag relationships that had duplicate tag references that are none approved.
+--;; The idea here is to move the references to use the tag with lowest id as the referenced tag id for all the tables
+--;; with relationships between tags and entities.
+UPDATE stakeholder_tag
+  SET tag = dtags.original_id
+  FROM duplicated_tags_for_review dtags
+  WHERE stakeholder_tag.tag = ANY(dtags.duplicate_ids);
+--;;
+UPDATE organisation_tag
+  SET tag = dtags.original_id
+  FROM duplicated_tags_for_review dtags
+  WHERE organisation_tag.tag = ANY(dtags.duplicate_ids);
+--;;
+UPDATE event_tag
+  SET tag = dtags.original_id
+  FROM duplicated_tags_for_review dtags
+  WHERE event_tag.tag = ANY(dtags.duplicate_ids);
+--;;
+UPDATE initiative_tag
+  SET tag = dtags.original_id
+  FROM duplicated_tags_for_review dtags
+  WHERE initiative_tag.tag = ANY(dtags.duplicate_ids);
+--;;
+UPDATE policy_tag
+  SET tag = dtags.original_id
+  FROM duplicated_tags_for_review dtags
+  WHERE policy_tag.tag = ANY(dtags.duplicate_ids);
+--;;
+UPDATE resource_tag
+  SET tag = dtags.original_id
+  FROM duplicated_tags_for_review dtags
+  WHERE resource_tag.tag = ANY(dtags.duplicate_ids);
+--;;
+UPDATE technology_tag
+  SET tag = dtags.original_id
+  FROM duplicated_tags_for_review dtags
+  WHERE technology_tag.tag = ANY(dtags.duplicate_ids);
+--;;
+--;; 3. Get rid of duplicates moving references to the min id one that is APPROVED (for the cases where at least
+--;; there is one APPROVED tag duplicated used as reference.
+UPDATE stakeholder_tag
+  SET tag = dtags.original_id
+  FROM duplicated_tags dtags
+  WHERE stakeholder_tag.tag = ANY(dtags.duplicate_ids);
+--;;
+UPDATE organisation_tag
+  SET tag = dtags.original_id
+  FROM duplicated_tags dtags
+  WHERE organisation_tag.tag = ANY(dtags.duplicate_ids);
+--;;
+UPDATE event_tag
+  SET tag = dtags.original_id
+  FROM duplicated_tags dtags
+  WHERE event_tag.tag = ANY(dtags.duplicate_ids);
+--;;
+UPDATE initiative_tag
+  SET tag = dtags.original_id
+  FROM duplicated_tags dtags
+  WHERE initiative_tag.tag = ANY(dtags.duplicate_ids);
+--;;
+UPDATE policy_tag
+  SET tag = dtags.original_id
+  FROM duplicated_tags dtags
+  WHERE policy_tag.tag = ANY(dtags.duplicate_ids);
+--;;
+UPDATE resource_tag
+  SET tag = dtags.original_id
+  FROM duplicated_tags dtags
+  WHERE resource_tag.tag = ANY(dtags.duplicate_ids);
+--;;
+UPDATE technology_tag
+  SET tag = dtags.original_id
+  FROM duplicated_tags dtags
+  WHERE technology_tag.tag = ANY(dtags.duplicate_ids);
+--;;
+--;; 4. Remove duplicate records in stakeholder tag and the rest. This can be due to duplicate tags or not.
+--;; Remove duplicate stakeholder_tag rows
+--;;
+WITH duplicated_stakeholder_tags_cte AS (
+  SELECT ARRAY_REMOVE(ARRAY_AGG(id), MIN(id)) AS duplicate_ids
+    FROM stakeholder_tag
+    GROUP BY (stakeholder, tag, LOWER(tag_relation_category))
+    HAVING COUNT(tag) > 1
+)
+DELETE FROM stakeholder_tag st
+  USING duplicated_stakeholder_tags_cte dstags
+  WHERE st.id = ANY(dstags.duplicate_ids);
+--;;
+--;; Remove duplicate organisation_tag rows
+--;;
+WITH duplicated_org_tags_cte AS (
+  SELECT ARRAY_REMOVE(ARRAY_AGG(id), MIN(id)) AS duplicate_ids
+    FROM organisation_tag
+    GROUP BY (organisation, tag)
+    HAVING COUNT(tag) > 1
+)
+DELETE FROM organisation_tag ot
+  USING duplicated_org_tags_cte dotags
+  WHERE ot.id = ANY(dotags.duplicate_ids);
+--;;
+--;; Remove duplicate event_tag rows
+--;;
+WITH duplicated_event_tags_cte AS (
+  SELECT ARRAY_REMOVE(ARRAY_AGG(id), MIN(id)) AS duplicate_ids
+    FROM event_tag
+    GROUP BY (event, tag)
+    HAVING COUNT(tag) > 1
+)
+DELETE FROM event_tag et
+  USING duplicated_event_tags_cte detags
+  WHERE et.id = ANY(detags.duplicate_ids);
+--;;
+--;; Remove duplicate initiative_tag rows
+--;;
+WITH duplicated_init_tags_cte AS (
+  SELECT ARRAY_REMOVE(ARRAY_AGG(id), MIN(id)) AS duplicate_ids
+    FROM initiative_tag
+    GROUP BY (initiative, tag)
+    HAVING COUNT(tag) > 1
+)
+DELETE FROM initiative_tag it
+  USING duplicated_init_tags_cte ditags
+  WHERE it.id = ANY(ditags.duplicate_ids);
+--;;
+--;; Remove duplicate policy_tag rows
+--;;
+WITH duplicated_pol_tags_cte AS (
+  SELECT ARRAY_REMOVE(ARRAY_AGG(id), MIN(id)) AS duplicate_ids
+    FROM policy_tag
+    GROUP BY (policy, tag)
+    HAVING COUNT(tag) > 1
+)
+DELETE FROM policy_tag pt
+  USING duplicated_pol_tags_cte dptags
+  WHERE pt.id = ANY(dptags.duplicate_ids);
+--;;
+--;; Remove duplicate resource_tag rows
+--;;
+WITH duplicated_res_tags_cte AS (
+  SELECT ARRAY_REMOVE(ARRAY_AGG(id), MIN(id)) AS duplicate_ids
+    FROM resource_tag
+    GROUP BY (resource, tag)
+    HAVING COUNT(tag) > 1
+)
+DELETE FROM resource_tag rt
+  USING duplicated_res_tags_cte drtags
+  WHERE rt.id = ANY(drtags.duplicate_ids);
+--;;
+--;; Remove duplicate technology_tag rows
+--;;
+WITH duplicated_tech_tags_cte AS (
+  SELECT ARRAY_REMOVE(ARRAY_AGG(id), MIN(id)) AS duplicate_ids
+    FROM technology_tag
+    GROUP BY (technology, tag)
+    HAVING COUNT(tag) > 1
+)
+DELETE FROM technology_tag tt
+  USING duplicated_tech_tags_cte dttags
+  WHERE tt.id = ANY(dttags.duplicate_ids);
+--;;
+--;; 5. Erase duplicated tags.
+--;; Erase duplicated tags (looking for only non-approved tags), keeping the one with lowest id as the original one.
+DELETE FROM tag t
+  USING duplicated_tags_for_review dtags
+  WHERE t.id = ANY(dtags.duplicate_ids);
+--;;
+--;; Erase duplicated tags (looking for one approved tag reference), keeping the approved one with lowest id as the
+--;; original one.
+DELETE FROM tag t
+  USING duplicated_tags dtags
+  WHERE t.id = ANY(dtags.duplicate_ids);
+--;;
+--;; Drop views now that will no longer be used.
+DROP VIEW IF EXISTS duplicated_tags;
+--;;
+DROP VIEW IF EXISTS duplicated_tags_for_review;
+--;;
+--;; 6. Ensure we keep uniqueness in x_tag tables:
+--;; We need to do it in this way to use LOWER function to build the index, as we cannot use an Expression creating
+--;; a constraint.
+CREATE UNIQUE INDEX IF NOT EXISTS stakeholder_tag_tag_rel_cat_unique
+  ON stakeholder_tag (
+    stakeholder,
+    tag,
+    LOWER(tag_relation_category));
+--;;
+ALTER TABLE IF EXISTS organisation_tag
+  ADD CONSTRAINT organisation_tag_unique UNIQUE(organisation, tag);
+--;;
+ALTER TABLE IF EXISTS event_tag
+  ADD CONSTRAINT event_tag_unique UNIQUE(event, tag);
+--;;
+ALTER TABLE IF EXISTS initiative_tag
+  ADD CONSTRAINT initiative_tag_unique UNIQUE(initiative, tag);
+--;;
+ALTER TABLE IF EXISTS policy_tag
+  ADD CONSTRAINT policy_tag_unique UNIQUE(policy, tag);
+--;;
+ALTER TABLE IF EXISTS resource_tag
+  ADD CONSTRAINT resource_tag_unique UNIQUE(resource, tag);
+--;;
+ALTER TABLE IF EXISTS technology_tag
+  ADD CONSTRAINT technology_tag_unique UNIQUE(technology, tag);
+--;;
+--;; 7. Ensure we keep uniqueness in tag table
+--;; We need to do it in this way to use LOWER function to build the index, as we cannot use an
+--;; Expression creating a constraint.
+CREATE UNIQUE INDEX tag_unique ON tag (LOWER(tag));
+--;;
+COMMIT;

--- a/backend/src/gpml/handler/event.clj
+++ b/backend/src/gpml/handler/event.clj
@@ -39,7 +39,7 @@
           :association (:role connection)
           :remarks nil})))
 
-(defn create-event [conn mailjet-config
+(defn create-event [conn logger mailjet-config
                     {:keys [tags urls title start_date end_date
                             description remarks geo_coverage_type
                             country city geo_coverage_value image thumbnail
@@ -76,10 +76,10 @@
                                                              (:stakeholder %))
                                                           api-individual-connections)))))]
     (when (not-empty tags)
-      (handler.resource.tag/create-resource-tags conn mailjet-config {:tags tags
-                                                                      :tag-category "general"
-                                                                      :resource-name "event"
-                                                                      :resource-id event-id}))
+      (handler.resource.tag/create-resource-tags conn logger mailjet-config {:tags tags
+                                                                             :tag-category "general"
+                                                                             :resource-name "event"
+                                                                             :resource-id event-id}))
     (doseq [stakeholder-id owners]
       (h.auth/grant-topic-to-stakeholder! conn {:topic-id event-id
                                                 :topic-type "event"
@@ -172,9 +172,9 @@
   (fn [{:keys [jwt-claims body-params] :as req}]
     (try
       (jdbc/with-db-transaction [conn (:spec db)]
-        (let [result (create-event conn mailjet-config (assoc body-params
-                                                              :created_by
-                                                              (-> (db.stakeholder/stakeholder-by-email conn jwt-claims) :id)))]
+        (let [result (create-event conn logger mailjet-config (assoc body-params
+                                                                     :created_by
+                                                                     (-> (db.stakeholder/stakeholder-by-email conn jwt-claims) :id)))]
           (resp/created (:referrer req) {:success? true
                                          :message "New event created"
                                          :id (:id result)})))

--- a/backend/src/gpml/handler/policy.clj
+++ b/backend/src/gpml/handler/policy.clj
@@ -40,7 +40,7 @@
           :association (:role connection)
           :remarks nil})))
 
-(defn create-policy [conn mailjet-config
+(defn create-policy [conn logger mailjet-config
                      {:keys [title original_title abstract url
                              data_source type_of_law record_number
                              first_publication_date latest_amendment_date
@@ -90,10 +90,10 @@
     (when (seq related_content)
       (handler.resource.related-content/create-related-contents conn policy-id "policy" related_content))
     (when (not-empty tags)
-      (handler.resource.tag/create-resource-tags conn mailjet-config {:tags tags
-                                                                      :tag-category "general"
-                                                                      :resource-name "policy"
-                                                                      :resource-id policy-id}))
+      (handler.resource.tag/create-resource-tags conn logger mailjet-config {:tags tags
+                                                                             :tag-category "general"
+                                                                             :resource-name "policy"
+                                                                             :resource-id policy-id}))
     (when (not-empty language)
       (let [lang-id (:id (db.language/language-by-iso-code conn (select-keys language [:iso_code])))]
         (if-not (nil? lang-id)
@@ -132,8 +132,8 @@
     (try
       (jdbc/with-db-transaction [conn (:spec db)]
         (let [user (db.stakeholder/stakeholder-by-email conn jwt-claims)
-              policy-id (create-policy conn mailjet-config (assoc body-params
-                                                                  :created_by (:id user)))]
+              policy-id (create-policy conn logger mailjet-config (assoc body-params
+                                                                         :created_by (:id user)))]
           (resp/created (:referrer req) {:success? true
                                          :message "New policy created"
                                          :id policy-id})))

--- a/backend/src/gpml/handler/resource.clj
+++ b/backend/src/gpml/handler/resource.clj
@@ -41,7 +41,7 @@
           :remarks nil})))
 
 (defn create-resource
-  [conn mailjet-config
+  [conn logger mailjet-config
    {:keys [resource_type title publish_year
            summary value value_currency
            value_remarks valid_from valid_to image
@@ -92,10 +92,10 @@
                                                 :stakeholder-id stakeholder-id
                                                 :roles ["owner"]}))
     (when (not-empty tags)
-      (handler.resource.tag/create-resource-tags conn mailjet-config {:tags tags
-                                                                      :tag-category "general"
-                                                                      :resource-name "resource"
-                                                                      :resource-id resource-id}))
+      (handler.resource.tag/create-resource-tags conn logger mailjet-config {:tags tags
+                                                                             :tag-category "general"
+                                                                             :resource-name "resource"
+                                                                             :resource-id resource-id}))
     (when (not-empty entity_connections)
       (doseq [association (expand-entity-associations entity_connections resource-id)]
         (db.favorite/new-organisation-association conn association)))
@@ -129,8 +129,8 @@
     (try
       (jdbc/with-db-transaction [conn (:spec db)]
         (let [user (db.stakeholder/stakeholder-by-email conn jwt-claims)
-              resource-id (create-resource conn mailjet-config (assoc body-params
-                                                                      :created_by (:id user)))
+              resource-id (create-resource conn logger mailjet-config (assoc body-params
+                                                                             :created_by (:id user)))
               activity {:id (util/uuid)
                         :type "create_resource"
                         :owner_id (:id user)

--- a/backend/src/gpml/handler/resource/tag.clj
+++ b/backend/src/gpml/handler/resource/tag.clj
@@ -3,9 +3,12 @@
   the functionality every platform resource (Policy, Event,
   Technology, Financing, Technical, Action, Organization and
   Stakeholder) shares in common."
-  (:require [gpml.db.resource.tag :as db.resource.tag]
+  (:require [duct.logger :refer [log]]
+            [gpml.db.resource.tag :as db.resource.tag]
             [gpml.handler.tag :as handler.tag]
-            [gpml.util.email :as email]))
+            [gpml.util.email :as email]
+            [gpml.util.postgresql :as pg-util])
+  (:import [java.sql SQLException]))
 
 (defn send-new-tags-admins-pending-approval-notification
   "Send notifications about new created tags that needs approval.
@@ -25,29 +28,51 @@
     (map #(vector resource-id % tag-category) tags-ids)
     (map (partial vector resource-id) tags-ids)))
 
+;; TODO: We are throwing again the captured exception so it is catched by above handlers, but we should return result
+;; and handle it in another way. Done this to log this specific error but keep current functionality without too much
+;; refactor, for now.
+;; We are using `handle-errors?` flag to avoid raising the exception for some cases where we actually handle this error.
 (defn create-resource-tags
   "Creates the relation between a resource `resource-name` and tags. If
   some of the tags don't exists they are created."
-  [conn mailjet-config {:keys [tags tag-category resource-name resource-id]}]
+  [conn logger mailjet-config {:keys [tags tag-category resource-name resource-id handle-errors?]}]
   (let [tags-ids (map :id tags)
         table (str resource-name "_tag")]
     (if-not (some nil? tags-ids)
-      (db.resource.tag/create-resource-tags conn
-                                            {:table table
-                                             :resource-col resource-name
-                                             :tags (prep-resource-tags resource-name resource-id tags-ids tag-category)})
-      (let [new-tags-ids (handler.tag/create-tags conn tags tag-category)
-            tags-to-add (concat (remove nil? tags-ids) new-tags-ids)
-            resource-tags-to-add (prep-resource-tags resource-name resource-id tags-to-add tag-category)
-            new-tags (db.resource.tag/create-resource-tags conn {:table table
-                                                                 :resource-col resource-name
-                                                                 :tags resource-tags-to-add})]
-        (send-new-tags-admins-pending-approval-notification conn mailjet-config new-tags)))))
+      (do
+        (db.resource.tag/create-resource-tags conn
+                                              {:table table
+                                               :resource-col resource-name
+                                               :tags (prep-resource-tags resource-name resource-id tags-ids tag-category)})
+        {:success? true})
+      (try
+        (let [new-tags-ids (handler.tag/create-tags conn tags tag-category)
+              tags-to-add (concat (remove nil? tags-ids) new-tags-ids)
+              resource-tags-to-add (prep-resource-tags resource-name resource-id tags-to-add tag-category)
+              new-tags (db.resource.tag/create-resource-tags conn {:table table
+                                                                   :resource-col resource-name
+                                                                   :tags resource-tags-to-add})]
+          (send-new-tags-admins-pending-approval-notification conn mailjet-config new-tags)
+          {:success? true})
+        (catch Exception e
+          (if (instance? SQLException e)
+            (let [reason (pg-util/get-sql-state e)]
+              (log logger :error ::failed-to-create-tag {:exception-message (.getMessage e)})
+              (when-not handle-errors?
+                (throw e))
+              {:success? false
+               :reason (if (= :unique-constraint-violation reason)
+                         :duplicate-tag-attempt
+                         reason)
+               :error-details {:message (.getMessage e)}})
+            {:success? false
+             :reason :could-not-create-new-tags
+             :error-details {:message (.getMessage e)}}))))))
 
 (defn update-resource-tags
   "Updates existing relations between a resource `resource-name` and tags."
-  [conn mailjet-config {:keys [resource-name resource-id] :as opts}]
+  [conn logger mailjet-config {:keys [resource-name resource-id] :as opts}]
   (db.resource.tag/delete-resource-tags conn {:table (str resource-name "_tag")
                                               :resource-col resource-name
                                               :resource-id resource-id})
-  (create-resource-tags conn mailjet-config opts))
+  (create-resource-tags conn logger mailjet-config opts))

--- a/backend/src/gpml/handler/stakeholder/expert.clj
+++ b/backend/src/gpml/handler/stakeholder/expert.clj
@@ -195,10 +195,12 @@
                              (map #(merge % (get-in experts-by-email [(:email %) 0]))))]
         (doseq [{:keys [email expertise]} body
                 :let [stakeholder-id (get-in (group-by :email expert-stakeholders) [email 0 :id])]]
-          (handler.stakeholder.tag/save-stakeholder-tags conn
-                                                         mailjet-config
-                                                         {:tags (handler.stakeholder.tag/api-stakeholder-tags->stakeholder-tags {:expertise expertise})
-                                                          :stakeholder-id stakeholder-id}))
+          (handler.stakeholder.tag/save-stakeholder-tags
+           conn
+           logger
+           mailjet-config
+           {:tags (handler.stakeholder.tag/api-stakeholder-tags->stakeholder-tags {:expertise expertise})
+            :stakeholder-id stakeholder-id}))
         (future (send-invitation-emails config invitations))
         (resp/response {:success? true
                         :invited-experts (map #(update % :id str) invitations)})))

--- a/backend/src/gpml/handler/stakeholder/tag.clj
+++ b/backend/src/gpml/handler/stakeholder/tag.clj
@@ -1,7 +1,6 @@
 (ns gpml.handler.stakeholder.tag
   (:require [clojure.data :as dt]
             [clojure.set :as set]
-            [clojure.string :as str]
             [clojure.walk :as w]
             [gpml.db.resource.tag :as db.resource.tag]
             [gpml.db.tag :as db.tag]
@@ -10,12 +9,10 @@
 (defn- add-tags-ids-for-categories
   [conn tags categories]
   (if-let [filtered-tags (seq (filter #(some #{(:tag_category %)} categories) tags))]
-    (let [result (db.tag/tag-by-tags conn {:tags (map (comp str/lower-case :tag) filtered-tags)})]
+    (let [result (db.tag/tag-by-tags conn {:tags (map :tag filtered-tags)})]
       (map (fn [{tag-name :tag :as tag}]
-             (let [grouped-result-tags (->> result
-                                            (map #(update % :tag str/lower-case))
-                                            (group-by :tag))]
-               (assoc tag :id (get-in grouped-result-tags [(str/lower-case tag-name) 0 :id]))))
+             (let [grouped-result-tags (group-by :tag result)]
+               (assoc tag :id (get-in grouped-result-tags [tag-name 0 :id]))))
            tags))
     tags))
 
@@ -54,9 +51,7 @@
                       (map (comp #(set/rename-keys % {:tag_relation_category :tag_category})
                                  #(select-keys % [:tag :tag_relation_category])))
                       (group-by :tag_category))
-        new-tags (->> new-tags
-                      (map #(update % :tag str/lower-case))
-                      (group-by :tag_category))]
+        new-tags (group-by :tag_category new-tags)]
     (->> (reduce (fn [acc [category tags]]
                    (let [old-tags (map :tag (get acc category))
                          new-tags (map :tag tags)
@@ -73,9 +68,11 @@
 (defn save-stakeholder-tags
   "Saves the stakeholder tags. Tag resolution is done by name to check
   if they exist. Non-existent tags will be created with the provided
-  `tag-category`."
-  [conn mailjet-config
-   {:keys [tags stakeholder-id update?]
+  `tag-category`.
+  It handles errors during resource tag creation, returning the results for each operation if it fails, when creating
+  resource tags."
+  [conn logger mailjet-config
+   {:keys [tags stakeholder-id update? handle-errors?]
     :or {update? false}}]
   (let [db-params {:table "stakeholder_tag"
                    :resource-col "stakeholder"
@@ -87,12 +84,22 @@
             grouped-tags (group-by :tag_category (add-tags-ids-for-categories conn tags categories))]
         (when update?
           (db.resource.tag/delete-resource-tags conn db-params))
-        (doseq [[tag-category tags] grouped-tags
-                :let [opts {:tags tags
-                            :tag-category tag-category
-                            :resource-name "stakeholder"
-                            :resource-id stakeholder-id}]]
-          (handler.resource.tag/create-resource-tags conn mailjet-config opts))))))
+        (let [create-res-tags-results (mapv (fn [[tag-category tags]]
+                                              (let [opts {:tags tags
+                                                          :tag-category tag-category
+                                                          :resource-name "stakeholder"
+                                                          :resource-id stakeholder-id}]
+                                                (handler.resource.tag/create-resource-tags
+                                                 conn
+                                                 logger
+                                                 mailjet-config
+                                                 (assoc opts :handle-errors? handle-errors?))))
+                                            grouped-tags)]
+          (if (every? #(get % :success?) create-res-tags-results)
+            {:success? true}
+            {:success? false
+             :reason (-> create-res-tags-results first :reason)
+             :results create-res-tags-results}))))))
 
 (defn unwrap-tags
   "Unwrap `:tags` key into three different keys `seeking`, `offering`

--- a/backend/src/gpml/handler/tag.clj
+++ b/backend/src/gpml/handler/tag.clj
@@ -101,7 +101,7 @@
   [conn tags tag-category]
   (let [tag-category ((comp :id first) (db.tag/get-tag-categories conn {:filters {:categories [tag-category]}}))
         new-tags (filter (comp not :id) tags)
-        tags-to-create (map #(vector (str/lower-case %) tag-category) (map :tag new-tags))
+        tags-to-create (map #(vector % tag-category) (map :tag new-tags))
         tag-entity-columns ["tag" "tag_category"]]
     (map :id (db.tag/new-tags conn {:tags tags-to-create
                                     :insert-cols tag-entity-columns}))))

--- a/backend/src/gpml/handler/technology.clj
+++ b/backend/src/gpml/handler/technology.clj
@@ -40,7 +40,7 @@
           :association (:role connection)
           :remarks nil})))
 
-(defn create-technology [conn mailjet-config
+(defn create-technology [conn logger mailjet-config
                          {:keys [name organisation_type
                                  development_stage specifications_provided
                                  year_founded email country
@@ -99,10 +99,10 @@
       (doseq [association (expand-individual-associations api-individual-connections technology-id)]
         (db.favorite/new-stakeholder-association conn association)))
     (when (not-empty tags)
-      (handler.resource.tag/create-resource-tags conn mailjet-config {:tags tags
-                                                                      :tag-category "general"
-                                                                      :resource-name "technology"
-                                                                      :resource-id technology-id}))
+      (handler.resource.tag/create-resource-tags conn logger mailjet-config {:tags tags
+                                                                             :tag-category "general"
+                                                                             :resource-name "technology"
+                                                                             :resource-id technology-id}))
     (when (not-empty urls)
       (let [lang-urls (map #(vector technology-id
                                     (->> % :lang
@@ -130,8 +130,8 @@
     (try
       (jdbc/with-db-transaction [conn (:spec db)]
         (let [user (db.stakeholder/stakeholder-by-email conn jwt-claims)
-              technology-id (create-technology conn mailjet-config (assoc body-params
-                                                                          :created_by (:id user)))]
+              technology-id (create-technology conn logger mailjet-config (assoc body-params
+                                                                                 :created_by (:id user)))]
           (resp/created (:referrer req) {:success? true
                                          :message "New technology created"
                                          :id technology-id})))


### PR DESCRIPTION
This PR contains:

- Get rid of duplicated tags, keeping current assignations between different resources, backporting the relationships to the remaining unique tags, once duplicated have been removed.
- Ensure uniqueness in tags creation. In this case, uniqueness is checked by lowercasing the tag name, to avoid duplicated tags with just different case.
- Remove duplicate relationships between tags and resources.
- Ensure uniqueness in relationships between tags and resources, once duplicates are gone.
- Make sure BE respect the tags as they have been received from FE, stopping converting tags to lowercase.