### PR TITLE
[#1431] Add capacity_building flag to resources

### DIFF
--- a/backend/resources/migrations/169-add-capacity-building-to-resources.up.sql
+++ b/backend/resources/migrations/169-add-capacity-building-to-resources.up.sql
@@ -1,0 +1,46 @@
+BEGIN;
+--;;
+-- Add new property capacity building for those resources that
+-- don't have it.
+ALTER TABLE initiative
+ADD COLUMN capacity_building BOOLEAN NOT NULL DEFAULT FALSE;
+--;;
+ALTER TABLE policy
+ADD COLUMN capacity_building BOOLEAN NOT NULL DEFAULT FALSE;
+--;;
+ALTER TABLE technology
+ADD COLUMN capacity_building BOOLEAN NOT NULL DEFAULT FALSE;
+--;;
+-- Update existing resources that have the `capacity building` tag to
+-- have the `capacity_buidling` flag set to `true`.
+UPDATE resource r
+SET capacity_building = TRUE
+FROM resource_tag rt
+JOIN tag t ON t.id = rt.tag
+WHERE r.id = rt.resource AND t.tag = 'capacity building';
+--;;
+UPDATE policy p
+SET capacity_building = TRUE
+FROM policy_tag pt
+JOIN tag t ON t.id = pt.tag
+WHERE p.id = pt.policy AND t.tag = 'capacity building';
+--;;
+UPDATE initiative i
+SET capacity_building = TRUE
+FROM initiative_tag it
+JOIN tag t ON t.id = it.tag
+WHERE i.id = it.initiative AND t.tag = 'capacity building';
+--;;
+UPDATE technology te
+SET capacity_building = TRUE
+FROM technology_tag tt
+JOIN tag t ON t.id = tt.tag
+WHERE te.id = tt.technology AND t.tag = 'capacity building';
+--;;
+UPDATE event e
+SET capacity_building = TRUE
+FROM event_tag et
+JOIN tag t ON t.id = et.tag
+WHERE e.id = et.event AND t.tag = 'capacity building';
+--;;
+COMMIT;

--- a/backend/src/gpml/handler/browse.clj
+++ b/backend/src/gpml/handler/browse.clj
@@ -5,22 +5,24 @@
             [gpml.db.country-group :as db.country-group]
             [gpml.db.resource.connection :as db.resource.connection]
             [gpml.db.topic :as db.topic]
+            [gpml.util.postgresql :as pg-util]
             [gpml.util.regular-expressions :as util.regex]
             [integrant.core :as ig]
-            [ring.util.response :as resp]))
+            [ring.util.response :as resp])
+  (:import [java.sql SQLException]))
 
 (def ^:const topic-re (util.regex/comma-separated-enums-re topics))
-(def ^:const order-by-fields ["title" "description" "id"])
-(def ^:const default-limit 50)
-(def ^:const default-offset 0)
+(def ^:const ^:private order-by-fields ["title" "description" "id"])
+(def ^:const ^:private default-limit 50)
+(def ^:const ^:private default-offset 0)
 
-(def query-params
+(def ^:private query-params
   [:map
    [:country {:optional true
               :swagger {:description "Comma separated list of country id"
                         :type "string"
                         :collectionFormat "csv"
-                        :allowEmptyValue true}}
+                        :allowEmptyValue false}}
     [:or
      [:string {:max 0}]
      [:re util.regex/comma-separated-numbers-re]]]
@@ -28,7 +30,7 @@
                     :swagger {:description "Comma separated list of transnational id"
                               :type "string"
                               :collectionFormat "csv"
-                              :allowEmptyValue true}}
+                              :allowEmptyValue false}}
     [:or
      [:string {:max 0}]
      [:re util.regex/comma-separated-numbers-re]]]
@@ -36,7 +38,7 @@
             :swagger {:description (format "Comma separated list of topics to filter: %s" (str/join "," topics))
                       :type "string"
                       :collectionFormat "csv"
-                      :allowEmptyValue true}}
+                      :allowEmptyValue false}}
     [:or
      [:string {:max 0}]
      [:re topic-re]]]
