### PR TITLE
Fix initiative geo_coverage_type transformation in topic query

### DIFF
--- a/backend/src/gpml/db/topic.clj
+++ b/backend/src/gpml/db/topic.clj
@@ -45,7 +45,7 @@
    e.created,
    e.modified,
    btrim((e.q2)::text, '\"'::text) AS title,
-   jsonb_object_keys(e.q24) AS geo_coverage_type,
+   (SELECT jsonb_object_keys(e.q24)) AS geo_coverage_type,
    btrim((e.q3)::text, '\"'::text) AS summary,
    e.reviewed_at,
    e.reviewed_by,


### PR DESCRIPTION
* Using jsonb_object_keys on an empty JSOB won't return anything. Since it does an implicit LATERAL JOIN it won't include the record with empty geo_coverage_type in the results. To fix it, we are executing a sub-query to get the results from jsonb_object_keys which will return null for empty geo_coverage_type cases. This is probably not the best solution but a temporary one. We'll soon refactor intiatives schema and simplify many things such as this column.