### PR TITLE
Fix favorites post endpoint

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -706,8 +706,8 @@
 
   :gpml.handler.file/profile-cv {:db #ig/ref :duct.database/sql}
 
-  :gpml.handler.favorite/get {:db #ig/ref :duct.database/sql}
-  :gpml.handler.favorite/post {:db #ig/ref :duct.database/sql}
+  :gpml.handler.favorite/get #ig/ref :gpml.config/common
+  :gpml.handler.favorite/post #ig/ref :gpml.config/common
   :gpml.handler.favorite/post-params {}
 
   :gpml.handler.env/get {:auth0 {:domain #duct/env "OIDC_ISSUER"

--- a/backend/resources/migrations/173-remove-is-bookmark-from-favorite-tables.up.sql
+++ b/backend/resources/migrations/173-remove-is-bookmark-from-favorite-tables.up.sql
@@ -1,0 +1,18 @@
+BEGIN;
+--;;
+ALTER TABLE stakeholder_technology
+DROP COLUMN is_bookmark;
+--;;
+ALTER TABLE stakeholder_event
+DROP COLUMN is_bookmark;
+--;;
+ALTER TABLE stakeholder_resource
+DROP COLUMN is_bookmark;
+--;;
+ALTER TABLE stakeholder_policy
+DROP COLUMN is_bookmark;
+--;;
+ALTER TABLE stakeholder_initiative
+DROP COLUMN is_bookmark;
+--;;
+COMMIT;

--- a/backend/src/gpml/db/favorite.sql
+++ b/backend/src/gpml/db/favorite.sql
@@ -1,13 +1,3 @@
--- :name new-association :!
--- :doc Upserts a new relation between a stakeholder and a topic
---~ (format "INSERT INTO stakeholder_%1$s AS sp (stakeholder, %2$s, association, remarks, is_bookmark)" (:topic params) (or (:column_name params) (:topic params)))
---~ (format "VALUES (:stakeholder, :topic_id, :v:association::%1$s_association, :remarks, true)" (:topic params))
---~ (format "ON CONFLICT (stakeholder, %1$s, association)" (or (:column_name params) (:topic params)))
-DO UPDATE SET modified = now(), remarks = EXCLUDED.remarks, is_bookmark = true
-    WHERE sp.stakeholder = EXCLUDED.stakeholder
---~ (format "AND sp.%1$s = EXCLUDED.%1$s" (or (:column_name params) (:topic params)))
-      AND sp.association = EXCLUDED.association;
-
 -- :name new-stakeholder-association :!
 -- :doc Upserts a new relation between a stakeholder and a topic
 --~ (format "INSERT INTO stakeholder_%1$s AS sp (stakeholder, %2$s, association, remarks)" (:topic params) (or (:column_name params) (:topic params)))
@@ -18,22 +8,10 @@ DO UPDATE SET modified = now(), remarks = EXCLUDED.remarks
 --~ (format "AND sp.%1$s = EXCLUDED.%1$s" (or (:column_name params) (:topic params)))
       AND sp.association = EXCLUDED.association
 
--- :name association-by-stakeholder :? :*
--- :doc Get all associations for a given stakeholder
-SELECT * FROM v_stakeholder_association WHERE stakeholder = :stakeholder
-
--- :name stakeholder-bookmarks :? :*
--- :doc Get stakeholder bookmark for a given topic
-SELECT * FROM :i:table
-WHERE stakeholder = :stakeholder
-AND :i:topic = :topic_id
-AND is_bookmark = true;
-
 -- :name association-by-stakeholder-topic :? :*
-SELECT * FROM :i:topic
-WHERE stakeholder = :stakeholder
-AND :i:column_name = :topic_id
-AND is_bookmark = false;
+SELECT * FROM :i:table
+WHERE stakeholder = :stakeholder-id
+AND :i:resource-col = :resource-id;
 
 -- :name delete-stakeholder-association :! :n
 DELETE FROM :i:topic WHERE id = :id

--- a/backend/src/gpml/db/resource/connection.sql
+++ b/backend/src/gpml/db/resource/connection.sql
@@ -7,9 +7,6 @@ ON sc.stakeholder = s.id
 LEFT JOIN stakeholder_tag st ON st.stakeholder = s.id
 LEFT JOIN tag t ON t.id = st.tag
 WHERE sc.:i:resource-type = :resource-id
--- TODO: remove the following line once we refactor association and
--- favorites schema.
-AND sc.is_bookmark IS FALSE
 GROUP BY sc.id, s.id
 
 -- :name get-resource-entity-connections

--- a/backend/src/gpml/db/topic.clj
+++ b/backend/src/gpml/db/topic.clj
@@ -397,6 +397,7 @@
      " "
      (list
       "SELECT t.* FROM cte_topic t"
+      ;; FIXME fix this to user a query instead of a view.
       (when (and favorites user-id resource-types)
         "JOIN v_stakeholder_association a
          ON a.stakeholder = :user-id

--- a/backend/src/gpml/handler/favorite.clj
+++ b/backend/src/gpml/handler/favorite.clj
@@ -105,10 +105,10 @@
                              (merge {:topic (str "stakeholder_" resource-type)}))]
               (db.favorite/delete-stakeholder-association conn delete)))
           (doseq [association (expand-associations body-params)]
-            (prn (db.favorite/new-stakeholder-association conn (merge
-                                                                {:stakeholder (:id user)
-                                                                 :remarks nil}
-                                                                association)))))
+            (db.favorite/new-stakeholder-association conn (merge
+                                                           {:stakeholder (:id user)
+                                                            :remarks nil}
+                                                           association))))
         (db.activity/create-activity db {:id (util/uuid)
                                          :type "bookmark_resource"
                                          :owner_id (:id user)

--- a/backend/test/gpml/db/favorite_test.clj
+++ b/backend/test/gpml/db/favorite_test.clj
@@ -35,29 +35,35 @@
     (let [sth1-id (:id (new-stakeholder db "email1@un.org"))
           sth2-id (:id (new-stakeholder db "email2@un.org"))]
       (testing "Creating a new relation between a stakeholder and a technolgy item"
-        (db.favorite/new-association db {:stakeholder sth1-id
-                                         :topic "technology"
-                                         :topic_id 1
-                                         :association "user"
-                                         :remarks nil})
-        (db.favorite/new-association db {:stakeholder sth1-id
-                                         :topic "technology"
-                                         :topic_id 1
-                                         :association "interested in"
-                                         :remarks nil})
-        (db.favorite/new-association db {:stakeholder sth2-id
-                                         :topic "technology"
-                                         :topic_id 1
-                                         :association "interested in"
-                                         :remarks nil}))
+        (db.favorite/new-stakeholder-association db {:stakeholder sth1-id
+                                                     :topic "technology"
+                                                     :topic_id 1
+                                                     :association "user"
+                                                     :remarks nil})
+        (db.favorite/new-stakeholder-association db {:stakeholder sth1-id
+                                                     :topic "technology"
+                                                     :topic_id 1
+                                                     :association "interested in"
+                                                     :remarks nil})
+        (db.favorite/new-stakeholder-association db {:stakeholder sth2-id
+                                                     :topic "technology"
+                                                     :topic_id 1
+                                                     :association "interested in"
+                                                     :remarks nil}))
       (testing "Attempting to create the same relation doesn't fail"
-        (db.favorite/new-association db {:stakeholder sth1-id
-                                         :topic "technology"
-                                         :topic_id 1
-                                         :association "user"
-                                         :remarks nil}))
+        (db.favorite/new-stakeholder-association db {:stakeholder sth1-id
+                                                     :topic "technology"
+                                                     :topic_id 1
+                                                     :association "user"
+                                                     :remarks nil}))
       (testing "Getting relations for a given stakeholder"
-        (is (= 2 (count (db.favorite/association-by-stakeholder db
-                                                                {:stakeholder sth1-id}))))
-        (is (= 1 (count (db.favorite/association-by-stakeholder db
-                                                                {:stakeholder sth2-id}))))))))
+        (is (= 2 (count (db.favorite/association-by-stakeholder-topic db
+                                                                      {:stakeholder-id sth1-id
+                                                                       :resource-col "technology"
+                                                                       :table "stakeholder_technology"
+                                                                       :resource-id 1}))))
+        (is (= 1 (count (db.favorite/association-by-stakeholder-topic db
+                                                                      {:stakeholder-id sth2-id
+                                                                       :resource-col "technology"
+                                                                       :table "stakeholder_technology"
+                                                                       :resource-id 1}))))))))

