### PR TITLE
Add multi lingual support for resources and fix resource edition/delete permissions #1422 #1428

### DIFF
--- a/backend/dev/resources/files/languages.json
+++ b/backend/dev/resources/files/languages.json
@@ -155,10 +155,6 @@
         "name":"Dutch",
         "nativeName":"Nederlands, Vlaams"
     },
-    "en":{
-        "name":"English",
-        "nativeName":"English"
-    },
     "eo":{
         "name":"Esperanto",
         "nativeName":"Esperanto"

--- a/backend/dev/src/gpml/seeder/dummy.clj
+++ b/backend/dev/src/gpml/seeder/dummy.clj
@@ -113,7 +113,8 @@
                                           :image "https://directory.growasia.org/wp-content/uploads/solution_logos/0.jpg"
                                           :country (get-country-id db "NLD"))
                                    (dissoc :id :languages :url)))
-                             (seeder/get-data "events"))]
+                             (seeder/get-data "events" {:keywords? true
+                                                        :add-default-lang? true}))]
     (if (= 0 (-> (db.event/dummy db) first :count))
       (doseq [data dummies]
         (let [event {:event (:id (db.event/new-event db data))}]
@@ -126,7 +127,8 @@
   (let [admin (get-or-create-profile db my-email my-name "ADMIN" "APPROVED")
         submission (seeder/parse-data
                     (slurp (io/resource "examples/submission-initiative.json"))
-                    {:keywords? true})
+                    {:keywords? true
+                     :add-default-lang? true})
         data (db.initiative/new-initiative
               db (assoc submission
                         :created_by (:id admin)

--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -432,7 +432,16 @@
                                                  :handler #ig/ref :gpml.handler.detail/put}}]]
                                         ["/translations"
                                          ["/{topic-type}/{topic-id}"
-                                          {:put {:middleware [#ig/ref :gpml.auth/auth-middleware
+                                          {:get {:middleware [#ig/ref :gpml.auth/auth-middleware]
+                                                 :summary "Get the translations for a specific resource"
+                                                 :swagger {:tags ["get resource translations"]}
+                                                 :parameters {:path [:map
+                                                                     [:topic-type
+                                                                      #ig/ref :gpml.handler.resource.translation/topics]
+                                                                     [:topic-id int?]]
+                                                              :query #ig/ref :gpml.handler.resource.translation/query-params}
+                                                 :handler #ig/ref :gpml.handler.resource.translation/get}
+                                           :put {:middleware [#ig/ref :gpml.auth/auth-middleware
                                                               #ig/ref :gpml.auth/auth-required
                                                               #ig/ref :gpml.auth/approved-user]
                                                  :summary "Create or edit resource translations"
@@ -698,7 +707,9 @@
   :gpml.handler.detail/put-params {}
 
   :gpml.handler.resource.translation/topics {}
+  :gpml.handler.resource.translation/get #ig/ref :gpml.config/common
   :gpml.handler.resource.translation/put #ig/ref :gpml.config/common
+  :gpml.handler.resource.translation/query-params {}
   :gpml.handler.resource.translation/put-params {}
 
   :gpml.handler.list/get {:db #ig/ref :duct.database/sql}

--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -430,6 +430,21 @@
                                                                      [:topic-id int?]]
                                                               :body #ig/ref :gpml.handler.detail/put-params}
                                                  :handler #ig/ref :gpml.handler.detail/put}}]]
+                                        ["/translations"
+                                         ["/{topic-type}/{topic-id}"
+                                          {:put {:middleware [#ig/ref :gpml.auth/auth-middleware
+                                                              #ig/ref :gpml.auth/auth-required
+                                                              #ig/ref :gpml.auth/approved-user]
+                                                 :summary "Create or edit resource translations"
+                                                 :swagger {:tags ["create resource translations"
+                                                                  "edit resource translations"]
+                                                           :security [{:id_token []}]}
+                                                 :parameters {:path [:map
+                                                                     [:topic-type
+                                                                      #ig/ref :gpml.handler.resource.translation/topics]
+                                                                     [:topic-id int?]]
+                                                              :body #ig/ref :gpml.handler.resource.translation/put-params}
+                                                 :handler #ig/ref :gpml.handler.resource.translation/put}}]]
                                         ["/list"
                                          {:get {:middleware [#ig/ref :gpml.auth/auth-middleware
                                                              #ig/ref :gpml.auth/auth-required]
@@ -681,6 +696,10 @@
   :gpml.handler.detail/delete #ig/ref :gpml.config/common
   :gpml.handler.detail/put #ig/ref :gpml.config/common
   :gpml.handler.detail/put-params {}
+
+  :gpml.handler.resource.translation/topics {}
+  :gpml.handler.resource.translation/put #ig/ref :gpml.config/common
+  :gpml.handler.resource.translation/put-params {}
 
   :gpml.handler.list/get {:db #ig/ref :duct.database/sql}
   :gpml.handler.list/get-params {}

--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -441,6 +441,17 @@
                                                                      [:topic-id int?]]
                                                               :query #ig/ref :gpml.handler.resource.translation/query-params}
                                                  :handler #ig/ref :gpml.handler.resource.translation/get}
+                                           :delete {:middleware [#ig/ref :gpml.auth/auth-middleware
+                                                                 #ig/ref :gpml.auth/auth-required
+                                                                 #ig/ref :gpml.auth/approved-user]
+                                                    :summary "Remove specific resource translations"
+                                                    :swagger {:tags ["remove resource translations"]}
+                                                    :parameters {:path [:map
+                                                                        [:topic-type
+                                                                         #ig/ref :gpml.handler.resource.translation/topics]
+                                                                        [:topic-id int?]]
+                                                                 :body #ig/ref :gpml.handler.resource.translation/delete-params}
+                                                    :handler #ig/ref :gpml.handler.resource.translation/delete}
                                            :put {:middleware [#ig/ref :gpml.auth/auth-middleware
                                                               #ig/ref :gpml.auth/auth-required
                                                               #ig/ref :gpml.auth/approved-user]
@@ -708,8 +719,10 @@
 
   :gpml.handler.resource.translation/topics {}
   :gpml.handler.resource.translation/get #ig/ref :gpml.config/common
+  :gpml.handler.resource.translation/delete #ig/ref :gpml.config/common
   :gpml.handler.resource.translation/put #ig/ref :gpml.config/common
   :gpml.handler.resource.translation/query-params {}
+  :gpml.handler.resource.translation/delete-params {}
   :gpml.handler.resource.translation/put-params {}
 
   :gpml.handler.list/get {:db #ig/ref :duct.database/sql}

--- a/backend/resources/migrations/166-fix-policy-languages-and-unify-for-translations.up.sql
+++ b/backend/resources/migrations/166-fix-policy-languages-and-unify-for-translations.up.sql
@@ -1,0 +1,21 @@
+BEGIN;
+--;;
+--;; Create english language in case it does not exist, avoiding errors if it already exists.
+--;; We need this to be always available for providing a default language to existing policies.
+INSERT INTO language (english_name, native_name, iso_code) VALUES
+  ('English', 'English', 'en')
+  ON CONFLICT DO NOTHING;
+--;;
+--;; Alter current `language` column type and set default value for existing rows.
+--;; We want to unify the column type to use more meaningful column for the language, as iso-code is unique as well,
+--;; so we do not need to deal with the serial id (PK) of the language table and we can simplify translations management.
+--;; We do not care about losing stored original languages, since we only can guarantee english content and we do not
+--;; support multi-lingual integration with LEAP API policies import.
+--;; In order to alter the column, we need to drop current FK constraint and re-create it pointing to the right column.
+ALTER TABLE IF EXISTS policy
+  DROP CONSTRAINT IF EXISTS policy_language_fkey,
+  ALTER COLUMN language TYPE varchar(3) USING 'en',
+  ALTER COLUMN language SET NOT NULL,
+  ADD CONSTRAINT policy_language_fkey FOREIGN KEY (language) REFERENCES language (iso_code) ON UPDATE CASCADE;
+--;;
+COMMIT;

--- a/backend/resources/migrations/167-add-language-to-remaining-resource-types.up.sql
+++ b/backend/resources/migrations/167-add-language-to-remaining-resource-types.up.sql
@@ -1,0 +1,44 @@
+BEGIN;
+--;; Add mandatory language prop to all resource types, ensuring a default value for existing entities.
+--;; Event resource type
+--;;
+ALTER TABLE IF EXISTS event
+  ADD COLUMN IF NOT EXISTS language varchar(3) DEFAULT 'en',
+  ALTER COLUMN language SET NOT NULL,
+  ADD CONSTRAINT event_language_fkey FOREIGN KEY (language) REFERENCES language (iso_code) ON UPDATE CASCADE;
+--;;
+--;; Now drop the default value after existing entities have a default language.
+ALTER TABLE IF EXISTS event
+  ALTER COLUMN language DROP DEFAULT;
+--;;
+--;; Initiative resource type
+ALTER TABLE IF EXISTS initiative
+  ADD COLUMN IF NOT EXISTS language varchar(3) DEFAULT 'en',
+  ALTER COLUMN language SET NOT NULL,
+  ADD CONSTRAINT initiative_language_fkey FOREIGN KEY (language) REFERENCES language (iso_code) ON UPDATE CASCADE;
+--;;
+--;; Now drop the default value after existing entities have a default language.
+ALTER TABLE IF EXISTS initiative
+  ALTER COLUMN language DROP DEFAULT;
+--;;
+--;; Resource resource type
+ALTER TABLE IF EXISTS resource
+  ADD COLUMN IF NOT EXISTS language varchar(3) DEFAULT 'en',
+  ALTER COLUMN language SET NOT NULL,
+  ADD CONSTRAINT resource_language_fkey FOREIGN KEY (language) REFERENCES language (iso_code) ON UPDATE CASCADE;
+--;;
+--;; Now drop the default value after existing entities have a default language.
+ALTER TABLE IF EXISTS resource
+  ALTER COLUMN language DROP DEFAULT;
+--;;
+--;; Technology resource type
+ALTER TABLE IF EXISTS technology
+  ADD COLUMN IF NOT EXISTS language varchar(3) DEFAULT 'en',
+  ALTER COLUMN language SET NOT NULL,
+  ADD CONSTRAINT technology_language_fkey FOREIGN KEY (language) REFERENCES language (iso_code) ON UPDATE CASCADE;
+--;;
+--;; Now drop the default value after existing entities have a default language.
+ALTER TABLE IF EXISTS technology
+  ALTER COLUMN language DROP DEFAULT;
+--;;
+COMMIT;

--- a/backend/resources/migrations/168-add-resource-translation-tables.up.sql
+++ b/backend/resources/migrations/168-add-resource-translation-tables.up.sql
@@ -1,0 +1,55 @@
+BEGIN;
+--;;
+--;; Create translation tables for each resource type.
+--;;
+CREATE TABLE IF NOT EXISTS policy_translation (
+  policy_id INTEGER,
+  translatable_field TEXT,
+  language VARCHAR(3),
+  value TEXT NOT NULL,
+  PRIMARY KEY (policy_id, translatable_field, language),
+  FOREIGN KEY (policy_id) REFERENCES policy(id) ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY (language) REFERENCES language(iso_code) ON UPDATE CASCADE ON DELETE CASCADE
+);
+--;;
+CREATE TABLE IF NOT EXISTS event_translation (
+  event_id INTEGER,
+  translatable_field TEXT,
+  language VARCHAR(3),
+  value TEXT NOT NULL,
+  PRIMARY KEY (event_id, translatable_field, language),
+  FOREIGN KEY (event_id) REFERENCES event(id) ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY (language) REFERENCES language(iso_code) ON UPDATE CASCADE ON DELETE CASCADE
+);
+--;;
+CREATE TABLE IF NOT EXISTS initiative_translation (
+  initiative_id INTEGER,
+  translatable_field TEXT,
+  language VARCHAR(3),
+  value TEXT NOT NULL,
+  PRIMARY KEY (initiative_id, translatable_field, language),
+  FOREIGN KEY (initiative_id) REFERENCES initiative(id) ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY (language) REFERENCES language(iso_code) ON UPDATE CASCADE ON DELETE CASCADE
+);
+--;;
+CREATE TABLE IF NOT EXISTS resource_translation (
+  resource_id INTEGER,
+  translatable_field TEXT,
+  language VARCHAR(3),
+  value TEXT NOT NULL,
+  PRIMARY KEY (resource_id, translatable_field, language),
+  FOREIGN KEY (resource_id) REFERENCES resource(id) ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY (language) REFERENCES language(iso_code) ON UPDATE CASCADE ON DELETE CASCADE
+);
+--;;
+CREATE TABLE IF NOT EXISTS technology_translation (
+  technology_id INTEGER,
+  translatable_field TEXT,
+  language VARCHAR(3),
+  value TEXT NOT NULL,
+  PRIMARY KEY (technology_id, translatable_field, language),
+  FOREIGN KEY (technology_id) REFERENCES technology(id) ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY (language) REFERENCES language(iso_code) ON UPDATE CASCADE ON DELETE CASCADE
+);
+--;;
+COMMIT;

--- a/backend/src/gpml/db/event.sql
+++ b/backend/src/gpml/db/event.sql
@@ -9,7 +9,8 @@ insert into event(
     geo_coverage_type,
     country,
     city,
-    image
+    image,
+    language
 --~ (when (contains? params :id) ", id")
 --~ (when (contains? params :review_status) ", review_status")
 --~ (when (contains? params :created_by) ", created_by")
@@ -31,7 +32,8 @@ values(
     :geo_coverage_type::geo_coverage_type,
     :country,
     :city,
-    :image
+    :image,
+    :language
 --~ (when (contains? params :id) ", :id")
 --~ (when (contains? params :review_status) ", :v:review_status::review_status")
 --~ (when (contains? params :created_by) ", :created_by")

--- a/backend/src/gpml/db/initiative.sql
+++ b/backend/src/gpml/db/initiative.sql
@@ -20,7 +20,7 @@ UPDATE initiative SET
 WHERE id = :id;
 
 -- :name initiative-detail-by-id :? :1
-SELECT id,
+SELECT id, language,
 json_agg(DISTINCT jsonb_build_object('name', focus_names.value)) AS focus_area,
 jsonb_build_object('name', STRING_AGG(DISTINCT outcome_names.value, ', ')) AS outcome_and_impact,
 jsonb_build_object('reports', report.value) AS is_action_being_reported,

--- a/backend/src/gpml/db/policy.clj
+++ b/backend/src/gpml/db/policy.clj
@@ -10,7 +10,6 @@
             [java-time.temporal]))
 
 (declare language-by-policy-id
-         add-language-to-policy
          new-policy
          add-policies-geo
          create-policies

--- a/backend/src/gpml/db/policy.sql
+++ b/backend/src/gpml/db/policy.sql
@@ -17,7 +17,8 @@ insert into policy(
     remarks,
     review_status,
     url,
-    image
+    image,
+    language
 --~ (when (contains? params :id) ", id")
 --~ (when (contains? params :created_by) ", created_by")
 --~ (when (contains? params :info_docs) ", info_docs")
@@ -43,7 +44,8 @@ values(
     :remarks,
     :v:review_status::review_status,
     :url,
-    :image
+    :image,
+    :language
 --~ (when (contains? params :id) ", :id")
 --~ (when (contains? params :created_by) ", :created_by")
 --~ (when (contains? params :info_docs) ", :info_docs")
@@ -81,6 +83,7 @@ select
     image,
     created_by,
     document_preview,
+    language,
     (select json_agg(tag) from policy_tag where policy = :id) as tags,
     (select json_agg(coalesce(country, country_group))
         from policy_geo_coverage where policy = :id) as geo_coverage_value
@@ -109,6 +112,7 @@ select
     url,
     image,
     document_preview,
+    language
     (select json_agg(tag)
         from policy_tag where policy = :id) as tags,
     (select created_by
@@ -145,13 +149,7 @@ select *
 --~ (when (> (-> params keys count) 2) " AND ")
 --~ (when (contains? params :leap_api_ids) " leap_api_id in (:v*:leap_api_ids)")
 
--- :name add-language-to-policy :! :n
--- :doc Add language to policy
-update policy
-  set language = :language
-  where id = :id
-
 -- :name language-by-policy-id :? :1
 -- :doc Get language by policy id
 select l.* from language l
-  where id = (select p.language from policy p where p.id = :id)
+  where iso_code = (select p.language from policy p where p.id = :id)

--- a/backend/src/gpml/db/resource.sql
+++ b/backend/src/gpml/db/resource.sql
@@ -7,7 +7,8 @@ insert into resource(
     summary,
     valid_from,
     valid_to,
-    geo_coverage_type
+    geo_coverage_type,
+    language
 --~ (when (contains? params :country) ", country")
 --~ (when (contains? params :value) ", value")
 --~ (when (contains? params :value_currency) ", value_currency")
@@ -34,7 +35,8 @@ values(
     :summary,
     :valid_from,
     :valid_to,
-    :v:geo_coverage_type::geo_coverage_type
+    :v:geo_coverage_type::geo_coverage_type,
+    :language
 --~ (when (contains? params :country) ", :country")
 --~ (when (contains? params :value) ", :value")
 --~ (when (contains? params :value_currency) ", :value_currency")
@@ -100,6 +102,7 @@ select
     url,
     created_by,
     document_preview,
+    language,
     (select json_agg(json_build_object('url',rlu.url, 'lang', l.iso_code))
         from resource_language_url rlu
         left join language l on l.id = rlu.language

--- a/backend/src/gpml/db/resource/translation.clj
+++ b/backend/src/gpml/db/resource/translation.clj
@@ -2,6 +2,8 @@
   {:ns-tracker/resource-deps ["resource/translation.sql"]}
   (:require [hugsql.core :as hugsql]))
 
-(declare create-or-update-translations)
+(declare create-or-update-translations
+         get-resource-translation-langs
+         get-resource-translations)
 
 (hugsql/def-db-fns "gpml/db/resource/translation.sql" {:quoting :ansi})

--- a/backend/src/gpml/db/resource/translation.clj
+++ b/backend/src/gpml/db/resource/translation.clj
@@ -4,6 +4,7 @@
 
 (declare create-or-update-translations
          get-resource-translation-langs
-         get-resource-translations)
+         get-resource-translations
+         delete-resource-translations)
 
 (hugsql/def-db-fns "gpml/db/resource/translation.sql" {:quoting :ansi})

--- a/backend/src/gpml/db/resource/translation.clj
+++ b/backend/src/gpml/db/resource/translation.clj
@@ -1,0 +1,7 @@
+(ns gpml.db.resource.translation
+  {:ns-tracker/resource-deps ["resource/translation.sql"]}
+  (:require [hugsql.core :as hugsql]))
+
+(declare create-or-update-translations)
+
+(hugsql/def-db-fns "gpml/db/resource/translation.sql" {:quoting :ansi})

--- a/backend/src/gpml/db/resource/translation.sql
+++ b/backend/src/gpml/db/resource/translation.sql
@@ -19,3 +19,11 @@ SELECT :i:resource-col,
   FROM :i:table
   WHERE :i:resource-col = :filters.resource-id
   GROUP BY (:i:resource-col, translatable_field);
+
+-- :name delete-resource-translations :execute :many
+-- :doc Remove translations specified with filters for a target resource.
+DELETE FROM :i:table
+  WHERE :i:resource-col = :filters.resource-id
+--~(when (seq (get-in params [:filters :translations])) " AND (language, translatable_field) IN (:t*:filters.translations)")
+--~(when (and (not (seq (get-in params [:filters :translations]))) (seq (get-in params [:filters :languages]))) " AND language IN (:v*:filters.languages)")
+--~(when (and (not (seq (get-in params [:filters :translations]))) (seq (get-in params [:filters :translatable_fields]))) " AND translatable_field IN (:v*:filters.translatable_fields)")

--- a/backend/src/gpml/db/resource/translation.sql
+++ b/backend/src/gpml/db/resource/translation.sql
@@ -1,0 +1,6 @@
+-- :name create-or-update-translations :execute :many
+-- :doc Upsert multiple translations for a target resource.
+INSERT INTO :i:table (:i*:insert-cols)
+  VALUES :t*:translations
+  ON CONFLICT (:i:resource-col, translatable_field, language)
+  DO UPDATE SET value = excluded.value;

--- a/backend/src/gpml/db/resource/translation.sql
+++ b/backend/src/gpml/db/resource/translation.sql
@@ -4,3 +4,18 @@ INSERT INTO :i:table (:i*:insert-cols)
   VALUES :t*:translations
   ON CONFLICT (:i:resource-col, translatable_field, language)
   DO UPDATE SET value = excluded.value;
+
+-- :name get-resource-translation-langs :query :many
+-- :doc Get all the translation languages available for a given resource.
+SELECT DISTINCT language
+  FROM :i:table
+  WHERE :i:resource-col = :filters.resource-id;
+
+-- :name get-resource-translations :query :many
+-- :doc Get all the translations available for a given resource.
+SELECT :i:resource-col,
+       translatable_field,
+       json_object_agg(language, value) AS translations
+  FROM :i:table
+  WHERE :i:resource-col = :filters.resource-id
+  GROUP BY (:i:resource-col, translatable_field);

--- a/backend/src/gpml/db/technology.sql
+++ b/backend/src/gpml/db/technology.sql
@@ -14,7 +14,8 @@ insert into technology(
     review_status,
     url,
     image,
-    logo
+    logo,
+    language
 --~ (when (contains? params :id) ", id")
 --~ (when (contains? params :created_by) ", created_by")
 --~ (when (contains? params :info_docs) ", info_docs")
@@ -37,7 +38,8 @@ values(
     :v:review_status::review_status,
     :url,
     :image,
-    :logo
+    :logo,
+    :language
 --~ (when (contains? params :id) ", :id")
 --~ (when (contains? params :created_by) ", :created_by")
 --~ (when (contains? params :info_docs) ", :info_docs")
@@ -71,6 +73,7 @@ select
     headquarter,
     created_by,
     document_preview,
+    language,
     COALESCE(json_agg(authz.stakeholder) FILTER (WHERE authz.stakeholder IS NOT NULL), '[]') as owners,
     (select json_agg(json_build_object('url',plu.url, 'lang', l.iso_code))
         from technology_language_url plu

--- a/backend/src/gpml/domain/translation.clj
+++ b/backend/src/gpml/domain/translation.clj
@@ -1,0 +1,14 @@
+(ns gpml.domain.translation)
+
+;; For each entity type here there are registered all the allowed translatable fields.
+;; However, right now the support is only given for resources."
+(defonce translatable-fields-by-entity
+  {:policy #{:title :abstract :info_docs}
+   :event #{:title :description :info_docs}
+   :resource #{:title :value_remarks :summary :info_docs}
+   :technology #{:title :remarks :info_docs}
+   :initiative #{:title :info_docs :summary :other_leg_stand_rules :other_working_with_people
+                 :other_tech_and_proc :other_monitoring :monitoring_protocol :monitored_data_access
+                 :other_report_progress :other_reported_entity_progress :other_outcome_impact_eval
+                 :kpis :co_benefits :other_lifecycle :other_impact_harm :other_sector
+                 :other_funding :other_duration}})

--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -619,13 +619,6 @@
       :id id
       :organisation org-id})))
 
-(defn update-policy-language [conn language policy-id]
-  (let [lang-id (:id (db.language/language-by-iso-code conn (select-keys language [:iso_code])))]
-    (if-not (nil? lang-id)
-      (db.policy/add-language-to-policy conn {:id policy-id :language lang-id})
-      (db.policy/add-language-to-policy conn {:id policy-id
-                                              :language (:id (db.language/insert-new-language conn language))}))))
-
 (defn -update-blank-resource-picture [conn image-type resource-id image-key]
   (db.detail/update-resource-table
    conn
@@ -723,8 +716,6 @@
                      (and (= -1 (:id org))
                           (handler.org/create conn logger mailjet-config org))))
         related-contents (:related_content updates)]
-    (when (and (contains? updates :language) (= topic-type "policy"))
-      (update-policy-language conn (:language updates) id))
     (doseq [[image-key image-data] (select-keys updates [:image :thumbnail :photo :logo])]
       (update-resource-image conn image-data image-key table id))
     (when (seq tags)

--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -14,16 +14,14 @@
             [gpml.db.organisation :as db.organisation]
             [gpml.db.policy :as db.policy]
             [gpml.db.project :as db.project]
-            [gpml.db.resource.association :as db.resource.association]
             [gpml.db.resource.connection :as db.resource.connection]
             [gpml.db.resource.tag :as db.resource.tag]
-            [gpml.db.review :as db.review]
             [gpml.db.submission :as db.submission]
-            [gpml.db.topic-stakeholder-auth :as db.ts-auth]
             [gpml.handler.geo :as handler.geo]
             [gpml.handler.image :as handler.image]
             [gpml.handler.initiative :as handler.initiative]
             [gpml.handler.organisation :as handler.org]
+            [gpml.handler.resource.permission :as handler.res-permission]
             [gpml.handler.resource.related-content :as handler.resource.related-content]
             [gpml.handler.resource.tag :as handler.resource.tag]
             [gpml.handler.stakeholder.tag :as handler.stakeholder.tag]
@@ -378,67 +376,6 @@
 (defmethod extra-details :nothing [_ _ _]
   nil)
 
-(defn- get-resource-if-allowed
-  [conn path user read?]
-  (let [{:keys [topic-type topic-id] :as params} (update path :topic-type util/get-internal-topic-type)
-        submission (->> {:table-name topic-type :id topic-id}
-                        (db.submission/detail conn))]
-    ;; The following checks are mostly to avoid doing a lot of work
-    ;; when checking the user permissions on a specific resource.
-    (cond
-      ;; If the user is empty it means the caller doesn't have a
-      ;; session and is just making a read call on the resource. So no
-      ;; need to check extra permissions since platform resources are
-      ;; public in a read-only state.
-      (and (not (seq user))
-           (= (:review_status submission) "APPROVED"))
-      submission
-
-      ;; If it's a read attempt, the resource is approved and the user
-      ;; is logged in then we should allow without checking extra
-      ;; permissions.
-      (and read?
-           (= (:review_status submission) "APPROVED"))
-      submission
-
-      ;; If it's not a read operation the respective PUT, POST and
-      ;; DELETE endpoints should check if the user is approved in the
-      ;; platform to do the desired action for the specific resource.
-      :else
-      (let [review (first (db.review/reviews-filter conn params))
-            resource-org-associations
-            (when-not (get #{"organisation" "stakeholder"} topic-type)
-              (db.resource.association/get-resource-associations conn {:table (str "organisation_" topic-type)
-                                                                       :entity-col "organisation"
-                                                                       :resource-col topic-type
-                                                                       :resource-assoc-type (str topic-type "_association")
-                                                                       :filters {:resource-id topic-id
-                                                                                 :associations ["owner"]}}))
-            user-org-auth-roles
-            (when (and (:id user)
-                       (not (get #{"organisation" "stakeholder"} topic-type)))
-              (->> (db.ts-auth/get-topic-stakeholder-auths conn {:filters {:topics-ids (map :organisation resource-org-associations)
-                                                                           :topic-types ["organisation"]
-                                                                           :stakeholders-ids [(:id user)]}})
-                   (map :roles)
-                   (set)))
-
-            user-auth-roles
-            (->> (db.ts-auth/get-topic-stakeholder-auths conn {:filters {:topics-ids [topic-id]
-                                                                         :topic-types [topic-type]
-                                                                         :stakeholders-ids [(:id user)]}})
-                 (map :roles)
-                 (set))
-            access-allowed?
-            (or (and (= (:role user) "REVIEWER") (= (:id user) (:reviewer review)))
-                (contains? user-auth-roles "owner")
-                (and (not (nil? (:id user)))
-                     (= (:created_by submission) (:id user)))
-                (some #(get user-org-auth-roles %) ["owner" "focal-point"])
-                (= (:role user) "ADMIN"))]
-        (when access-allowed?
-          submission)))))
-
 (def not-nil-name #(vec (filter :name %)))
 
 (defn adapt [data]
@@ -481,7 +418,7 @@
       (let [conn        (:spec db)
             topic       (resolve-resource-type (:topic-type path))
             authorized? (and (or (model.topic/public? topic) approved?)
-                             (some? (get-resource-if-allowed conn path user false)))
+                             (some? (handler.res-permission/get-resource-if-allowed conn path user false)))
             sqls (condp = topic
                    "policy" (common-queries topic path true false true true)
                    "event" (common-queries topic path true true true true)
@@ -533,7 +470,7 @@
             topic (:topic-type path)
             id (:topic-id path)
             authorized? (and (or (model.topic/public? topic) approved?)
-                             (some? (get-resource-if-allowed conn path user true)))]
+                             (some? (handler.res-permission/get-resource-if-allowed conn path user true)))]
         (if authorized?
           (if-let [data (get-detail conn topic id query)]
             (resp/response (merge
@@ -755,7 +692,7 @@
   (fn [{{{:keys [topic-type topic-id] :as path} :path body :body} :parameters
         user :user}]
     (try
-      (let [submission (get-resource-if-allowed (:spec db) path user false)
+      (let [submission (handler.res-permission/get-resource-if-allowed (:spec db) path user false)
             review_status (:review_status submission)]
         (if (some? submission)
           (let [conn (:spec db)

--- a/backend/src/gpml/handler/event.clj
+++ b/backend/src/gpml/handler/event.clj
@@ -47,7 +47,7 @@
                             geo_coverage_value_subnational_city
                             created_by owners url info_docs sub_content_type
                             recording document_preview related_content
-                            entity_connections individual_connections]}]
+                            entity_connections individual_connections language]}]
   (let [data {:title title
               :start_date start_date
               :end_date end_date
@@ -68,7 +68,8 @@
               :info_docs info_docs
               :sub_content_type sub_content_type
               :recording recording
-              :document_preview document_preview}
+              :document_preview document_preview
+              :language language}
         event-id (->> data (db.event/new-event conn) :id)
         api-individual-connections (handler.util/individual-connections->api-individual-connections conn individual_connections created_by)
         owners (distinct (remove nil? (flatten (conj owners
@@ -164,7 +165,8 @@
      [:vector {:optional true}
       [:map {:optional true}
        [:id {:optional true} pos-int?]
-       [:tag string?]]]]]
+       [:tag string?]]]]
+    [:language string?]]
    (into handler.geo/params-payload)))
 
 (defmethod ig/init-key :gpml.handler.event/post

--- a/backend/src/gpml/handler/initiative.clj
+++ b/backend/src/gpml/handler/initiative.clj
@@ -122,7 +122,7 @@
         (log logger :error ::failed-to-create-initiative {:exception-message (.getMessage e)})
         (let [response {:status 500
                         :body {:success? false
-                               :reason :could-not-create-event}}]
+                               :reason :could-not-create-initiative}}]
 
           (if (instance? SQLException e)
             response
@@ -157,4 +157,6 @@
       (resp/response (merge data extra-details)))))
 
 (defmethod ig/init-key :gpml.handler.initiative/post-params [_ _]
-  [:map [:version integer?]])
+  [:map
+   [:version integer?]
+   [:language string?]])

--- a/backend/src/gpml/handler/policy.clj
+++ b/backend/src/gpml/handler/policy.clj
@@ -4,7 +4,6 @@
             [gpml.auth :as auth]
             [gpml.constants :as constants]
             [gpml.db.favorite :as db.favorite]
-            [gpml.db.language :as db.language]
             [gpml.db.policy :as db.policy]
             [gpml.db.stakeholder :as db.stakeholder]
             [gpml.handler.auth :as h.auth]
@@ -79,7 +78,8 @@
               :attachments attachments
               :remarks remarks
               :created_by created_by
-              :review_status "SUBMITTED"}
+              :review_status "SUBMITTED"
+              :language language}
         policy-geo-coverage-insert-cols ["policy" "country_group" "country"]
         policy-id (->> data (db.policy/new-policy conn) :id)
         api-individual-connections (handler.util/individual-connections->api-individual-connections conn individual_connections created_by)
@@ -94,12 +94,6 @@
                                                                              :tag-category "general"
                                                                              :resource-name "policy"
                                                                              :resource-id policy-id}))
-    (when (not-empty language)
-      (let [lang-id (:id (db.language/language-by-iso-code conn (select-keys language [:iso_code])))]
-        (if-not (nil? lang-id)
-          (db.policy/add-language-to-policy conn {:id policy-id :language lang-id})
-          (db.policy/add-language-to-policy conn {:id policy-id
-                                                  :language (:id (db.language/insert-new-language conn language))}))))
     (doseq [stakeholder-id owners]
       (h.auth/grant-topic-to-stakeholder! conn {:topic-id policy-id
                                                 :topic-type "policy"
@@ -199,11 +193,7 @@
     [:urls {:optional true}
      [:vector {:optional true}
       [:map [:lang string?] [:url [:string {:min 1}]]]]]
-    [:language {:optional true}
-     [:map
-      [:english_name string?]
-      [:native_name string?]
-      [:iso_code string?]]]
+    [:language string?]
     auth/owners-schema]
    (into handler.geo/params-payload)))
 

--- a/backend/src/gpml/handler/resource.clj
+++ b/backend/src/gpml/handler/resource.clj
@@ -51,7 +51,7 @@
            attachments country urls tags remarks thumbnail
            created_by url owners info_docs sub_content_type related_content
            first_publication_date latest_amendment_date document_preview
-           entity_connections individual_connections]}]
+           entity_connections individual_connections language]}]
   (let [data {:type resource_type
               :title title
               :publish_year publish_year
@@ -77,7 +77,8 @@
               :sub_content_type sub_content_type
               :first_publication_date first_publication_date
               :latest_amendment_date latest_amendment_date
-              :document_preview document_preview}
+              :document_preview document_preview
+              :language language}
         resource-id (:id (db.resource/new-resource conn data))
         api-individual-connections (handler.util/individual-connections->api-individual-connections conn individual_connections created_by)
         owners (distinct (remove nil? (flatten (conj owners
@@ -144,7 +145,7 @@
         (log logger :error ::failed-to-create-resource {:exception-message (.getMessage e)})
         (let [response {:status 500
                         :body {:success? false
-                               :reason :could-not-create-event}}]
+                               :reason :could-not-create-resource}}]
 
           (if (instance? SQLException e)
             response
@@ -223,6 +224,7 @@
             [:map {:optional true}
              [:id {:optional true} pos-int?]
              [:tag string?]]]]
+          [:language string?]
           auth/owners-schema]
          handler.geo/params-payload)])
 

--- a/backend/src/gpml/handler/resource/permission.clj
+++ b/backend/src/gpml/handler/resource/permission.clj
@@ -1,0 +1,69 @@
+(ns gpml.handler.resource.permission
+  (:require [gpml.db.resource.association :as db.resource.association]
+            [gpml.db.review :as db.review]
+            [gpml.db.submission :as db.submission]
+            [gpml.db.topic-stakeholder-auth :as db.ts-auth]
+            [gpml.handler.util :as util]))
+
+(defn get-resource-if-allowed
+  [conn path user read?]
+  (let [{:keys [topic-type topic-id] :as params} (update path :topic-type util/get-internal-topic-type)
+        submission (->> {:table-name topic-type :id topic-id}
+                        (db.submission/detail conn))]
+    ;; The following checks are mostly to avoid doing a lot of work
+    ;; when checking the user permissions on a specific resource.
+    (cond
+      ;; If the user is empty it means the caller doesn't have a
+      ;; session and is just making a read call on the resource. So no
+      ;; need to check extra permissions since platform resources are
+      ;; public in a read-only state.
+      (and (not (seq user))
+           (= (:review_status submission) "APPROVED"))
+      submission
+
+      ;; If it's a read attempt, the resource is approved and the user
+      ;; is logged in then we should allow without checking extra
+      ;; permissions.
+      (and read?
+           (= (:review_status submission) "APPROVED"))
+      submission
+
+      ;; If it's not a read operation the respective PUT, POST and
+      ;; DELETE endpoints should check if the user is approved in the
+      ;; platform to do the desired action for the specific resource.
+      :else
+      (let [review (first (db.review/reviews-filter conn params))
+            resource-org-associations
+            (when-not (get #{"organisation" "stakeholder"} topic-type)
+              (db.resource.association/get-resource-associations conn {:table (str "organisation_" topic-type)
+                                                                       :entity-col "organisation"
+                                                                       :resource-col topic-type
+                                                                       :resource-assoc-type (str topic-type "_association")
+                                                                       :filters {:resource-id topic-id
+                                                                                 :associations ["owner"]}}))
+            user-org-auth-roles
+            (when (and (:id user)
+                       (not (get #{"organisation" "stakeholder"} topic-type)))
+              (->> (db.ts-auth/get-topic-stakeholder-auths conn {:filters {:topics-ids (map :organisation resource-org-associations)
+                                                                           :topic-types ["organisation"]
+                                                                           :stakeholders-ids [(:id user)]}})
+                   first
+                   :roles
+                   (set)))
+
+            user-auth-roles
+            (->> (db.ts-auth/get-topic-stakeholder-auths conn {:filters {:topics-ids [topic-id]
+                                                                         :topic-types [topic-type]
+                                                                         :stakeholders-ids [(:id user)]}})
+                 first
+                 :roles
+                 (set))
+            access-allowed?
+            (or (and (= (:role user) "REVIEWER") (= (:id user) (:reviewer review)))
+                (contains? user-auth-roles "owner")
+                (and (not (nil? (:id user)))
+                     (= (:created_by submission) (:id user)))
+                (some #(get user-org-auth-roles %) ["owner" "focal-point"])
+                (= (:role user) "ADMIN"))]
+        (when access-allowed?
+          submission)))))

--- a/backend/src/gpml/handler/resource/translation.clj
+++ b/backend/src/gpml/handler/resource/translation.clj
@@ -1,0 +1,104 @@
+(ns gpml.handler.resource.translation
+  (:require [clojure.string :as str]
+            [duct.logger :refer [log]]
+            [gpml.constants :as constants]
+            [gpml.db.resource.translation :as db.res-translation]
+            [gpml.domain.translation :as dom.translation]
+            [gpml.handler.resource.permission :as res-permission]
+            [gpml.handler.util :as util]
+            [gpml.util.sql :as sql-util]
+            [integrant.core :as ig]
+            [ring.util.response :as resp])
+  (:import [java.sql SQLException]))
+
+(defmethod ig/init-key :gpml.handler.resource.translation/topics [_ _]
+  (apply conj [:enum] constants/topic-tables))
+
+(defn- is-lowercase?
+  [content-str]
+  (and (string? content-str)
+       (not (str/blank? content-str))
+       (= content-str (str/lower-case content-str))))
+
+(defn- is-allowed-translation-entity?
+  [topic-type]
+  (get (set constants/topic-tables) topic-type))
+
+(defn- all-valid-translatable-fields?
+  [{:keys [translations topic-type]}]
+  (and
+   (is-allowed-translation-entity? topic-type)
+   (every? (fn [{:keys [translatable_field]}]
+             (get-in dom.translation/translatable-fields-by-entity
+                     [(keyword topic-type)
+                      (keyword translatable_field)]))
+           translations)))
+
+(def put-params
+  [:and
+   [:map
+    [:translations
+     [:vector {:min 1
+               :error/message "There has to be at least one element"}
+      [:map
+       [:language
+        [:string {:min 2 :max 3}]]
+       [:translatable_field
+        [:fn {:error/message "It must be lower-cased."}
+         is-lowercase?]]
+       [:value string?]]]]
+    [:topic-type string?]]
+   [:fn {:error/message "There is some invalid translatable_field"}
+    all-valid-translatable-fields?]])
+
+(defmethod ig/init-key :gpml.handler.resource.translation/put-params [_ _]
+  put-params)
+
+(defn- api-translation-translation
+  [api-translation resource-col topic-id]
+  (assoc api-translation resource-col topic-id))
+
+(defn- valid-translation-languages?
+  "The translations will be valid if they are not related to the resource's original language"
+  [translations original-lang]
+  (every? (fn [{:keys [language]}]
+            (not= language original-lang))
+          translations))
+
+(defmethod ig/init-key :gpml.handler.resource.translation/put
+  [_ {:keys [db logger]}]
+  (fn [{{{:keys [topic-type topic-id] :as path} :path body :body} :parameters
+        user :user}]
+    (try
+      (let [submission (res-permission/get-resource-if-allowed (:spec db) path user false)]
+        (if (some? submission)
+          (if (valid-translation-languages? (:translations body) (:language submission))
+            (let [conn (:spec db)
+                  resource-col (keyword (str topic-type "_id"))
+                  parsed-translations (mapv #(api-translation-translation % resource-col topic-id)
+                                            (:translations body))
+                  res-translation-columns (sql-util/get-insert-columns-from-entity-col parsed-translations)
+                  db-res-translations (sql-util/entity-col->persistence-entity-col parsed-translations)
+                  result (db.res-translation/create-or-update-translations
+                          conn
+                          {:table (str topic-type "_translation")
+                           :resource-col (name resource-col)
+                           :insert-cols res-translation-columns
+                           :translations db-res-translations})]
+              (if (> (first result) 0)
+                (resp/response {})
+                {:status 500
+                 :body {:success? false
+                        :reason :no-translations-affected}}))
+            (resp/bad-request body))
+          util/unauthorized))
+      (catch Exception e
+        (log logger :error ::failed-to-create-or-edit-resource-translations {:exception-message (.getMessage e)
+                                                                             :context-data {:path-params path
+                                                                                            :body-params body}})
+        (let [response {:status 500
+                        :body {:success? false
+                               :reason :failed-to-create-or-edit-resource-translations}}]
+          (if (instance? SQLException e)
+            response
+            (assoc-in response [:body :error-details :error] (.getMessage e))))))))

--- a/backend/src/gpml/handler/technology.clj
+++ b/backend/src/gpml/handler/technology.clj
@@ -51,7 +51,7 @@
                                  sub_content_type related_content
                                  headquarter document_preview
                                  logo thumbnail attachments remarks
-                                 entity_connections individual_connections]}]
+                                 entity_connections individual_connections language]}]
   (let [data {:name name
               :year_founded year_founded
               :organisation_type organisation_type
@@ -76,7 +76,8 @@
               :sub_content_type sub_content_type
               :headquarter headquarter
               :document_preview document_preview
-              :review_status "SUBMITTED"}
+              :review_status "SUBMITTED"
+              :language language}
         technology-id (->> data (db.technology/new-technology conn) :id)
         api-individual-connections (handler.util/individual-connections->api-individual-connections conn individual_connections created_by)
         owners (distinct (remove nil? (flatten (conj owners
@@ -139,7 +140,7 @@
         (log logger :error ::failed-to-create-technology {:exception-message (.getMessage e)})
         (let [response {:status 500
                         :body {:success? false
-                               :reason :could-not-create-event}}]
+                               :reason :could-not-create-technology}}]
 
           (if (instance? SQLException e)
             response
@@ -193,6 +194,7 @@
          [:urls {:optional true}
           [:vector {:optional true}
            [:map [:lang string?] [:url [:string {:min 1}]]]]]
+         [:language string?]
          auth/owners-schema]
         handler.geo/params-payload))
 

--- a/backend/src/gpml/scheduler/leap_api_policy_importer.clj
+++ b/backend/src/gpml/scheduler/leap_api_policy_importer.clj
@@ -252,13 +252,18 @@
    way to transform the data will be the right one.
 
    `:leap_api_modified` field can be already transformed into a java time instant, if we are coming from the Update
-    flow, so that is why we apply a conditional transformation there."
+    flow, so that is why we apply a conditional transformation there.
+
+    For now we are not supporting multi-lingual content from the LEAP API import, so we are not using the item's
+    language, neither the `languages-by-iso-code` option, as we are hardcoding all the items language to be
+    english, since right now it is the only language we have the content for.
+    In the future, we will use the original content for creating translations and support multi-lingual
+    feature, but not for now."
   [{:keys [title originalTitle source country abstract type
            dateOfText lastAmendmentDate status files link regulatoryApproach
-           topics language id updated implementingMeas] :as policy-raw}
+           topics id updated implementingMeas] :as policy-raw}
    {:keys [default-lang
            countries-by-iso-code
-           languages-by-iso-code
            tags-by-normalized-name
            mea-country-groups-by-name
            policy-types-of-law
@@ -309,11 +314,7 @@
                       :available-opts
                       policy-sub-content-types)
    :topics (parse-policy-leap-api-field :collection topics)
-   :language (parse-policy-leap-api-field
-              :iso-code
-              language
-              :opts-by-iso-code
-              languages-by-iso-code)
+   :language (name default-lang)
    :leap_api_id (parse-policy-leap-api-field :uuid id)
    :leap_api_modified (if-not (jt/instant? updated)
                         (parse-policy-leap-api-field :timestamp updated)

--- a/backend/test/gpml/db/initiative_test.clj
+++ b/backend/test/gpml/db/initiative_test.clj
@@ -71,7 +71,8 @@
    :q39 1
    :q40 1
    :q41 2
-   :q41_1 "test"})
+   :q41_1 "test"
+   :language "en"})
 
 (deftest insert-data
   (let [db (test-util/db-test-conn)

--- a/backend/test/gpml/db/landing_test.clj
+++ b/backend/test/gpml/db/landing_test.clj
@@ -26,7 +26,8 @@
    :geo_coverage_type geo-coverage
    :attachments nil
    :remarks "Remarks"
-   :review_status "APPROVED"})
+   :review_status "APPROVED"
+   :language "en"})
 
 (defn add-country-data [conn]
   (db.country/new-country conn {:name "Spain" :description "Member State" :iso_code "ESP"})
@@ -96,7 +97,8 @@
                                  :country nil
                                  :city nil
                                  :image nil
-                                 :review_status "SUBMITTED"})
+                                 :review_status "SUBMITTED"
+                                 :language "en"})
           summary (db.landing/summary conn)
           extract-data (fn [topic]
                          (->> summary

--- a/backend/test/gpml/db/topic_test.clj
+++ b/backend/test/gpml/db/topic_test.clj
@@ -20,7 +20,8 @@
    :geo_coverage_type nil
    :end_date "2021-01-01T12:00:00Z"
    :reviewed_at "2021-01-01T12:00:00Z"
-   :start_date "2021-01-01T10:00:00Z"})
+   :start_date "2021-01-01T10:00:00Z"
+   :language "en"})
 
 (defn make-profile [first-name last-name email]
   {:picture nil

--- a/backend/test/gpml/db/updater_test.clj
+++ b/backend/test/gpml/db/updater_test.clj
@@ -93,13 +93,15 @@
           ;; transnational initiative
           tn-initiative-data (seeder/parse-data
                               (slurp (io/resource "examples/initiative-transnational.json"))
-                              {:keywords? true})
+                              {:keywords? true
+                               :add-default-lang? true})
           tn-initiative-id (db.initiative/new-initiative db tn-initiative-data)
           tn-initiative (db.initiative/initiative-by-id db tn-initiative-id)
           ;; national initiative
           n-initiative-data (seeder/parse-data
                              (slurp (io/resource "examples/initiative-national.json"))
-                             {:keywords? true})
+                             {:keywords? true
+                              :add-default-lang? true})
           n-initiative-id (db.initiative/new-initiative db n-initiative-data)
           n-initiative (db.initiative/initiative-by-id db n-initiative-id)]
 

--- a/backend/test/gpml/handler/detail_test.clj
+++ b/backend/test/gpml/handler/detail_test.clj
@@ -13,6 +13,8 @@
             [integrant.core :as ig]
             [ring.mock.request :as mock]))
 
+(defonce ^:private default-lang-iso-code "en")
+
 (use-fixtures :each fixtures/with-test-system)
 
 (defn- new-stakeholder [db email first_name last_name role review_status]
@@ -52,7 +54,7 @@
    :review_status nil
    :document_preview false
    :image nil
-   :language "en"})
+   :language default-lang-iso-code})
 
 (def technology-data
   {:name "technology Title"
@@ -70,7 +72,8 @@
    :document_preview false
    :image nil
    :logo nil
-   :tags nil})
+   :tags nil
+   :language default-lang-iso-code})
 
 (def event-data
   {:title "Event Data"
@@ -84,7 +87,8 @@
    :document_preview false
    :review_status nil
    :image nil
-   :tags nil})
+   :tags nil
+   :language default-lang-iso-code})
 
 (deftest handler-put-test
   (let [system (ig/init fixtures/*system* [::detail/put])
@@ -95,7 +99,8 @@
     (testing "Check editing allowed only if user has the rights"
       (let [data (seeder/parse-data
                   (slurp (io/resource "examples/initiative-national.json"))
-                  {:keywords? true})
+                  {:keywords? true
+                   :add-default-lang? true})
             initiative (db.initiative/new-initiative db data)
             edited-data (merge data {:q2 "New Title"})
             resp (handler (-> (mock/request :put "/")
@@ -111,7 +116,8 @@
                      db {:name "Indonesia" :iso_code "IND" :description "Member State" :territory "IND"})
             data (-> (seeder/parse-data
                       (slurp (io/resource "examples/initiative-national.json"))
-                      {:keywords? true})
+                      {:keywords? true
+                       :add-default-lang? true})
                      (assoc :q24_2 [{(keyword (str (:id country))) "Indonesia"}]))
             initiative (db.initiative/new-initiative db data)
             edited-data (merge data {:q2 "New Title"})
@@ -171,7 +177,8 @@
         creator (new-stakeholder db "user-approved@org.com" "U" "A" "USER" "APPROVED")
         data (seeder/parse-data
               (slurp (io/resource "examples/initiative-national.json"))
-              {:keywords? true})
+              {:keywords? true
+               :add-default-lang? true})
         initiative (db.initiative/new-initiative db (assoc data :created_by (:id creator)))]
 
     (testing "Fetching detail of unapproved resource unauthenticated"

--- a/backend/test/gpml/handler/detail_test.clj
+++ b/backend/test/gpml/handler/detail_test.clj
@@ -51,7 +51,8 @@
    :remarks nil
    :review_status nil
    :document_preview false
-   :image nil})
+   :image nil
+   :language "en"})
 
 (def technology-data
   {:name "technology Title"

--- a/backend/test/gpml/handler/event_test.clj
+++ b/backend/test/gpml/handler/event_test.clj
@@ -22,7 +22,8 @@
    :geo_coverage_type "global"
    :country (get-in data [:countries 0 :id])
    :city "string"
-   :image "image" :url "url"})
+   :image "image" :url "url"
+   :language "en"})
 
 (deftest handler-post-test
   (testing "New event is created"

--- a/backend/test/gpml/handler/initiative_test.clj
+++ b/backend/test/gpml/handler/initiative_test.clj
@@ -28,7 +28,8 @@
           ;; John create new initiative with new organisation
           submission (seeder/parse-data
                       (slurp (io/resource "examples/submission-initiative.json"))
-                      {:keywords? true})
+                      {:keywords? true
+                       :add-default-lang? true})
           resp (handler (-> (mock/request :post "/")
                             (assoc :jwt-claims {:email "john@org"})
                             (assoc :body-params (assoc submission :version 1))))

--- a/backend/test/gpml/handler/policy_test.clj
+++ b/backend/test/gpml/handler/policy_test.clj
@@ -30,7 +30,8 @@
    :remarks nil
    :document_preview false
    :country (-> (:countries data) first :id)
-   :tags (:tags data)})
+   :tags (:tags data)
+   :language "id"})
 
 (deftest handler-post-test
   (testing "New policy is created"

--- a/backend/test/gpml/handler/resource/translation_test.clj
+++ b/backend/test/gpml/handler/resource/translation_test.clj
@@ -1,0 +1,95 @@
+(ns gpml.handler.resource.translation-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [gpml.db.event :as db.event]
+            [gpml.fixtures :as fixtures]
+            [gpml.handler.resource.translation :as res-translation]
+            [gpml.seeder.main :as seeder]
+            [integrant.core :as ig]
+            [ring.mock.request :as mock]))
+
+(defonce ^:private default-lang-iso-code "en")
+
+(use-fixtures :each fixtures/with-test-system)
+
+(def event-data
+  {:title "Event Data"
+   :description "Event Description"
+   :start_date "2021-04-01"
+   :end_date "2021-04-01"
+   :city "Amsterdam"
+   :country nil
+   :geo_coverage_type "global"
+   :remarks nil
+   :document_preview false
+   :review_status nil
+   :image nil
+   :tags nil
+   :language default-lang-iso-code})
+
+(def translations-event-data
+  {:topic-type "event"
+   :translations [{:language "es"
+                   :translatable_field "title"
+                   :value "Título en castellano evento 37"}
+                  {:language "fr"
+                   :translatable_field "title"
+                   :value "Título en francés falso, evento 37"}]})
+
+;; NOTE: We are just using Event resource type as example for tests since the rest are the same.
+(deftest handler-put-test
+  (let [system (ig/init fixtures/*system* [::res-translation/put])
+        handler (::res-translation/put system)
+        db (-> system :duct.database.sql/hikaricp :spec)
+        admin {:id 0 :role "ADMIN"}
+        event (db.event/new-event db event-data)]
+    (seeder/seed-languages db)
+    (testing "Creating translations for an event"
+      (let [translations (assoc translations-event-data :topic-id (:id event))
+            resp (handler (-> (mock/request :put "/")
+                              (assoc :jwt-claims {:email "john@org"}
+                                     :user admin
+                                     :parameters
+                                     {:path {:topic-type "event" :topic-id (:id event)}
+                                      :body translations})))]
+        (is (= 200 (:status resp)))))
+    (testing "Updating translations for an event"
+      (let [translations (-> translations-event-data
+                             (assoc :topic-id (:id event))
+                             (update-in [:translations 0 :value] #(str % " edited")))
+            resp (handler (-> (mock/request :put "/")
+                              (assoc :jwt-claims {:email "john@org"}
+                                     :user admin
+                                     :parameters
+                                     {:path {:topic-type "event" :topic-id (:id event)}
+                                      :body translations})))]
+        (is (= 200 (:status resp)))))
+    (testing "Creating translations fails if not authorized user"
+      (let [translations (assoc translations-event-data :topic-id (:id event))
+            resp (handler (-> (mock/request :put "/")
+                              (assoc :jwt-claims {:email "john@org"}
+                                     :parameters
+                                     {:path {:topic-type "event" :topic-id (:id event)}
+                                      :body translations})))]
+        (is (= 403 (:status resp)))))
+    (testing "Updating translations with original language fails"
+      (let [translations (-> translations-event-data
+                             (assoc :topic-id (:id event))
+                             (assoc-in [:translations 0 :language] (:language event-data)))
+            resp (handler (-> (mock/request :put "/")
+                              (assoc :jwt-claims {:email "john@org"}
+                                     :user admin
+                                     :parameters
+                                     {:path {:topic-type "event" :topic-id (:id event)}
+                                      :body translations})))]
+        (is (= 400 (:status resp)))))
+    (testing "Updating translations for non-valid resource type fails"
+      (let [translations (-> translations-event-data
+                             (assoc :topic-id (:id event))
+                             (assoc :topic-type "stakeholder"))
+            resp (handler (-> (mock/request :put "/")
+                              (assoc :jwt-claims {:email "john@org"}
+                                     :user admin
+                                     :parameters
+                                     {:path {:topic-type "stakeholder" :topic-id (:id event)}
+                                      :body translations})))]
+        (is (= 403 (:status resp)))))))

--- a/backend/test/gpml/handler/resource_test.clj
+++ b/backend/test/gpml/handler/resource_test.clj
@@ -36,7 +36,8 @@
    :country (-> (:countries data) first :id)
    :tags (:tags data)
    :url "resource url"
-   :owners (:owners data)})
+   :owners (:owners data)
+   :language "en"})
 
 (defn fake-upload-blob [_ _ _ content-type]
   (is (= content-type "image/png")))

--- a/backend/test/gpml/handler/submission_test.clj
+++ b/backend/test/gpml/handler/submission_test.clj
@@ -56,7 +56,8 @@
                                     :city nil
                                     :image nil
                                     :geo_coverage_type "global"
-                                    :created_by (:id user_justin)})
+                                    :created_by (:id user_justin)
+                                    :language "en"})
 
           ;; Jane trying to see the list of submission user in this case Nick
           resp (handler (-> (mock/request :get "/")

--- a/backend/test/gpml/handler/technology_test.clj
+++ b/backend/test/gpml/handler/technology_test.clj
@@ -28,7 +28,8 @@
    :document_preview false
    :year_founded 2021
    :tags (:tags data)
-   :owners (or (:owners data) [])})
+   :owners (or (:owners data) [])
+   :language "en"})
 
 (deftest handler-post-test
   (testing "New technology is created"


### PR DESCRIPTION
This PR contains:

- Fix language of imported policies from LEAP API, hardcoding default (original) language to english. Right now the content we get can only be (fully) in english, so in the future we will manage translations and save content in different languages.
- Make sure all the resource types have "language" property (mandatory for new resources;  "english" should be the default value for existing ones; it's the original resource language).
- Support resource translation system in DB model.
- Implement resource translations related endpoints (more details in the related Trello card).
- Fix permissions check for Update and Delete resources (`/api/detail/{topic-type}/{topic-id}` PUT and DELETE endpoints).
  This fix is registered in issue #1428 but it has been included here, since the refactor needed for issue #1422 would provide a fix.
  
  NOTE: In order to merge this, FE will need to send the "language" property whenever a resource is created.