### PR TITLE
1488 fix get suggested profiles endpoint

### DIFF
--- a/backend/src/gpml/db/stakeholder.sql
+++ b/backend/src/gpml/db/stakeholder.sql
@@ -287,35 +287,34 @@ select id, first_name, last_name, email from stakeholder
    and review_status = 'APPROVED';
 
 -- :name get-suggested-stakeholders :?
--- :doc Get stakeholder based on matching seeking, offerings and location
+-- :doc Get distinct stakeholders based on matching seeking and offerings.
 WITH suggested_stakeholders AS (
     SELECT
-        *
+        DISTINCT s.*
     FROM
         stakeholder s
         JOIN stakeholder_tag st ON s.id = st.stakeholder
         JOIN tag t ON st.tag = t.id
-        JOIN tag_category tg ON t.tag_category = tg.id
     WHERE
-        t.tag IN (:v*:offering-seekings)
+        t.id IN (:v*:seeking-ids-for-offerings)
         AND s.id != :stakeholder-id
+        AND st.tag_relation_category = 'offering'
     UNION
     SELECT
-        *
+        DISTINCT s.*
     FROM
         stakeholder s
         JOIN stakeholder_tag st ON s.id = st.stakeholder
         JOIN tag t ON st.tag = t.id
-        JOIN tag_category tg ON t.tag_category = tg.id
     WHERE
-        t.tag IN (:v*:seeking-offerings)
-        AND s.id != :stakeholder-id)
-SELECT
-    *
+        t.id IN (:v*:offering-ids-for-seekings)
+        AND s.id != :stakeholder-id
+        AND st.tag_relation_category = 'seeking')
+SELECT *
 FROM
     suggested_stakeholders
 LIMIT :limit
-OFFSET :offset
+OFFSET :offset;
 
 -- :name get-recent-active-stakeholders :? :*
 -- :doc Get stakeholders based on the most recent activites

--- a/backend/src/gpml/db/stakeholder.sql
+++ b/backend/src/gpml/db/stakeholder.sql
@@ -324,7 +324,7 @@ SELECT
 FROM
     stakeholder s
     JOIN activity a ON s.id = a.owner_id
-    WHERE s.id != :stakeholder-id
+    WHERE s.id NOT IN (:v*:stakeholder-ids)
 ORDER BY
     s.id,
     a.created_at DESC

--- a/backend/src/gpml/handler/tag.clj
+++ b/backend/src/gpml/handler/tag.clj
@@ -68,32 +68,6 @@
                :type "integer"}}
     [:int {:min 0}]]])
 
-(def ^:const offerings-seekings
-  "Mapping between offerings and seekings."
-  {"software development" #{"software products"}
-   "legal services" #{"funds" "legal expert"}
-   "marine litter consultancy" #{"marine biologists" "marine litter experts"
-                                 "plastic expert" "recyclers" "environmental scientists"
-                                 "waste management services"}
-   "knowledge management" #{"marine litter experts"}})
-
-(defn get-offerings-seekings-matches [db offerings-ids seekings-ids]
-  (let [offering-seekings (->> (db.tag/tag-by-category (:spec db) {:category "offering"})
-                               (filter #(some #{(:id %)} offerings-ids))
-                               (map :tag)
-                               (reduce (fn [acc offering] (concat acc (get offerings-seekings offering))) []))
-        seekings-to-search (->> (db.tag/tag-by-category (:spec db) {:category "seeking"})
-                                (filter #(some #{(:id %)} seekings-ids))
-                                (map :tag))
-        seeking-offerings (reduce (fn [acc [offering seekings]]
-                                    (if (seq (filter #(some #{%} seekings) seekings-to-search))
-                                      (conj acc offering)
-                                      acc))
-                                  []
-                                  offerings-seekings)]
-    {:offering-seekings offering-seekings
-     :seeking-offerings seeking-offerings}))
-
 (defn create-tags
   "Creates N `tags` given a `tag-category`. `tags` are expected to have
   to have the following structure:


### PR DESCRIPTION
Fixed the problems described in the issue.

Now as a side-note for FE, we take into account `limit` property sent by FE, but if neither `limit` or `page` params are provided, we use default values hardcoded in BE (limit = 5; page = 0).