### PR TITLE
[#1509] Add missing program param in org spec on sign up endpoint

### DIFF
--- a/backend/src/gpml/handler/stakeholder.clj
+++ b/backend/src/gpml/handler/stakeholder.clj
@@ -461,6 +461,7 @@
          [:name {:optional true} string?]
          [:url {:optional true} string?]
          [:type {:optional true} string?] ;;representative_group
+         [:program {:optional true} string?]
          [:representative_group_government {:optional true} string?]
          [:representative_group_private_sector {:optional true} string?]
          [:representative_group_academia_research {:optional true} string?]


### PR DESCRIPTION
TODO: we should move all the organisation logic from `/profile` to `/organisation` endpoint as they are independent flows now from FE POV.