@@ -44,24 +46,24 @@
           :swagger {:description "Comma separated list of tags"
                     :type "string"
                     :collectionFormat "csv"
-                    :allowEmptyValue true}}
+                    :allowEmptyValue false}}
     string?]
    [:q {:optional true
         :swagger {:description "Text search term to be found on the different topics"
                   :type "string"
-                  :allowEmptyValue true}}
+                  :allowEmptyValue false}}
     [:string]]
    [:favorites {:optional true
                 :error/message "Favorites should be 'true' or 'false'"
                 :swagger {:description "Flag to return only favorited items"
                           :type "boolean"
-                          :allowEmptyValue true}}
+                          :allowEmptyValue false}}
     [:boolean]]
    [:startDate {:optional true
                 :error/message "startDate should be in the ISO 8601 format i.e.: YYYY-MM-DD"
                 :swagger {:description "Events startDate in the format of ISO 8601 i.e.: YYYY-MM-DD"
                           :type "string"
-                          :allowEmptyValue true}}
+                          :allowEmptyValue false}}
     [:or
      [:string {:max 0}]
      [:re util.regex/date-iso-8601-re]]]
@@ -69,34 +71,34 @@
               :error/message "endDate should be in the ISO 8601 format i.e.: YYYY-MM-DD"
               :swagger {:description "Events endDate in the format of ISO 8601 i.e.: YYYY-MM-DD"
                         :type "string"
-                        :allowEmptyValue true}}
+                        :allowEmptyValue false}}
     [:or
      [:string {:max 0}]
      [:re util.regex/date-iso-8601-re]]]
    [:representativeGroup {:optional true
                           :swagger {:description "Comma separated list of representative groups"
                                     :type "string"
-                                    :allowEmptyValue true}}
+                                    :allowEmptyValue false}}
     string?]
    [:affiliation {:optional true
                   :swagger {:description "Comma separated list of affiliation ids (i.e., organisation ids)"
                             :type "string"
-                            :allowEmptyValue true}}
+                            :allowEmptyValue false}}
     string?]
    [:subContentType {:optional true
                      :swagger {:description "Comma separated list of a topic's subContentTypes"
                                :type "string"
-                               :allowEmptyValue true}}
+                               :allowEmptyValue false}}
     string?]
    [:entity {:optional true
              :swagger {:description "Comma separated list of entity IDs"
                        :type "string"
-                       :allowEmptyValue true}}
+                       :allowEmptyValue false}}
     string?]
    [:orderBy {:optional true
               :swagger {:description "One of the following properties to order the list of results: title, description, id"
                         :type "string"
-                        :allowEmptyValue true}}
+                        :allowEmptyValue false}}
     (apply vector :enum order-by-fields)]
    [:incCountsForTags {:optional true
                        :swagger {:description "Includes the counts for the specified tags which is a comma separated list of approved tags."
@@ -105,29 +107,36 @@
    [:descending {:optional true
                  :swagger {:description "Order results in descending order: true or false"
                            :type "boolean"
-                           :allowEmptyValue true}}
+                           :allowEmptyValue false}}
     [:boolean]]
    [:limit {:optional true
             :swagger {:description "Limit the number of entries per page"
                       :type "int"
-                      :allowEmptyValue true}}
+                      :allowEmptyValue false}}
     [:int {:min 0 :max 100}]]
    [:offset {:optional true
              :swagger {:description "Number of items to skip when fetching entries"
                        :type "int"
-                       :allowEmptyValue true}}
+                       :allowEmptyValue false}}
     [:int {:min 0}]]
    [:featured {:optional true
                :error/message "Featured should be 'true' or 'false'"
                :swagger {:description "Boolean flag to filter by featured resources"
                          :type "boolean"
-                         :allowEmptyValue true}}
+                         :allowEmptyValue false}}
+    boolean?]
+   [:capacity_building {:optional true
+                        :error/message "'capacity_building' should be 'true' or 'false'"
+                        :swagger {:description "Boolean flag to filter by capacity building resources"
+                                  :type "boolean"
+                                  :allowEmptyValue false}}
     boolean?]])
 
 (defn get-db-filter
+  "Transforms API query parameters into a map of database filters."
   [{:keys [limit offset startDate endDate user-id favorites country transnational
            topic tag affiliation representativeGroup subContentType entity orderBy
-           descending q incCountsForTags featured]
+           descending q incCountsForTags featured capacity_building]
     :or {limit default-limit
          offset default-offset}}]
   (cond-> {}
@@ -185,12 +194,17 @@
                              (re-seq #"\w+")
                              (str/join " & ")))
 
