### PR TITLE
Fix map count for initiatives

### DIFF
--- a/backend/src/gpml/db/landing.sql
+++ b/backend/src/gpml/db/landing.sql
@@ -14,10 +14,11 @@ transnational_counts_per_country AS (
          topic,
          COUNT(DISTINCT json->>'id') AS topic_count
   FROM filtered_entities
-  LEFT JOIN json_array_elements_text((json->>'geo_coverage_country_groups')::JSON) country_groups
-  ON json->>'geo_coverage_country_groups' IS NOT NULL
-  JOIN country_group_country cgc ON cgc.country_group = (country_groups.value)::TEXT::INT
-  WHERE (country_groups.value)::TEXT <> 'null' AND json->>'geo_coverage_type' = 'transnational'
+  LEFT JOIN json_array_elements_text((json->>'geo_coverage_values')::JSON) cgcs
+  ON json->>'geo_coverage_values' IS NOT NULL
+  JOIN country_group_country cgc ON cgc.country_group = (cgcs.value)::TEXT::INT
+  OR cgc.country = (cgcs.value)::TEXT::INT
+  WHERE (cgcs.value)::TEXT <> 'null' AND json->>'geo_coverage_type' = 'transnational'
   GROUP BY cgc.country, topic
 ),
 country_group_counts AS (

--- a/backend/src/gpml/db/topic.clj
+++ b/backend/src/gpml/db/topic.clj
@@ -45,7 +45,7 @@
    e.created,
    e.modified,
    btrim((e.q2)::text, '\"'::text) AS title,
-   e.q24 AS geo_coverage_type,
+   jsonb_object_keys(e.q24) AS geo_coverage_type,
    btrim((e.q3)::text, '\"'::text) AS summary,
    e.reviewed_at,
    e.reviewed_by,
@@ -130,7 +130,7 @@
         search-text-fields (get search-text-fields entity-name)
         tsvector-str (generate-tsvector-str entity-name search-text-fields)
         geo-coverage-type-cond (if (= entity-name "initiative")
-                                 "(select json_object_keys(q24::json) from initiative where id = e.id)::geo_coverage_type"
+                                 "(select jsonb_object_keys(q24) from initiative where id = e.id)::geo_coverage_type"
                                  "e.geo_coverage_type")
         where-cond (cond-> "WHERE 1=1"
                      (seq review-status)

--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -332,7 +332,6 @@
 (defmethod extra-details "initiative" [resource-type db initiative]
   (merge
    (add-extra-details db initiative resource-type {})
-   {:geo_coverage_type (-> initiative :geo_coverage_type ffirst)}
    (db.initiative/initiative-detail-by-id db initiative)))
 
 (defmethod extra-details "policy" [resource-type db policy]


### PR DESCRIPTION
* The transnational count and national counts weren't calculated because initiative's geo_coverage_type was a JSON instead of a plain string. So when doing the WHERE conditions for `transnational` or `national,sub-national` values it would fail and always account to 0.