### PR TITLE
Fix URL handle in GET `/image/{image-type}/{id}`

### DIFF
--- a/backend/src/gpml/handler/image.clj
+++ b/backend/src/gpml/handler/image.clj
@@ -1,6 +1,7 @@
 (ns gpml.handler.image
   (:require [clj-gcp.storage.core :as sut]
             [clojure.string :as str]
+            [duct.logger :refer [log]]
             [gpml.boundary.port.storage-client :as storage-client]
             [gpml.db.event :as db.event]
             [gpml.db.stakeholder :as db.stakeholder]
@@ -78,21 +79,23 @@
 
 (defn- handle-img-resp-from-url
   [logger img-url]
-  (if-not (util/try-url-str img-url)
-    (resp/not-found {:message "Image not found (not valid url)"})
-    (let [{:keys [status headers body]} (http-client/do-request logger
-                                                                {:method :get
-                                                                 :url img-url
-                                                                 :as :byte-array}
-                                                                {})]
-      (if (<= 200 status 299)
-        (-> body
-            (resp/response)
-            (resp/content-type (get headers "Content-Type"))
-            (resp/header "Cache-Control" "public,max-age:60"))
-        (resp/not-found {:message "Image not found (could not fetch the url)"})))))
+  (let [{:keys [status headers body] :as result} (http-client/do-request logger
+                                                                         {:method :get
+                                                                          :url img-url
+                                                                          :as :byte-array}
+                                                                         {})]
+    (if (and status
+             (<= 200 status 299))
+      (-> body
+          (resp/response)
+          (resp/content-type (get headers "Content-Type"))
+          (resp/header "Cache-Control" "public,max-age:60"))
+      (do
+        (log logger :error ::could-not-fetch-image {:status status
+                                                    :reason-phrase (:reason-phrase result)})
+        (resp/not-found {:message "Image not found (could not download the image)"})))))
 
-(defmethod ig/init-key :gpml.handler.image/get [{:keys [logger]} {:keys [db]}]
+(defmethod ig/init-key :gpml.handler.image/get [_ {:keys [logger db]}]
   (fn [{{{:keys [id image_type]} :path} :parameters}]
     (if-let [data (cond
                     (= image_type "profile")
@@ -100,8 +103,19 @@
                     (= image_type "event")
                     (:image (db.event/event-image-by-id (:spec db) {:id id}))
                     :else nil)]
-      (if (and (seq data)
-               (util/base64? (util/base64-headless data)))
-        (get-content data)
-        (handle-img-resp-from-url logger data))
+      (cond (util/try-url-str data)
+            (handle-img-resp-from-url logger data)
+
+            (and
+             (seq data)
+             (seq (util/base64-headless data))
+             (util/base64? (util/base64-headless data)))
+            (get-content data)
+
+            :else
+            (do
+              (log logger :error ::could-not-fetch-url {:data data
+                                                        :id id
+                                                        :image-type image_type})
+              (resp/not-found {:message "Image not found (could not fetch the url)"})))
       (resp/not-found {:message "Image not found"}))))


### PR DESCRIPTION
[closes #1492]

We were not handling image URLs appropriately, so now we check first if we can build a URL out of the image got from DB, so we try to download the image in that case, as before. However, if we cannot make a URL we make sure we have a valid string before trying to parse the image as Base64 content.

Now we also do proper logging, as we were not doing much before and we were expecting the logger config in the wrong place as argument.

Now the fetch image function is also safer in case there is no `status` got from the result, before trying to do further checks with its value.