### PR TITLE
[#1485] Add upcoming filter and refactor browse API opts schema

### DIFF
--- a/backend/src/gpml/db/topic.clj
+++ b/backend/src/gpml/db/topic.clj
@@ -119,7 +119,7 @@
   [entity-name
    {:keys [entity tag representative-group
            geo-coverage-types sub-content-type
-           search-text review-status featured capacity-building] :as _params}
+           search-text review-status featured capacity-building upcoming] :as _params}
    {:keys [search-text-fields] :as _opts}]
   (let [entity-connections-join (if-not (or (seq entity) (seq representative-group))
                                   ""
@@ -158,7 +158,10 @@
                      (str " AND e.featured = :featured")
 
                      capacity-building
-                     (str " AND e.capacity_building = :capacity-building"))]
+                     (str " AND e.capacity_building = :capacity-building")
+
+                     (and upcoming (= entity-name "event"))
+                     (str " AND now() < e.start_date"))]
     (apply
      format
      "SELECT

--- a/backend/src/gpml/db/topic.clj
+++ b/backend/src/gpml/db/topic.clj
@@ -356,10 +356,20 @@
      (str " UNION ALL " capacity-building-count-aggregate-query-raw-sql))))
 
 (defn- generate-get-topics-query
-  [{:keys [order-by limit offset descending]}]
+  [{:keys [order-by limit offset descending upcoming topic]}]
   (let [order (if descending "DESC" "ASC")
-        order-by-clause (if (seq order-by)
+        order-by-clause (cond
+                          ;; We assume the upcoming filter will always
+                          ;; be together with the event topic. The
+                          ;; browse API disallows its usage if there
+                          ;; are multiple topics.
+                          (and upcoming (= (first topic) "event"))
+                          "ORDER BY json->>'start_date' ASC"
+
+                          (seq order-by)
                           (format "ORDER BY json->>'%s' %s" order-by order)
+
+                          :else
                           "ORDER BY (COALESCE(json->>'start_date', json->>'created'))::timestamptz DESC")]
     (str/join
      " "

--- a/backend/test/gpml/handler/browse_test.clj
+++ b/backend/test/gpml/handler/browse_test.clj
@@ -12,6 +12,8 @@
             [gpml.util.regular-expressions :as util.regex]
             [integrant.core :as ig]
             [malli.core :as malli]
+            [malli.transform :as mt]
+            [muuntaja.core :as m]
             [ring.mock.request :as mock]))
 
 (use-fixtures :each fixtures/with-test-system)
@@ -49,36 +51,38 @@
         false ",,"))))
 
 (deftest db-filter-based-on-query-params
-  (testing "Default filter values"
-    (is (= (browse/get-db-filter {}) {:offset 0 :limit 50 :review-status "APPROVED"}))
-    (is (= (browse/get-db-filter {:q "" :topic "" :country ""}) {:offset 0 :limit 50 :review-status "APPROVED"})))
-  (testing "Country is not empty"
-    (is (= (browse/get-db-filter {:country "73,106,107"})
-           {:geo-coverage [107 73 106] :offset 0 :limit 50 :review-status "APPROVED"})))
-  (testing "Topic is not empty"
-    (is (= (browse/get-db-filter {:topic "technology"})
-           {:topic #{"technology"} :offset 0 :limit 50 :review-status "APPROVED"})))
-  (testing "Search is not empty"
-    (is (= (browse/get-db-filter {:q "act"})
-           {:search-text "act" :offset 0 :limit 50 :review-status "APPROVED"})))
-  (testing "Search multiple keywords"
-    (is (= (browse/get-db-filter {:q "some test"})
-           {:search-text "some & test" :offset 0 :limit 50 :review-status "APPROVED"})))
-  (testing "Trailing/leading/double spaces are trimmed"
-    (is (= (browse/get-db-filter {:q "  This   is a test  "})
-           {:search-text "This & is & a & test" :offset 0 :limit 50 :review-status "APPROVED"})))
-  (testing "Ampersand is removed"
-    (is (= (browse/get-db-filter {:q "&&test&&"})
-           {:search-text "test" :offset 0 :limit 50 :review-status "APPROVED"})))
-  (testing "None is empty"
-    (is (= (browse/get-db-filter {:q "eco"
-                                  :country "253"
-                                  :topic "initiative,event"})
-           {:search-text "eco"
-            :geo-coverage [253]
-            :topic #{"initiative" "event"}
-            :offset 0 :limit 50
-            :review-status "APPROVED"}))))
+  (letfn [(decode-params [params]
+            (malli/decode browse/api-opts-schema params mt/string-transformer))]
+    (testing "Default filter values"
+      (is (= (browse/get-db-filter (decode-params {})) {:offset 0 :limit 50 :review-status "APPROVED"})))
+    (testing "Country is not empty"
+      (is (= (browse/get-db-filter (decode-params {:country "73,106,107"}))
+             {:geo-coverage #{107 73 106} :offset 0 :limit 50 :review-status "APPROVED"})))
+    (testing "Topic is not empty"
+      (is (= (browse/get-db-filter (decode-params {:topic "technology"}))
+             {:topic #{"technology"} :offset 0 :limit 50 :review-status "APPROVED"})))
+    (testing "Search is not empty"
+      (is (= (browse/get-db-filter (decode-params {:q "act"}))
+             {:search-text "act" :offset 0 :limit 50 :review-status "APPROVED"})))
+    (testing "Search multiple keywords"
+      (is (= (browse/get-db-filter (decode-params {:q "some test"}))
+             {:search-text "some & test" :offset 0 :limit 50 :review-status "APPROVED"})))
+    (testing "Trailing/leading/double spaces are trimmed"
+      (is (= (browse/get-db-filter (decode-params {:q "  This   is a test  "}))
+             {:search-text "This & is & a & test" :offset 0 :limit 50 :review-status "APPROVED"})))
+    (testing "Ampersand is removed"
+      (is (= (browse/get-db-filter (decode-params {:q "&&test&&"}))
+             {:search-text "test" :offset 0 :limit 50 :review-status "APPROVED"})))
+    (testing "None is empty"
+      (is (= (browse/get-db-filter (decode-params
+                                    {:q "eco"
+                                     :country "253"
+                                     :topic "initiative,event"}))
+             {:search-text "eco"
+              :geo-coverage #{253}
+              :topic #{"initiative" "event"}
+              :offset 0 :limit 50
+              :review-status "APPROVED"})))))
 
 (deftest browse-view-results
   (let [db (test-util/db-test-conn)
@@ -135,14 +139,14 @@
 
     (testing "Testing query for BOGUS tags"
       (let [resp (handler (-> (mock/request :get "/")
-                              (assoc :parameters {:query {:tag "bogus1,bogus2"}})))
+                              (assoc :parameters {:query {:tag #{"bogus1" "bogus2"}}})))
             body (-> resp :body)
             results (:results body)]
         (is (= 0 (count results)))))
 
     (testing "Testing query for existing tags"
       (let [resp (handler (-> (mock/request :get "/")
-                              (assoc :parameters {:query {:tag "waste management"}})))
+                              (assoc :parameters {:query {:tag #{"waste management"}}})))
             body (-> resp :body)
             results (:results body)]
         (is (= 16 (count results)))))))

--- a/backend/test/gpml/handler/browse_test.clj
+++ b/backend/test/gpml/handler/browse_test.clj
@@ -13,7 +13,6 @@
             [integrant.core :as ig]
             [malli.core :as malli]
             [malli.transform :as mt]
-            [muuntaja.core :as m]
             [ring.mock.request :as mock]))
 
 (use-fixtures :each fixtures/with-test-system)


### PR DESCRIPTION
* Also, move all parameter parsing to the opts schema. We should always use Malli directly for parameter coercion, error handling, etc.
* Closes #1485 