-    featured (assoc :featured featured)
+    featured
+    (assoc :featured featured)
+
+    capacity_building
+    (assoc :capacity-building capacity_building)
 
     true
     (assoc :review-status "APPROVED")))
 
-(defn- result->result-with-connections [db {:keys [type] :as result}]
+(defn- result->result-with-connections
+  [db {:keys [type] :as result}]
   (let [resource-type (cond
                         (some #{type} resource-types)
                         "resource"
@@ -207,68 +221,79 @@
          (db.resource.connection/get-resource-stakeholder-connections db)
          (assoc result :stakeholder_connections))))
 
-(defn browse-response
+(defn- browse-response
   [{:keys [logger] {db :spec} :db} query approved? admin]
-  (let [{:keys [geo-coverage transnational] :as modified-filters} (->> query
-                                                                       (get-db-filter)
-                                                                       (merge {:approved approved?
-                                                                               :admin admin}))
-        modified-filters (cond
-                           (and (seq geo-coverage) (seq transnational))
-                           (let [country-group-countries (flatten
-                                                          (conj
-                                                           (map #(db.country-group/get-country-group-countries
-                                                                  db {:id %})
-                                                                (:transnational modified-filters))))
-                                 geo-coverage-countries (map :id country-group-countries)
-                                 transnational (->> (map #(db.country-group/get-country-groups-by-country db {:id %}) (:geo-coverage modified-filters))
-                                                    (apply concat)
-                                                    (map :id)
-                                                    set)]
-                             (assoc modified-filters :geo-coverage-countries (set (concat geo-coverage-countries geo-coverage))
-                                    :transnational transnational))
+  (try
+    (let [{:keys [geo-coverage transnational] :as modified-filters} (->> query
+                                                                         (get-db-filter)
+                                                                         (merge {:approved approved?
+                                                                                 :admin admin}))
+          modified-filters (cond
+                             (and (seq geo-coverage) (seq transnational))
+                             (let [country-group-countries (flatten
+                                                            (conj
+                                                             (map #(db.country-group/get-country-group-countries
+                                                                    db {:id %})
+                                                                  (:transnational modified-filters))))
+                                   geo-coverage-countries (map :id country-group-countries)
+                                   transnational (->> (map #(db.country-group/get-country-groups-by-country db {:id %}) (:geo-coverage modified-filters))
+                                                      (apply concat)
+                                                      (map :id)
+                                                      set)]
+                               (assoc modified-filters :geo-coverage-countries (set (concat geo-coverage-countries geo-coverage))
+                                      :transnational transnational))
 
-                           (seq geo-coverage)
-                           (let [transnational (->> (map #(db.country-group/get-country-groups-by-country db {:id %}) (:geo-coverage modified-filters))
-                                                    (apply concat)
-                                                    (map :id)
-                                                    set)]
-                             (assoc modified-filters :transnational transnational))
+                             (seq geo-coverage)
+                             (let [transnational (->> (map #(db.country-group/get-country-groups-by-country db {:id %}) (:geo-coverage modified-filters))
+                                                      (apply concat)
+                                                      (map :id)
+                                                      set)]
+                               (assoc modified-filters :transnational transnational))
 
-                           (seq transnational)
-                           (let [country-group-countries (flatten
-                                                          (conj
-                                                           (map #(db.country-group/get-country-group-countries
-                                                                  db {:id %})
-                                                                (:transnational modified-filters))))
-                                 geo-coverage-countries (map :id country-group-countries)]
-                             (assoc modified-filters :geo-coverage-countries (set geo-coverage-countries)))
-                           :else
-                           modified-filters)
-        get-topics-start-time (System/currentTimeMillis)
-        results (->> modified-filters
-                     (db.topic/get-topics db)
-                     (map (fn [{:keys [json topic]}]
-                            (assoc json :type topic))))
-        get-topics-exec-time (- (System/currentTimeMillis) get-topics-start-time)
-        count-topics-start-time (System/currentTimeMillis)
-        counts (->> (assoc modified-filters :count-only? true)
-                    (db.topic/get-topics db))
-        count-topics-exec-time (- (System/currentTimeMillis) count-topics-start-time)]
-    (log logger :info ::query-exec-time {:get-topics-exec-time (str get-topics-exec-time "ms")
-                                         :count-topics-exec-time (str count-topics-exec-time "ms")})
-    {:results (map #(result->result-with-connections db %) results)
-     :counts counts}))
+                             (seq transnational)
+                             (let [country-group-countries (flatten
+                                                            (conj
+                                                             (map #(db.country-group/get-country-group-countries
+                                                                    db {:id %})
+                                                                  (:transnational modified-filters))))
+                                   geo-coverage-countries (map :id country-group-countries)]
+                               (assoc modified-filters :geo-coverage-countries (set geo-coverage-countries)))
+                             :else
+                             modified-filters)
+          get-topics-start-time (System/currentTimeMillis)
+          results (->> modified-filters
+                       (db.topic/get-topics db)
+                       (map (fn [{:keys [json topic]}]
+                              (assoc json :type topic))))
+          get-topics-exec-time (- (System/currentTimeMillis) get-topics-start-time)
+          count-topics-start-time (System/currentTimeMillis)
+          counts (->> (assoc modified-filters :count-only? true)
+                      (db.topic/get-topics db))
+          count-topics-exec-time (- (System/currentTimeMillis) count-topics-start-time)]
+      (log logger :info ::query-exec-time {:get-topics-exec-time (str get-topics-exec-time "ms")
+                                           :count-topics-exec-time (str count-topics-exec-time "ms")})
+      (resp/response {:success? true
+                      :results (map #(result->result-with-connections db %) results)
+                      :counts counts}))
+    (catch Exception e
+      (log logger :error :failed-to-get-topics {:exception-message (.getMessage e)
+                                                :context-data {:query-params query}})
+      (let [response {:status 500
+                      :body {:success? false
+                             :reason :could-not-get-topics}}]
+        (if (instance? SQLException e)
+          (assoc-in response [:body :error-details :error] (pg-util/get-sql-state e))
+          (assoc-in response [:body :error-details :error] (.getMessage e)))))))
 
 (defmethod ig/init-key :gpml.handler.browse/get [_ config]
   (fn [{{:keys [query]} :parameters
         approved? :approved?
         user :user}]
-    (resp/response (#'browse-response
-                    config
-                    (merge query {:user-id (:id user)})
-                    approved?
-                    (= "ADMIN" (:role user))))))
+    (#'browse-response
+     config
+     (merge query {:user-id (:id user)})
+     approved?
+     (= "ADMIN" (:role user)))))
 
 (defmethod ig/init-key :gpml.handler.browse/query-params [_ _]
   query-params)

--- a/backend/src/gpml/handler/resource.clj
+++ b/backend/src/gpml/handler/resource.clj
@@ -20,7 +20,7 @@
             [ring.util.response :as resp])
   (:import [java.sql SQLException]))
 
-(defn expand-entity-associations
+(defn- expand-entity-associations
   [entity-connections resource-id]
   (vec (for [connection entity-connections]
          {:column_name "resource"
@@ -30,7 +30,7 @@
           :association (:role connection)
           :remarks nil})))
 
-(defn expand-individual-associations
+(defn- expand-individual-associations
   [individual-connections resource-id]
   (vec (for [connection individual-connections]
          {:column_name "resource"
@@ -40,7 +40,7 @@
           :association (:role connection)
           :remarks nil})))
 
-(defn create-resource
+(defn- create-resource
   [conn logger mailjet-config
    {:keys [resource_type title publish_year
            summary value value_currency
@@ -51,34 +51,37 @@
            attachments country urls tags remarks thumbnail
            created_by url owners info_docs sub_content_type related_content
            first_publication_date latest_amendment_date document_preview
-           entity_connections individual_connections language]}]
-  (let [data {:type resource_type
-              :title title
-              :publish_year publish_year
-              :summary summary
-              :value value
-              :value_currency value_currency
-              :value_remarks value_remarks
-              :valid_from valid_from
-              :valid_to valid_to
-              :image (handler.image/assoc-image conn image "resource")
-              :thumbnail (handler.image/assoc-image conn thumbnail "resource")
-              :geo_coverage_type geo_coverage_type
-              :geo_coverage_value geo_coverage_value
-              :geo_coverage_countries geo_coverage_countries
-              :geo_coverage_country_groups geo_coverage_country_groups
-              :subnational_city geo_coverage_value_subnational_city
-              :country country
-              :attachments attachments
-              :remarks remarks
-              :created_by created_by
-              :url url
-              :info_docs info_docs
-              :sub_content_type sub_content_type
-              :first_publication_date first_publication_date
-              :latest_amendment_date latest_amendment_date
-              :document_preview document_preview
-              :language language}
+           entity_connections individual_connections language
+           capacity_building]}]
+  (let [data (cond-> {:type resource_type
+                      :title title
+                      :publish_year publish_year
+                      :summary summary
+                      :value value
+                      :value_currency value_currency
+                      :value_remarks value_remarks
+                      :valid_from valid_from
+                      :valid_to valid_to
+                      :image (handler.image/assoc-image conn image "resource")
+                      :thumbnail (handler.image/assoc-image conn thumbnail "resource")
+                      :geo_coverage_type geo_coverage_type
+                      :geo_coverage_value geo_coverage_value
+                      :geo_coverage_countries geo_coverage_countries
+                      :geo_coverage_country_groups geo_coverage_country_groups
+                      :subnational_city geo_coverage_value_subnational_city
+                      :country country
+                      :attachments attachments
+                      :remarks remarks
+                      :created_by created_by
+                      :url url
+                      :info_docs info_docs
+                      :sub_content_type sub_content_type
+                      :first_publication_date first_publication_date
+                      :latest_amendment_date latest_amendment_date
+                      :document_preview document_preview
+                      :language language}
+               (not (nil? capacity_building))
+               (assoc :capacity_building capacity_building))
         resource-id (:id (db.resource/new-resource conn data))
         api-individual-connections (handler.util/individual-connections->api-individual-connections conn individual_connections created_by)
         owners (distinct (remove nil? (flatten (conj owners
@@ -151,12 +154,7 @@
             response
             (assoc-in response [:body :error-details :error] (.getMessage e))))))))
 
-(defn or-and [resource_type validator]
-  (or (= "Action Plan" resource_type)
-      (and (= "Technical Resource" resource_type) (empty? validator))
-      (and (= "Financing Resource" resource_type) (some? validator))))
-
-(def post-params
+(def ^:private post-params
   [:and
    (into [:map
           [:resource_type

--- a/backend/src/gpml/handler/technology.clj
+++ b/backend/src/gpml/handler/technology.clj
@@ -20,7 +20,7 @@
             [ring.util.response :as resp])
   (:import [java.sql SQLException]))
 
-(defn expand-entity-associations
+(defn- expand-entity-associations
   [entity-connections resource-id]
   (vec (for [connection entity-connections]
          {:column_name "technology"
@@ -30,7 +30,7 @@
           :association (:role connection)
           :remarks nil})))
 
-(defn expand-individual-associations
+(defn- expand-individual-associations
   [individual-connections resource-id]
   (vec (for [connection individual-connections]
          {:column_name "technology"
@@ -40,44 +40,48 @@
           :association (:role connection)
           :remarks nil})))
 
-(defn create-technology [conn logger mailjet-config
-                         {:keys [name organisation_type
-                                 development_stage specifications_provided
-                                 year_founded email country
-                                 geo_coverage_type geo_coverage_value
-                                 geo_coverage_countries geo_coverage_country_groups
-                                 geo_coverage_value_subnational_city
-                                 tags url urls created_by image owners info_docs
-                                 sub_content_type related_content
-                                 headquarter document_preview
-                                 logo thumbnail attachments remarks
-                                 entity_connections individual_connections language]}]
-  (let [data {:name name
-              :year_founded year_founded
-              :organisation_type organisation_type
-              :development_stage development_stage
-              :specifications_provided specifications_provided
-              :email email
-              :url url
-              :country country
-              :image (handler.image/assoc-image conn image "technology")
-              :logo (handler.image/assoc-image conn logo "technology")
-              :thumbnail (handler.image/assoc-image conn thumbnail "technology")
-              :geo_coverage_type geo_coverage_type
-              :geo_coverage_value geo_coverage_value
-              :geo_coverage_countries geo_coverage_countries
-              :geo_coverage_country_groups geo_coverage_country_groups
-              :subnational_city geo_coverage_value_subnational_city
-              :remarks remarks
-              :attachments attachments
-              :created_by created_by
-              :owners owners
-              :info_docs info_docs
-              :sub_content_type sub_content_type
-              :headquarter headquarter
-              :document_preview document_preview
-              :review_status "SUBMITTED"
-              :language language}
+(defn- create-technology
+  [conn logger mailjet-config
+   {:keys [name organisation_type
+           development_stage specifications_provided
+           year_founded email country
+           geo_coverage_type geo_coverage_value
+           geo_coverage_countries geo_coverage_country_groups
+           geo_coverage_value_subnational_city
+           tags url urls created_by image owners info_docs
+           sub_content_type related_content
+           headquarter document_preview
+           logo thumbnail attachments remarks
+           entity_connections individual_connections language
+           capacity_building]}]
+  (let [data (cond-> {:name name
+                      :year_founded year_founded
+                      :organisation_type organisation_type
+                      :development_stage development_stage
+                      :specifications_provided specifications_provided
+                      :email email
+                      :url url
+                      :country country
+                      :image (handler.image/assoc-image conn image "technology")
+                      :logo (handler.image/assoc-image conn logo "technology")
+                      :thumbnail (handler.image/assoc-image conn thumbnail "technology")
+                      :geo_coverage_type geo_coverage_type
+                      :geo_coverage_value geo_coverage_value
+                      :geo_coverage_countries geo_coverage_countries
+                      :geo_coverage_country_groups geo_coverage_country_groups
+                      :subnational_city geo_coverage_value_subnational_city
+                      :remarks remarks
+                      :attachments attachments
+                      :created_by created_by
+                      :owners owners
+                      :info_docs info_docs
+                      :sub_content_type sub_content_type
+                      :headquarter headquarter
+                      :document_preview document_preview
+                      :review_status "SUBMITTED"
+                      :language language}
+               (not (nil? capacity_building))
+               (assoc :capacity_building capacity_building))
         technology-id (->> data (db.technology/new-technology conn) :id)
         api-individual-connections (handler.util/individual-connections->api-individual-connections conn individual_connections created_by)
         owners (distinct (remove nil? (flatten (conj owners
@@ -146,7 +150,7 @@
             response
             (assoc-in response [:body :error-details :error] (.getMessage e))))))))
 
-(def post-params
+(def ^:private post-params
   (into [:map
          [:name string?]
          [:year_founded {:optional true} integer?]
@@ -195,6 +199,7 @@
           [:vector {:optional true}
            [:map [:lang string?] [:url [:string {:min 1}]]]]]
          [:language string?]
+         [:capacity_building {:optional true} boolean?]
          auth/owners-schema]
         handler.geo/params-payload))
 


### PR DESCRIPTION
* We want to flag resources as 'capacity building' when
required. Previously only Events and Resources had this flag. Now we
are expanding it to all resources.
* This didn't exist in the following resources: Initiative, Policy and
Technology.
* Updated browse API to implement the 'capacity_building' filter.
* Updated browse API to handle errors.
* Updated landing API to implement the 'capacity_building' filter.
* Cleaned up the places where I touched with linting warnings.
* Closes #1431