### PR TITLE
Update project's GET/PUT/DELETE endpoints to restrict by user

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -558,16 +558,19 @@
                                          ["/:id"
                                           {:get {:summary "Get a project"
                                                  :swagger {:tags ["project"]}
+                                                 :middleware [#ig/ref :gpml.auth/restrict-to-project-owner]
                                                  :parameters #ig/ref :gpml.handler.project/get-by-id-params
                                                  :responses #ig/ref :gpml.handler.project/get-by-id-responses
                                                  :handler #ig/ref :gpml.handler.project/get-by-id}
                                            :put {:summary "Update a project"
                                                  :swagger {:tags ["project"]}
+                                                 :middleware [#ig/ref :gpml.auth/restrict-to-project-owner]
                                                  :parameters #ig/ref :gpml.handler.project/put-params
                                                  :responses #ig/ref :gpml.handler.project/put-responses
                                                  :handler #ig/ref :gpml.handler.project/put}
                                            :delete {:summary "Delete a project"
                                                     :swagger {:tags ["project"]}
+                                                    :middleware [#ig/ref :gpml.auth/restrict-to-project-owner]
                                                     :parameters #ig/ref :gpml.handler.project/delete-params
                                                     :responses #ig/ref :gpml.handler.project/delete-responses
                                                     :handler #ig/ref :gpml.handler.project/delete}}]]]]
@@ -813,13 +816,13 @@
   :gpml.auth/auth-middleware-auth0-actions {:issuer #duct/env "OIDC_ISSUER"
                                             :audience #duct/env "OIDC_AUDIENCE_AUTH0_ACTIONS"
                                             :db #ig/ref :duct.database/sql}
-
   :gpml.auth/auth-required {}
   :gpml.auth/restrict-to-admin-and-comment-author-middleware {:db #ig/ref :duct.database/sql}
   :gpml.auth/restrict-to-organisation-admin-or-owner {:db #ig/ref :duct.database/sql}
   :gpml.auth/approved-user {:db #ig/ref :duct.database/sql}
   :gpml.auth/admin-required-middleware {:db #ig/ref :duct.database/sql}
   :gpml.auth/admin-or-reviewer-required-middleware {:db #ig/ref :duct.database/sql}
+  :gpml.auth/restrict-to-project-owner #ig/ref :gpml.config/common
 
   :gpml.handler.monitoring/collector {}
 

--- a/backend/src/gpml/handler/project.clj
+++ b/backend/src/gpml/handler/project.clj
@@ -25,14 +25,6 @@
     [:sequential
      {:decode/string (fn [s] (str/split s #","))}
      uuid?]]
-   [:stakeholders_ids
-    {:optional true
-     :swagger {:description "A comma separated list of stakeholder identifiers."
-               :type "integer"
-               :allowEmptyValue false}}
-    [:sequential
-     {:decode/string (fn [s] (str/split s #","))}
-     pos-int?]]
    [:geo_coverage_types
     {:optional true
      :swagger {:description "A comma separated list of geo_coverage_types"
@@ -117,9 +109,11 @@
                                                 (.getMessage e))}}))))
 
 (defn- get-projects
-  [{:keys [db logger]} {:keys [parameters]}]
+  [{:keys [db logger]} {:keys [parameters user]}]
   (try
-    (let [db-opts (db.prj/opts->db-opts (:query parameters))
+    (let [db-opts (-> (:query parameters)
+                      (assoc :stakeholders_ids [(:id user)])
+                      (db.prj/opts->db-opts))
           results (db.prj/get-projects (:spec db)
                                        {:filters db-opts})]
       {:success? true

--- a/backend/test/gpml/handler/project_test.clj
+++ b/backend/test/gpml/handler/project_test.clj
@@ -129,7 +129,8 @@
         project-id (create-random-project db sth-id)]
     (testing "Happy path"
       (let [request (-> (mock/request :get "/")
-                        (assoc :parameters {:path {:id project-id}}))
+                        (assoc :parameters {:path {:id project-id}}
+                               :user {:id sth-id}))
             {:keys [status body]} (handler request)]
         (is (= 200 status))
         (is (:success? body))
@@ -153,14 +154,16 @@
         project-id-1 (create-random-project db sth-id)
         _project-id-2 (create-random-project db sth-id)]
     (testing "Happy path"
-      (let [request (mock/request :get "/")
+      (let [request (-> (mock/request :get "/")
+                        (assoc :user {:id sth-id}))
             {:keys [status body]} (handler request)]
         (is (= 200 status))
         (is (:success? body))
         (is (= 2 (count (:projects body))))))
     (testing "Happy path applying filters"
       (let [request (-> (mock/request :get "/")
-                        (assoc :parameters {:query {:ids [project-id-1]}}))
+                        (assoc :parameters {:query {:ids [project-id-1]}}
+                               :user {:id sth-id}))
             {:keys [status body]} (handler request)]
         (is (= 200 status))
         (is (:success? body))
@@ -181,7 +184,8 @@
         project-id (create-random-project db sth-id)]
     (testing "Happy path"
       (let [request (-> (mock/request :delete "/")
-                        (assoc :parameters {:path {:id project-id}}))
+                        (assoc :parameters {:path {:id project-id}}
+                               :user {:id sth-id}))
             {:keys [status body]} (handler request)
             project (db.prj/get-projects db {:filters {:ids (pg-util/->JDBCArray [project-id] "uuid")}})]
         (is (= 200 status))


### PR DESCRIPTION
* GET endpoints should return projects owned by the user.
* GET/PUT/DELETE/:id should allow the request if the user owns the
specified project. Otherwise return an unauthorized response.