### PR TITLE
Fix browse and landing API resource count bugs

### DIFF
--- a/backend/src/gpml/db/country-group.sql
+++ b/backend/src/gpml/db/country-group.sql
@@ -61,22 +61,16 @@ select * from country_group where type = :type
 insert into country_group_country (country_group, country)
 values(:country_group, :country)
 
--- :name get-country-groups-by-country :? :*
--- :doc get country groups by country-id
-select country_group.id, country_group.name from country_group
-left join country_group_country on country_group_country.country_group= country_group.id
-where country_group_country.country= :id
-
--- FIXME: we should deprecate this function in favor of `get-country-groups-countries`
--- :name get-country-group-countries :? :*
--- :doc get country group countries by country group id
-select cgc.country as id from country_group_country cgc
-left join country_group cg on cgc.country_group = cg.id
-where 1=1
-
 -- :name get-country-groups-countries :query :many
 -- :doc Get country groups countries by country groups ids.
 SELECT cgc.country AS id
 FROM country_group_country cgc
 LEFT JOIN country_group cg ON cgc.country_group = cg.id
 WHERE cg.id IN (:v*:filters.country-groups)
+
+-- :name get-country-groups-by-countries
+-- :doc Get country-group countries by countries ids.
+SELECT cg.id, cg.name
+FROM country_group cg
+LEFT JOIN country_group_country cgc ON cgc.country_group= cg.id
+WHERE cgc.country IN (:v*:filters.countries-ids);

--- a/backend/src/gpml/db/landing.clj
+++ b/backend/src/gpml/db/landing.clj
@@ -43,7 +43,7 @@
                                "")]
     (apply
      format
-     "SELECT DISTINCT ON (cgc.country_group, e.id) cgc.country_group AS country_group_id,
+     "SELECT DISTINCT ON (e.id) cgc.country_group AS country_group_id,
 	     %s AS entity,
              COUNT(e.id) entity_count
       FROM %s_geo_coverage egc
@@ -51,7 +51,7 @@
       LEFT JOIN country_group_country cgc ON egc.country = cgc.country
       OR egc.country_group = cgc.country_group
       WHERE e.review_status = 'APPROVED' %s
-      GROUP BY cgc.country_group, e.id, cgc.country %s"
+      GROUP BY cgc.country_group, e.id %s"
      (flatten [entity-name-select-clause
                (repeat 3 entity-name-from-clause)
                where-cond extra-group-by-field]))))

