### PR TITLE
Fix GET `/image/{image_type}/{id}` endpoint

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -737,7 +737,8 @@
   :gpml.handler.programmatic.organisation/post #ig/ref :gpml.config/common
   :gpml.handler.programmatic.organisation/post-params {}
 
-  :gpml.handler.image/get {:db #ig/ref :duct.database/sql}
+  :gpml.handler.image/get {:db #ig/ref :duct.database/sql
+                           :logger #ig/ref :duct/logger}
 
   :gpml.handler.file/profile-cv {:db #ig/ref :duct.database/sql}
 


### PR DESCRIPTION
[closes #1492]

Now we check if the loaded image from the DB has Base64 format before parsing it like that in order to send FE the image as bytes array. For this check, we need to ensure first the image content is not empty and then check if it is a valid Base64 image, removing the possibly added headers for the check (since we store the Base64 headers too in order to have the metadata there).

In case the image does not have Base64 format, we treat it as an URL if we can build a correct URL from there. In case we can, the image is downloaded from the URL, so we can serve it as a bytes array, providing its content-type info as well. Thus FE can expect the image data always coming in the same format. Otherwise we cannot infer the image's content type just from the URL and would be harder to make the browser recognizes the image naturally.

In the future we might refactor how we deal with images, in order to unify the system.