### PR TITLE
Fix stakeholder affiliation submission and read permissions

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -223,18 +223,18 @@
                                           [""
                                            {:get {:middleware [#ig/ref :gpml.auth/auth-required
                                                                #ig/ref :gpml.auth/approved-user
-                                                               #ig/ref :gpml.auth/admin-required-middleware]
+                                                               #ig/ref :gpml.auth/admin-or-profile-owner-required-middleware]
                                                   :summary "Get a stakeholder by id"
                                                   :swagger {:tags ["stakeholder"]}
                                                   :parameters {:path [:map [:id int?]]}
                                                   :handler #ig/ref :gpml.handler.stakeholder/get-by-id}
                                             :put {:middleware [#ig/ref :gpml.auth/auth-required
                                                                #ig/ref :gpml.auth/approved-user
-                                                               #ig/ref :gpml.auth/admin-required-middleware]
+                                                               #ig/ref :gpml.auth/admin-or-profile-owner-required-middleware]
                                                   :summary "Edit stakeholder's data"
                                                   :swagger {:tags ["stakeholder"]}
-                                                  :parameters #ig/ref :gpml.handler.stakeholder/put-by-admin-params
-                                                  :handler #ig/ref :gpml.handler.stakeholder/put-by-admin}
+                                                  :parameters #ig/ref :gpml.handler.stakeholder/put-restricted-params
+                                                  :handler #ig/ref :gpml.handler.stakeholder/put-restricted}
                                             :patch {:middleware [#ig/ref :gpml.auth/auth-required
                                                                  #ig/ref :gpml.auth/approved-user
                                                                  #ig/ref :gpml.auth/admin-required-middleware]
@@ -695,8 +695,8 @@
   :gpml.handler.stakeholder/post #ig/ref :gpml.config/common
   :gpml.handler.stakeholder/post-params {}
   :gpml.handler.stakeholder/put #ig/ref :gpml.config/common
-  :gpml.handler.stakeholder/put-by-admin #ig/ref :gpml.config/common
-  :gpml.handler.stakeholder/put-by-admin-params {}
+  :gpml.handler.stakeholder/put-restricted #ig/ref :gpml.config/common
+  :gpml.handler.stakeholder/put-restricted-params {}
   :gpml.handler.stakeholder-association/get-associated-topics {:db #ig/ref :duct.database/sql}
   :gpml.handler.stakeholder-association/get-associated-topics-params {}
 
@@ -871,6 +871,7 @@
   :gpml.auth/admin-required-middleware {:db #ig/ref :duct.database/sql}
   :gpml.auth/admin-or-reviewer-required-middleware {:db #ig/ref :duct.database/sql}
   :gpml.auth/restrict-to-project-owner #ig/ref :gpml.config/common
+  :gpml.auth/admin-or-profile-owner-required-middleware {}
 
   :gpml.handler.monitoring/collector {}
 

--- a/backend/src/gpml/auth.clj
+++ b/backend/src/gpml/auth.clj
@@ -176,6 +176,15 @@
         {:status 403
          :body {:message "Unauthorized"}}))))
 
+(defmethod ig/init-key :gpml.auth/admin-or-profile-owner-required-middleware [_ _]
+  (fn [handler]
+    (fn [{:keys [user parameters] :as request}]
+      (if (or (= "ADMIN" (:role user))
+              (= (get-in parameters [:path :id]) (:id user)))
+        (handler (assoc request :admin user))
+        {:status 403
+         :body {:message "Unauthorized"}}))))
+
 (defmethod ig/init-key :gpml.auth/admin-or-reviewer-required-middleware [_ _]
   (fn [handler]
     (fn [{:keys [user approved?] :as request}]

--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -483,7 +483,7 @@
                                     (extra-details topic conn details)))
                             {:owners (:owners details)}))
             (r/not-found {}))
-          (r/unauthorized {})))
+          (r/forbidden {})))
       (catch Exception e
         (log logger :error ::failed-to-get-resource-details {:exception-message (.getMessage e)
                                                              :context-data {:path-params path

--- a/backend/src/gpml/handler/stakeholder.clj
+++ b/backend/src/gpml/handler/stakeholder.clj
@@ -66,7 +66,6 @@
                              linked_in
                              public_database
                              public_email
-                             non_member_organisation
                              cv
                              affiliation
                              job_title
@@ -86,13 +85,12 @@
    :country           country
    :public_email      (boolean public_email)
    :public_database   public_database
-   :affiliation       (or affiliation (when (and non_member_organisation (pos? non_member_organisation)) non_member_organisation))
-   :job_title job_title})
+   :affiliation       affiliation
+   :job_title         job_title})
 
 (defn- create-profile
   [{:keys [id photo picture about
            title first_name role
-           non_member_organisation
            last_name idp_usernames
            linked_in cv twitter email
            affiliation job_title
@@ -100,14 +98,13 @@
            reviewed_at reviewed_by review_status
            organisation_role public_email]}
    tags
-   geo
    org]
   (let [{:keys [seeking offering expertise]} (->> tags
                                                   (group-by :tag_relation_category)
                                                   (reduce-kv (fn [m k v] (assoc m (keyword k) (map :tag v))) {}))]
     {:id id
      :title title
-     :affiliation (or affiliation (when (and non_member_organisation (pos? non_member_organisation)) non_member_organisation))
+     :affiliation affiliation
      :job_title job_title
      :first_name first_name
      :last_name last_name
@@ -124,7 +121,6 @@
      :expertise expertise
      :tags tags
      :geo_coverage_type geo_coverage_type
-     :geo_coverage_value geo
      :org org
      :about about
      :role role
@@ -181,26 +177,17 @@
         tags (db.resource.tag/get-resource-tags conn {:table "stakeholder_tag"
                                                       :resource-col "stakeholder"
                                                       :resource-id (:id stakeholder)})
-        org (db.organisation/organisation-by-id conn {:id (:affiliation stakeholder)})
-        geo-type (:geo_coverage_type stakeholder)
-        geo-value (db.stakeholder/get-stakeholder-geo conn stakeholder)
-        geo (cond
-              (contains? #{"regional" "global with elements in specific areas"} geo-type)
-              (mapv :country_group geo-value)
-              (contains? #{"national" "transnational" "sub-national"} geo-type)
-              (mapv :country geo-value))
-        profile (create-profile stakeholder tags geo org)]
-    (if (-> profile :org :is_member)
-      (assoc profile :affiliation (-> profile :org :id) :non_member_organisation nil)
-      (assoc profile :non_member_organisation (-> profile :org :id) :affiliation nil))))
+        org (db.organisation/organisation-by-id conn {:id (:affiliation stakeholder)})]
+    (create-profile stakeholder tags org)))
 
 (defn- update-stakeholder
   [{:keys [logger mailjet-config] :as config} tx {:keys [body-params old-profile]}]
-  (let [{:keys [id]} body-params
-        new-profile (merge (dissoc old-profile :non_member_organisation)
-                           (if (:non_member_organisation body-params)
-                             (-> body-params (assoc :affiliation (:non_member_organisation body-params)) (dissoc :non_member_organisation))
-                             body-params))
+  (let [{:keys [id org]} body-params
+        new-profile (merge
+                     old-profile
+                     (if (:id org)
+                       (-> body-params (assoc :affiliation (:id org)) (dissoc :org :org-name))
+                       body-params))
         profile (create-new-profile config tx new-profile body-params)
         tags (handler.stakeholder.tag/api-stakeholder-tags->stakeholder-tags body-params)]
     (db.stakeholder/update-stakeholder tx profile)

--- a/backend/src/gpml/handler/stakeholder.clj
+++ b/backend/src/gpml/handler/stakeholder.clj
@@ -563,7 +563,7 @@
       (resp/response
        (get-stakeholder-profile db stakeholder)))))
 
-(defmethod ig/init-key :gpml.handler.stakeholder/put-by-admin
+(defmethod ig/init-key :gpml.handler.stakeholder/put-restricted
   [_ {:keys [db logger] :as config}]
   (fn [{{:keys [path body]} :parameters}]
     (try
@@ -581,7 +581,7 @@
             response
             (assoc-in response [:body :error-details :error] (.getMessage e))))))))
 
-(defmethod ig/init-key :gpml.handler.stakeholder/put-by-admin-params [_ _]
+(defmethod ig/init-key :gpml.handler.stakeholder/put-restricted-params [_ _]
   {:path [:map [:id int?]]
    :body [:map
           [:id {:optional true} int?]


### PR DESCRIPTION
* Fix permissions check for stakeholder. Stakeholders should be able to see their own profiles and allow other approved stakeholders see it too.
* Fix affiliation management to allow conversion from/to private citizen to member/non-member org affiliations.