### PR TITLE
Refactor landing API to simplify resource map count

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -254,7 +254,7 @@
                                           {:get {:summary "End-point for the landing page"
                                                  :middleware [#ig/ref :gpml.auth/auth-middleware]
                                                  :swagger {:tags ["landing"]}
-                                                 :parameters {:query #ig/ref :gpml.handler.landing/get-query-params}
+                                                 :parameters #ig/ref :gpml.handler.landing/get-query-params
                                                  :handler #ig/ref :gpml.handler.landing/get}}]]
                                         ["/nav"
                                          [""
@@ -631,7 +631,7 @@
   :gpml.handler.review/list-user-reviews-params {}
   :gpml.handler.review/review-status-params {}
 
-  :gpml.handler.landing/get {:db #ig/ref :duct.database/sql}
+  :gpml.handler.landing/get #ig/ref :gpml.config/common
   :gpml.handler.landing/get-query-params {}
   :gpml.handler.nav/get {:db #ig/ref :duct.database/sql}
 

--- a/backend/src/gpml/db/landing.clj
+++ b/backend/src/gpml/db/landing.clj
@@ -9,108 +9,39 @@
 (def ^:const ^:private non-transnational-geo-coverage-types ["regional" "national" "sub-national"])
 (def ^:const ^:private transnational-geo-coverage-types ["transnational"])
 
-(declare map-counts map-counts-by-country-group summary)
+(declare map-counts summary)
 
 (hugsql/def-db-fns "gpml/db/landing.sql")
 
-(defn- entity-count-by-country-group-query
-  [entity-name]
-  (let [entity-name-select-clause (cond
-                                    (= entity-name "resource")
-                                    "REPLACE(LOWER(e.type), ' ', '_')"
-
-                                    ;;TODO: discuss initiative naming
-                                    ;;with FE team. Ideally we should
-                                    ;;stop using `project` name and
-                                    ;;use the real table name which is
-                                    ;;`initiative`.
-                                    (= entity-name "initiative")
-                                    "'project'"
-
-                                    :else
-                                    (str "'" entity-name "'"))
-        entity-name-from-clause (if (= entity-name "non_member_organisation")
-                                  "organisation"
-                                  entity-name)
-        where-cond (cond-> ""
-                     (= entity-name "non_member_organisation")
-                     (str " AND e.is_member IS FALSE")
-
-                     (= entity-name "organisation")
-                     (str " AND e.is_member IS TRUE"))
-        extra-group-by-field (if (= entity-name "resource")
-                               ", e.type"
-                               "")]
-    (apply
-     format
-     "SELECT DISTINCT ON (e.id) cgc.country_group AS country_group_id,
-	     %s AS entity,
-             COUNT(e.id) entity_count
-      FROM %s_geo_coverage egc
-      LEFT JOIN %s e ON e.id = egc.%s
-      LEFT JOIN country_group_country cgc ON egc.country = cgc.country
-      OR egc.country_group = cgc.country_group
-      WHERE e.review_status = 'APPROVED' %s
-      GROUP BY cgc.country_group, e.id %s"
-     (flatten [entity-name-select-clause
-               (repeat 3 entity-name-from-clause)
-               where-cond extra-group-by-field]))))
-
-(defn generate-entity-count-by-country-group-queries
-  [_ _]
-  (reduce (fn [acc entity]
-            (let [query (entity-count-by-country-group-query entity)]
-              (if (seq acc)
-                (str acc " UNION ALL " query)
-                query)))
-          ""
-          constants/geo-coverage-entity-tables))
-
-(def topic-counts
+(def ^:private default-topic-counts
   (->> constants/topics
        (map #(-> {}
                  (assoc-in [:counts (keyword %)] 0)
                  (assoc-in [:transnational_counts (keyword %)] 0)))
        (apply merge-with into)))
 
-(defn get-map-counts-by-country-group
-  "Get the entities count (i.e., Policy, Resource, Event, Organisation,
-  Stakeholder, etc.) by country group (Europe, African States, etc.)."
-  [conn]
-  (let [counts (map-counts-by-country-group conn {})
-        default-count-values (->> constants/topics
-                                  (map #(assoc-in {} [:counts (keyword %)] 0))
-                                  (apply merge-with into))]
-    (reduce (fn [acc counts]
-              (conj acc (merge-with into default-count-values counts)))
-            []
-            counts)))
-
-(defn map-counts-explicit
-  "Get the entities count (i.e., Policy, Resource, Event, Organisation,
-  Stakeholder, etc.) by country. The result of this
-  counting is grouped by countries."
+(defn- get-resource-map-counts*
   [conn opts]
-  (let [counts (map-counts conn (merge opts {:count-name "counts"}
-                                       (when (= :topic (:entity-group opts))
-                                         {:geo-coverage-types non-transnational-geo-coverage-types})))
-        transnational-counts-by-country (map-counts conn (merge opts {:geo-coverage-types transnational-geo-coverage-types
-                                                                      :count-name "transnational_counts"}))]
-    (reduce
-     (fn [acc [_ counts]]
-       (conj acc (merge-with into topic-counts (apply merge counts))))
-     []
-     (group-by :id (concat counts transnational-counts-by-country)))))
+  (let [modified-opts (if (= :topic (:entity-group opts))
+                        (merge opts {:geo-coverage-types (concat non-transnational-geo-coverage-types transnational-geo-coverage-types)})
+                        opts)
+        {:keys [country_counts transnational_counts country_group_counts]}
+        (:result (map-counts conn modified-opts))]
+    {:country_counts (reduce
+                      (fn [acc [_ counts]]
+                        (conj acc (merge-with into default-topic-counts (apply merge counts))))
+                      []
+                      (group-by :country_id (concat country_counts transnational_counts)))
+     :country_group_counts country_group_counts}))
 
-(defn remap-counts
-  [x]
-  (assoc (dissoc x :id) :country_id (:id x)))
-
-(defn map-counts-include-all-countries
+(defn get-resource-map-counts
+  "Returns a map with resource counts aggregated by country and country
+  group."
   [conn opts]
-  (let [counts (map-counts-explicit conn opts)
-        included-countries (->> counts (map :id) set)
+  (let [{:keys [country_counts country_group_counts]} (get-resource-map-counts* conn opts)
+        included-countries (->> country_counts (map :country_id) set)
         all-countries (->> (db.country/all-countries conn) (map :id) set)
         missing-countries (remove nil? (set/difference all-countries included-countries))
-        missing-counts (map #(merge {:id %} topic-counts) missing-countries)]
-    (map remap-counts (concat counts missing-counts))))
+        missing-counts (map #(merge {:country_id %} default-topic-counts) missing-countries)]
+    {:country_counts (concat country_counts missing-counts)
+     :country_group_counts country_group_counts}))

--- a/backend/src/gpml/db/landing.sql
+++ b/backend/src/gpml/db/landing.sql
@@ -10,7 +10,7 @@ filtered_entities AS (
 --~ (#'gpml.db.topic/generate-filter-topic-snippet params)
 ),
 transnational_counts_per_country AS (
-  SELECT cgc.country AS country_id,
+  SELECT DISTINCT ON (cgc.country) cgc.country AS country_id,
          topic,
          COUNT(topic) AS topic_count
   FROM filtered_entities
@@ -38,7 +38,7 @@ country_counts AS (
   FROM filtered_entities
   LEFT JOIN json_array_elements_text((json->>'geo_coverage_countries')::JSON) countries
   ON json->>'geo_coverage_countries' IS NOT NULL
-  WHERE (countries.value)::TEXT <> 'null' AND json->>'geo_coverage_type' != 'transnational'
+  WHERE (countries.value)::TEXT <> 'null'
   GROUP BY (countries.value)::TEXT::INT, topic
 /*~*/
   SELECT (json->>'country')::INT AS country_id, 'stakeholder' AS topic, COUNT(topic) AS topic_count

--- a/backend/src/gpml/db/landing.sql
+++ b/backend/src/gpml/db/landing.sql
@@ -1,4 +1,4 @@
--- :name map-counts :? :*
+-- :name map-counts :? :one
 -- :doc Gets the entity count per country.
 -- :require [gpml.db.topic]
 /*~ (if (= (:entity-group params) :topic)
@@ -9,49 +9,73 @@
 filtered_entities AS (
 --~ (#'gpml.db.topic/generate-filter-topic-snippet params)
 ),
-country_counts AS (
-  SELECT (countries.value)::TEXT::INT AS geo_coverage,
+transnational_counts_per_country AS (
+  SELECT cgc.country AS country_id,
          topic,
          COUNT(topic) AS topic_count
   FROM filtered_entities
-  LEFT JOIN json_array_elements(geo_coverage) countries
-  ON geo_coverage IS NOT NULL
-  WHERE (countries.value)::TEXT <> 'null'
-  GROUP BY (countries.value)::TEXT::INT, topic
-/*~ (when (= (:entity-group params) :community) */
-  UNION ALL
-  SELECT (countries.value)::TEXT::INT AS geo_coverage, 'organisation' AS topic, COUNT(topic) AS topic_count
-  FROM filtered_entities
-  LEFT JOIN json_array_elements(geo_coverage) countries ON geo_coverage IS NOT NULL
-  WHERE (countries.value)::TEXT <> 'null' AND topic = 'organisation' AND (json->>'is_member')::BOOLEAN IS TRUE
-  GROUP BY (countries.value)::TEXT::INT, topic
-  UNION ALL
-  SELECT (countries.value)::TEXT::INT AS geo_coverage, 'non_member_organisation' AS topic, COUNT(topic) AS topic_count
-  FROM filtered_entities
-  LEFT JOIN json_array_elements(geo_coverage) countries ON geo_coverage IS NOT NULL
-  WHERE (countries.value)::TEXT <> 'null' AND topic = 'organisation' AND (json->>'is_member')::BOOLEAN IS FALSE
-  GROUP BY (countries.value)::TEXT::INT, topic
-/*~ ) ~*/
-)
-SELECT geo_coverage AS id, json_object_agg(COALESCE(topic, 'project'), topic_count)
---~ (str " AS " (:count-name params))
-FROM country_counts
-GROUP BY geo_coverage;
-
--- :name map-counts-by-country-group :? :*
--- :doc Get the entity count per country group.
--- :require [gpml.db.landing]
-WITH country_group_counts AS (
---~(#'gpml.db.landing/generate-entity-count-by-country-group-queries {} {})
+  LEFT JOIN json_array_elements_text((json->>'geo_coverage_country_groups')::JSON) country_groups
+  ON json->>'geo_coverage_country_groups' IS NOT NULL
+  JOIN country_group_country cgc ON cgc.country_group = (country_groups.value)::TEXT::INT
+  WHERE (country_groups.value)::TEXT <> 'null' AND json->>'geo_coverage_type' = 'transnational'
+  GROUP BY cgc.country, topic
 ),
-aggregate_country_group_counts AS (
-  SELECT country_group_id, entity, SUM(entity_count) AS total_entity_count
+country_group_counts AS (
+  SELECT (country_groups.value)::TEXT::INT AS country_group_id,
+         topic,
+         COUNT(topic) AS topic_count
+  FROM filtered_entities
+  LEFT JOIN json_array_elements_text((json->>'geo_coverage_country_groups')::JSON) country_groups
+  ON json->>'geo_coverage_country_groups' IS NOT NULL
+  WHERE (country_groups.value)::TEXT <> 'null'
+  GROUP BY (country_groups.value)::TEXT::INT, topic
+),
+country_counts AS (
+/*~ (if (= (:entity-group params) :topic) */
+  SELECT (countries.value)::TEXT::INT AS country_id,
+         topic,
+         COUNT(topic) AS topic_count
+  FROM filtered_entities
+  LEFT JOIN json_array_elements_text((json->>'geo_coverage_countries')::JSON) countries
+  ON json->>'geo_coverage_countries' IS NOT NULL
+  WHERE (countries.value)::TEXT <> 'null' AND json->>'geo_coverage_type' != 'transnational'
+  GROUP BY (countries.value)::TEXT::INT, topic
+/*~*/
+  SELECT (json->>'country')::INT AS country_id, 'stakeholder' AS topic, COUNT(topic) AS topic_count
+  FROM filtered_entities
+  WHERE (json->>'country')::INT IS NOT NULL AND topic = 'stakeholder'
+  GROUP BY (json->>'country')::INT, topic
+  UNION ALL
+  SELECT (json->>'country')::INT AS country_id, 'organisation' AS topic, COUNT(topic) AS topic_count
+  FROM filtered_entities
+  WHERE (json->>'country')::INT IS NOT NULL AND topic = 'organisation' AND (json->>'is_member')::BOOLEAN IS TRUE
+  GROUP BY (json->>'country')::INT, topic
+  UNION ALL
+  SELECT (json->>'country')::INT AS country_id, 'non_member_organisation' AS topic, COUNT(topic) AS topic_count
+  FROM filtered_entities
+  WHERE (json->>'country')::INT IS NOT NULL AND topic = 'organisation' AND (json->>'is_member')::BOOLEAN IS FALSE
+  GROUP BY (json->>'country')::INT, topic
+/*~ ) ~*/
+),
+country_counts_agg AS (
+  SELECT country_id, json_object_agg(COALESCE(topic, 'project'), topic_count) AS counts
+  FROM country_counts
+  GROUP BY country_id
+),
+transnational_counts_per_country_agg AS (
+  SELECT country_id, json_object_agg(COALESCE(topic, 'project'), topic_count) AS transnational_counts
+  FROM transnational_counts_per_country
+  GROUP BY country_id
+),
+country_group_counts_agg AS (
+  SELECT country_group_id, json_object_agg(COALESCE(topic, 'project'), topic_count) AS counts
   FROM country_group_counts
-  GROUP BY country_group_id, entity
-)
-SELECT country_group_id, json_object_agg(COALESCE(entity, 'project'), total_entity_count) AS counts
-FROM aggregate_country_group_counts
-GROUP BY country_group_id;
+  GROUP BY country_group_id
+) SELECT json_build_object(
+    'country_counts', (SELECT json_agg(row_to_json(country_counts_agg)) AS counts FROM country_counts_agg),
+    'transnational_counts', (SELECT json_agg(row_to_json(transnational_counts_per_country_agg)) AS counts FROM transnational_counts_per_country_agg),
+    'country_group_counts', (SELECT json_agg(row_to_json(country_group_counts_agg)) AS counts FROM country_group_counts_agg)
+) AS result;
 
 -- :name summary
 -- :doc Get summary of count of entities and number of countries

--- a/backend/src/gpml/db/stakeholder_association.sql
+++ b/backend/src/gpml/db/stakeholder_association.sql
@@ -102,7 +102,7 @@ stakeholder_association AS (
 ),
 associated_topics AS (
 SELECT DISTINCT ON (t.topic, (COALESCE(t.json ->> 'start_date', t.json ->> 'created'))::timestamptz,
-    (t.json ->> 'id')::int) t.topic, t.geo_coverage, t.json, sa.stakeholder_connections, sa.entity_connections
+    (t.json ->> 'id')::int) t.topic, t.json, sa.stakeholder_connections, sa.entity_connections
 FROM
     cte_topic t
     JOIN stakeholder_association sa ON sa.id = (t.json->>'id')::int AND sa.topic = t.topic

--- a/backend/src/gpml/handler/browse.clj
+++ b/backend/src/gpml/handler/browse.clj
@@ -113,7 +113,7 @@
             :swagger {:description "Limit the number of entries per page"
                       :type "int"
                       :allowEmptyValue false}}
-    [:int {:min 0 :max 100}]]
+    [:int {:min 1}]]
    [:offset {:optional true
              :swagger {:description "Number of items to skip when fetching entries"
                        :type "int"

--- a/backend/src/gpml/handler/landing.clj
+++ b/backend/src/gpml/handler/landing.clj
@@ -1,11 +1,15 @@
 (ns gpml.handler.landing
   (:require [clojure.string :as str]
+            [duct.logger :refer [log]]
             [gpml.constants :refer [resource-types topics]]
             [gpml.db.country-group :as db.country-group]
             [gpml.db.landing :as db.landing]
+            [gpml.handler.responses :as r]
+            [gpml.util.postgresql :as pg-util]
             [gpml.util.regular-expressions :as util.regex]
             [integrant.core :as ig]
-            [ring.util.response :as resp]))
+            [ring.util.response :as resp])
+  (:import [java.sql SQLException]))
 
 (def ^:const ^:private topic-re (util.regex/comma-separated-enums-re topics))
 (def ^:const ^:private entity-groups ["topic" "community"])
@@ -165,28 +169,41 @@
     true
     (assoc :review-status "APPROVED")))
 
-(defn- landing-response [conn query]
-  (let [opts (api-opts->opts query)
-        modified-opts (if-not (seq (get opts :transnational))
-                        opts
-                        (let [opts {:filters {:country-groups (get opts :transnational)}}
-                              country-group-countries (db.country-group/get-country-groups-countries opts)
-                              geo-coverage-countries (map :id country-group-countries)]
-                          (assoc opts :geo-coverage (set (concat
-                                                          (get opts :geo-coverage)
-                                                          geo-coverage-countries)))))
-        summary-data (->> (gpml.db.landing/summary conn)
-                          (mapv (fn [{:keys [resource_type count country_count]}]
-                                  {(keyword resource_type) count :countries country_count})))]
-    (resp/response {:map (db.landing/map-counts-include-all-countries conn modified-opts)
-                    :country_group_counts (db.landing/get-map-counts-by-country-group conn)
-                    :summary summary-data})))
+(defn- get-resource-map-counts
+  [{:keys [db logger]}
+   {{:keys [query]} :parameters
+    user :user}]
+  (try
+    (let [conn (:spec db)
+          opts (api-opts->opts (assoc query :user-id (:id user)))
+          modified-opts (if-not (seq (get opts :transnational))
+                          opts
+                          (let [opts {:filters {:country-groups (get opts :transnational)}}
+                                country-group-countries (db.country-group/get-country-groups-countries opts)
+                                geo-coverage-countries (map :id country-group-countries)]
+                            (assoc opts :geo-coverage (set (concat
+                                                            (get opts :geo-coverage)
+                                                            geo-coverage-countries)))))
+          summary-data (->> (gpml.db.landing/summary conn)
+                            (mapv (fn [{:keys [resource_type count country_count]}]
+                                    {(keyword resource_type) count :countries country_count})))
+          {:keys [country_counts country_group_counts]} (db.landing/get-resource-map-counts conn modified-opts)]
+      (resp/response {:success? true
+                      :map country_counts
+                      :country_group_counts country_group_counts
+                      :summary summary-data}))
+    (catch Exception e
+      (log logger :error ::failed-to-get-resource-map-counts {:exception-message (.getMessage e)})
+      (r/server-error {:success? false
+                       :reason :failed-to-get-resource-map-counts
+                       :error-details {:error (if (instance? SQLException e)
+                                                (pg-util/get-sql-state e)
+                                                (.getMessage e))}}))))
 
-(defmethod ig/init-key :gpml.handler.landing/get [_ {:keys [db]}]
-  (fn [{{:keys [query]} :parameters
-        user :user}]
-    (let [conn (:spec db)]
-      (landing-response conn (assoc query :user-id (:id user))))))
+(defmethod ig/init-key :gpml.handler.landing/get
+  [_ config]
+  (fn [req]
+    (get-resource-map-counts config req)))
 
 (defmethod ig/init-key :gpml.handler.landing/get-query-params [_ _]
-  query-params)
+  {:query query-params})

--- a/backend/test/gpml/db/landing_test.clj
+++ b/backend/test/gpml/db/landing_test.clj
@@ -68,8 +68,8 @@
           system (ig/init fixtures/*system* [db-key])
           conn (-> system db-key :spec)
           _ (add-resource-data conn)
-          landing (db.landing/map-counts-include-all-countries conn {:entity-group :topic})
-          valid? (fn [country-id] (->> landing
+          {:keys [country_counts]} (db.landing/get-resource-map-counts conn {:entity-group :topic})
+          valid? (fn [country-id] (->> country_counts
                                        (filter #(= country-id (:country_id %)))
                                        first
                                        :counts
@@ -120,13 +120,13 @@
         system (ig/init fixtures/*system* [db-key])
         conn (-> system db-key :spec)
         _ (add-resource-data conn)
-        landing (db.landing/map-counts-include-all-countries conn {:entity-group :topic})]
+        {:keys [country_counts]} (db.landing/get-resource-map-counts conn {:entity-group :topic})]
     (testing "Landing counts match browse results"
       (let [country-id 4
             transnationals (->> (get-country-group-ids conn country-id)
                                 (map (comp str :id))
                                 set)
-            landing-counts-by-country (filter #(= country-id (:country_id %)) landing)
+            landing-counts-by-country (filter #(= country-id (:country_id %)) country_counts)
             browse (db.topic/get-topics conn {:topic #{"financing_resource"}
                                               :geo-coverage [country-id]
                                               :transnational transnationals


### PR DESCRIPTION
Main issues:
* Improves performance. All counts in a single query.
* Fix country groups count. Counting using solely the
<resource>_geo_coverage table was not enough and more than often gave
wrong counts. This new query simplifies not only the map count but the
topic query itself because we don't need geo coverage CTE anymore. All
information needed to aggregate resource count per country and country
group is contained in the `geo_coverage_countries` and
`geo_coverage_country_groups` fields generated from the topic
query. This means 5 geo coverage queries less to process.

Secondary issues:
* Remove the limit from browse API.