--- a/backend/src/gpml/handler/browse.clj
+++ b/backend/src/gpml/handler/browse.clj
@@ -230,32 +230,26 @@
                                                                                  :admin admin}))
           modified-filters (cond
                              (and (seq geo-coverage) (seq transnational))
-                             (let [country-group-countries (flatten
-                                                            (conj
-                                                             (map #(db.country-group/get-country-group-countries
-                                                                    db {:id %})
-                                                                  (:transnational modified-filters))))
+                             (let [opts {:filters {:country-groups (:transnational modified-filters)
+                                                   :countries-ids (:geo-coverage modified-filters)}}
+                                   country-group-countries (db.country-group/get-country-groups-countries db opts)
                                    geo-coverage-countries (map :id country-group-countries)
-                                   transnational (->> (map #(db.country-group/get-country-groups-by-country db {:id %}) (:geo-coverage modified-filters))
-                                                      (apply concat)
+                                   transnational (->> (db.country-group/get-country-groups-by-countries db opts)
                                                       (map :id)
                                                       set)]
                                (assoc modified-filters :geo-coverage-countries (set (concat geo-coverage-countries geo-coverage))
                                       :transnational transnational))
 
                              (seq geo-coverage)
-                             (let [transnational (->> (map #(db.country-group/get-country-groups-by-country db {:id %}) (:geo-coverage modified-filters))
-                                                      (apply concat)
+                             (let [opts {:filters {:countries-ids (:geo-coverage modified-filters)}}
+                                   transnational (->> (db.country-group/get-country-groups-by-countries db opts)
                                                       (map :id)
                                                       set)]
                                (assoc modified-filters :transnational transnational))
 
                              (seq transnational)
-                             (let [country-group-countries (flatten
-                                                            (conj
-                                                             (map #(db.country-group/get-country-group-countries
-                                                                    db {:id %})
-                                                                  (:transnational modified-filters))))
+                             (let [opts {:filters {:country-groups (:transnational modified-filters)}}
+                                   country-group-countries (db.country-group/get-country-groups-countries db opts)
                                    geo-coverage-countries (map :id country-group-countries)]
                                (assoc modified-filters :geo-coverage-countries (set geo-coverage-countries)))
                              :else

--- a/backend/src/gpml/handler/community.clj
+++ b/backend/src/gpml/handler/community.clj
@@ -167,10 +167,8 @@
   (let [conn (:spec db)
         opts (api-params->opts query-params)
         modified-filters (if (get-in opts [:filters :transnational])
-                           (let [country-group-countries (flatten
-                                                          (map #(db.country-group/get-country-group-countries
-                                                                 conn {:id %})
-                                                               (get-in opts [:filters :transnational])))
+                           (let [opts {:filters {:country-groups (get-in opts [:filters :transnational])}}
+                                 country-group-countries (db.country-group/get-country-groups-countries conn opts)
                                  geo-coverage-countries (map :id country-group-countries)]
                              (assoc-in opts [:filters :country] (set (concat
                                                                       (get-in opts [:filters :country])

--- a/backend/src/gpml/handler/landing.clj
+++ b/backend/src/gpml/handler/landing.clj
@@ -167,10 +167,8 @@
 
 (defn- landing-response [conn query]
   (let [opts (api-opts->opts query)
-        modified-opts (let [country-group-countries (->> (get opts :transnational)
-                                                         (map #(db.country-group/get-country-group-countries
-                                                                conn {:id %}))
-                                                         (apply concat))
+        modified-opts (let [opts {:filters {:country-groups (get opts :transnational)}}
+                            country-group-countries (db.country-group/get-country-groups-countries opts)
                             geo-coverage-countries (map :id country-group-countries)]
                         (assoc opts :geo-coverage (set (concat
                                                         (get opts :geo-coverage)

--- a/backend/src/gpml/handler/landing.clj
+++ b/backend/src/gpml/handler/landing.clj
@@ -167,12 +167,14 @@
 
 (defn- landing-response [conn query]
   (let [opts (api-opts->opts query)
-        modified-opts (let [opts {:filters {:country-groups (get opts :transnational)}}
-                            country-group-countries (db.country-group/get-country-groups-countries opts)
-                            geo-coverage-countries (map :id country-group-countries)]
-                        (assoc opts :geo-coverage (set (concat
-                                                        (get opts :geo-coverage)
-                                                        geo-coverage-countries))))
+        modified-opts (if-not (seq (get opts :transnational))
+                        opts
+                        (let [opts {:filters {:country-groups (get opts :transnational)}}
+                              country-group-countries (db.country-group/get-country-groups-countries opts)
+                              geo-coverage-countries (map :id country-group-countries)]
+                          (assoc opts :geo-coverage (set (concat
+                                                          (get opts :geo-coverage)
+                                                          geo-coverage-countries)))))
         summary-data (->> (gpml.db.landing/summary conn)
                           (mapv (fn [{:keys [resource_type count country_count]}]
                                   {(keyword resource_type) count :countries country_count})))]

--- a/backend/test/gpml/db/landing_test.clj
+++ b/backend/test/gpml/db/landing_test.clj
@@ -112,26 +112,8 @@
         4 "financing_resource"
         0 "event"))))
 
-(def spanish {:country 2
-              :geo_coverage_type "national"
-              :geo_coverage_value [1]})
-
-(def india {:country 2
-            :geo_coverage_type "national"
-            :geo_coverage_value [2]})
-
-(def asia {:geo_coverage_type "regional" :geo_coverage_value [1]})
-
-(def approved {:review_status "APPROVED"})
-
-(defn org [& org-data]
-  (apply merge
-         {:name (str "org" (fixtures/uuid))
-          :review_status "SUBMITTED"}
-         org-data))
-
-(defn get-country-group-ids [db country-id]
-  (db.country-group/get-country-groups-by-country db {:id country-id}))
+(defn- get-country-group-ids [db country-id]
+  (db.country-group/get-country-groups-by-countries db {:filters {:countries-ids [country-id]}}))
 
 (deftest landing-counts
   (let [db-key :duct.database.sql/hikaricp

--- a/backend/test/gpml/db/topic_test.clj
+++ b/backend/test/gpml/db/topic_test.clj
@@ -47,7 +47,7 @@
        (map :id)))
 
 (defn get-country-group-ids [db country-id]
-  (db.country-group/get-country-groups-by-country db {:id country-id}))
+  (db.country-group/get-country-groups-by-countries db {:filters {:countries-ids [country-id]}}))
 
 ;; TODO: Extend the tests to include filtering by `featured` flag of resources
 (deftest topic-filtering


### PR DESCRIPTION
* Browse API was handling the country groups and countries count wrong
because we were retrieving their values wrongly.
* Landing API was counting the transnationals wrong because it was
considering duplicate values.