### PR TITLE
Fix permission check when user didn't verify the email

### DIFF
--- a/backend/src/gpml/auth.clj
+++ b/backend/src/gpml/auth.clj
@@ -93,7 +93,7 @@
                          (:email_verified jwt-claims)
                          (db.stakeholder/stakeholder-by-email conn jwt-claims))]
     {:approved? (= "APPROVED" (:review_status stakeholder))
-     :user stakeholder}))
+     :user (or stakeholder {})}))
 
 (defn id-token-verifier
   [signature-verifier opts]

--- a/backend/src/gpml/auth.clj
+++ b/backend/src/gpml/auth.clj
@@ -93,7 +93,7 @@
                          (:email_verified jwt-claims)
                          (db.stakeholder/stakeholder-by-email conn jwt-claims))]
     {:approved? (= "APPROVED" (:review_status stakeholder))
-     :user (or stakeholder {})}))
+     :user (or stakeholder nil)}))
 
 (defn id-token-verifier
   [signature-verifier opts]

--- a/backend/src/gpml/handler/resource/permission.clj
+++ b/backend/src/gpml/handler/resource/permission.clj
@@ -64,18 +64,18 @@
     ;; The following checks are mostly to avoid doing a lot of work
     ;; when checking the user permissions on a specific resource.
     (cond
+      ;; If it's a read attempt, the resource is approved and the user
+      ;; is logged in then we should allow without checking extra
+      ;; permissions.
+      (and read?
+           (= (:review_status resource) "APPROVED"))
+      resource
+
       ;; If the user is empty it means the caller doesn't have a
       ;; session and is just making a read call on the resource. So no
       ;; need to check extra permissions since platform resources are
       ;; public in a read-only state.
       (and (not (seq user))
-           (= (:review_status resource) "APPROVED"))
-      resource
-
-      ;; If it's a read attempt, the resource is approved and the user
-      ;; is logged in then we should allow without checking extra
-      ;; permissions.
-      (and read?
            (= (:review_status resource) "APPROVED"))
       resource
 


### PR DESCRIPTION
* If the user doesn't verify the email our BE authentication code assign a false value to the `:user` key in the autentication details. That was causing a problem when checking for permissions as we do `seq` on the `:user` key's value. That would case an exception. So now instead of assigning a false value we assign an empty map.
* I also changed in what order the permissions are checked because if it's a read we don't have to check for the user as resources are publicly readable.