### PR TITLE
Fix get translation endpoint permissions

### DIFF
--- a/backend/src/gpml/handler/resource/translation.clj
+++ b/backend/src/gpml/handler/resource/translation.clj
@@ -168,7 +168,6 @@
                                                                        (handler.util/get-internal-topic-type topic-type)
                                                                        topic-id
                                                                        {:read? false}))]
-        (prn "hey")
         (if authorized?
           (let [conn (:spec db)
                 resource-col (keyword (str topic-type translation-entity-id-sufix))

--- a/backend/src/gpml/handler/resource/translation.clj
+++ b/backend/src/gpml/handler/resource/translation.clj
@@ -211,7 +211,7 @@
 
 (defmethod ig/init-key :gpml.handler.resource.translation/get
   [_ {:keys [db logger]}]
-  (fn [{{:keys [path query]} :parameters approved? :approved? user :user}]
+  (fn [{{:keys [path query]} :parameters user :user}]
     (try
       (let [conn (:spec db)
             topic-type (:topic-type path)

--- a/backend/src/gpml/handler/resource/translation.clj
+++ b/backend/src/gpml/handler/resource/translation.clj
@@ -219,12 +219,11 @@
             resource-col (keyword (str topic-type translation-entity-id-sufix))
             topic-id (:topic-id path)
             langs-only? (:langs-only query)
-            authorized? (and approved?
-                             (some? (res-permission/get-resource-if-allowed conn
-                                                                            user
-                                                                            (handler.util/get-internal-topic-type topic-type)
-                                                                            topic-id
-                                                                            {:read? true})))]
+            authorized? (some? (res-permission/get-resource-if-allowed conn
+                                                                       user
+                                                                       (handler.util/get-internal-topic-type topic-type)
+                                                                       topic-id
+                                                                       {:read? true}))]
         (if authorized?
           (let [table-name (str topic-type translation-table-sufix)
                 result (if langs-only?


### PR DESCRIPTION
* Read operations on approved resources is public. We don't
need to check if the user is approved. In this case, the user may be or
not there depending if it's logged in or not. That is why we get
unauthorized when calling the API with a user that is not logged in
or not approved.