--- a/backend/test/gpml/handler/browse_test.clj
+++ b/backend/test/gpml/handler/browse_test.clj
@@ -94,11 +94,11 @@
         ;; Mark stakeholder as APPROVED
         _ (db.stakeholder/update-stakeholder-status db (assoc sth :review_status "APPROVED"))
         ;; Mark a technology as favorite
-        _ (db.favorite/new-association db {:stakeholder (:id sth)
-                                           :topic "technology"
-                                           :topic_id 1
-                                           :association "user"
-                                           :remarks nil})]
+        _ (db.favorite/new-stakeholder-association db {:stakeholder (:id sth)
+                                                       :topic "technology"
+                                                       :topic_id 1
+                                                       :association "user"
+                                                       :remarks nil})]
 
     (testing "Query for favorites WITHOUT LOGIN"
       (let [request (-> (mock/request :get "/")

--- a/backend/test/gpml/handler/favorite_test.clj
+++ b/backend/test/gpml/handler/favorite_test.clj
@@ -50,11 +50,12 @@
                                              :geo_coverage_type nil
                                              :role "USER"
                                              :idp_usernames ["auth0|123"]})]
-    (db.stakeholder/update-stakeholder-status db (assoc sth :review_status "APPROVED"))))
+    (db.stakeholder/update-stakeholder-status db (assoc sth :review_status "APPROVED"))
+    sth))
 
-(defn- mock-post [email]
+(defn- mock-post [sth-id]
   (-> (mock/request :post "/")
-      (assoc :jwt-claims {:email email})
+      (assoc :user {:id sth-id})
       (assoc :body-params {:topic_id 1
                            :topic "technology"
                            :association ["user" "interested in"]})))
@@ -67,6 +68,6 @@
           handler (::favorite/post system)
           _ (seeder/seed db {:country? true
                              :technology? true})
-          _ (new-stakeholder db "email@un.org")
-          resp (handler (mock-post "email@un.org"))]
+          sth-id (:id (new-stakeholder db "email@un.org"))
+          resp (handler (mock-post sth-id))]
       (is (= 200 (:status resp))))))


### PR DESCRIPTION
* The endpoint was not create and deleting bookmarks properly.
* Ideally bookmarks, follow and association should be splited into
three different things. This will need a refactor in the future.
* Removed `is_bookmark` from the tables as it doesn't add any benefit
since the association `interested in` is already treated as the
bookmark/follow value.