### PR TITLE
1508 support case study resource type

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -590,7 +590,16 @@
                                          {:post {:summary "Send an email to GPML Secretariat about a new subscription request"
                                                  :swagger {:tags ["subscribe"]}
                                                  :handler #ig/ref :gpml.handler.subscribe/post
-                                                 :parameters #ig/ref :gpml.handler.subscribe/post-params}}]]]
+                                                 :parameters #ig/ref :gpml.handler.subscribe/post-params}}]
+                                        ["/case-study" {:middleware [#ig/ref :gpml.auth/auth-middleware
+                                                                     #ig/ref :gpml.auth/auth-required
+                                                                     #ig/ref :gpml.auth/approved-user]}
+                                         [""
+                                          {:post {:summary "Create a new case study"
+                                                  :swagger {:tags ["case-study"]}
+                                                  :handler #ig/ref :gpml.handler.case-study/post
+                                                  :parameters #ig/ref :gpml.handler.case-study/post-params
+                                                  :responses #ig/ref :gpml.handler.case-study/post-responses}}]]]]
                               :logger #ig/ref :duct.logger/timbre}
 
   ;; Consts
@@ -831,6 +840,10 @@
   :gpml.handler.project/delete #ig/ref :gpml.config/common
   :gpml.handler.project/delete-params {}
   :gpml.handler.project/delete-responses {}
+
+  :gpml.handler.case-study/post #ig/ref :gpml.config/common
+  :gpml.handler.case-study/post-params {}
+  :gpml.handler.case-study/post-responses {}
 
   :gpml.handler.programmatic.brs-api-importer/post #ig/ref :gpml.config/common
 

--- a/backend/resources/migrations/178-add-source-prop-to-all-res-types.up.sql
+++ b/backend/resources/migrations/178-add-source-prop-to-all-res-types.up.sql
@@ -1,0 +1,26 @@
+BEGIN;
+--;; Create new resource source enum
+--;;
+CREATE TYPE RESOURCE_SOURCE AS ENUM('gpml','cobsea');
+--;;
+--;; Add it to each resource type as not null with predefined value to indicate
+--;; that by default the content source is the gpml platform.
+ALTER TABLE IF EXISTS policy
+  ADD COLUMN source RESOURCE_SOURCE NOT NULL DEFAULT 'gpml';
+--;;
+ALTER TABLE IF EXISTS event
+  ADD COLUMN source RESOURCE_SOURCE NOT NULL DEFAULT 'gpml';
+--;;
+ALTER TABLE IF EXISTS initiative
+  ADD COLUMN source RESOURCE_SOURCE NOT NULL DEFAULT 'gpml';
+--;;
+ALTER TABLE IF EXISTS resource
+  ADD COLUMN source RESOURCE_SOURCE NOT NULL DEFAULT 'gpml';
+--;;
+ALTER TABLE IF EXISTS technology
+  ADD COLUMN source RESOURCE_SOURCE NOT NULL DEFAULT 'gpml';
+--;;
+ALTER TABLE IF EXISTS project
+  ADD COLUMN source RESOURCE_SOURCE NOT NULL DEFAULT 'gpml';
+--;;
+COMMIT;

--- a/backend/resources/migrations/179-setup-case-study-res-type-schema.up.sql
+++ b/backend/resources/migrations/179-setup-case-study-res-type-schema.up.sql
@@ -1,0 +1,95 @@
+BEGIN;
+--;; Base entity definition
+--;;
+CREATE TABLE IF NOT EXISTS case_study (
+  id SERIAL NOT NULL PRIMARY KEY,
+  title TEXT NOT NULL,
+  description TEXT,
+  geo_coverage_type GEO_COVERAGE_TYPE NOT NULL,
+  source RESOURCE_SOURCE NOT NULL DEFAULT 'gpml',
+  publish_year SMALLINT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  last_modified_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  reviewed_at TIMESTAMP,
+  reviewed_by INTEGER REFERENCES stakeholder(id) ON UPDATE CASCADE,
+  review_status REVIEW_STATUS DEFAULT 'SUBMITTED' NOT NULL,
+  created_by INTEGER NOT NULL REFERENCES stakeholder(id) ON UPDATE CASCADE,
+  image TEXT,
+  thumbnail TEXT,
+  language VARCHAR(3) NOT NULL REFERENCES language (iso_code) ON UPDATE CASCADE,
+  featured BOOLEAN DEFAULT FALSE,
+  capacity_building BOOLEAN NOT NULL DEFAULT FALSE
+);
+--;;
+--;; Geo-coverage related schema
+CREATE TABLE IF NOT EXISTS case_study_geo_coverage (
+  id SERIAL NOT NULL PRIMARY KEY,
+  case_study_id INTEGER NOT NULL REFERENCES case_study(id) ON DELETE CASCADE,
+  country_id INTEGER REFERENCES country(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  country_group_id INTEGER REFERENCES country_group(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+--;;
+ALTER TABLE IF EXISTS case_study_geo_coverage
+  ADD CONSTRAINT case_study_geo_coverage_unique UNIQUE (case_study_id, country_id, country_group_id);
+--;;
+CREATE UNIQUE INDEX IF NOT EXISTS case_study_geo_coverage_case_study_id_country_id_idx
+  ON case_study_geo_coverage (
+    case_study_id,
+    country_id)
+  WHERE country_id IS NULL;
+--;;
+CREATE UNIQUE INDEX IF NOT EXISTS case_study_geo_coverage_case_study_id_country_group_id_idx
+  ON case_study_geo_coverage (
+    case_study_id,
+    country_group_id)
+  WHERE country_group_id IS NULL;
+--;;
+--;; Tags related schema
+--;;
+CREATE TABLE IF NOT EXISTS case_study_tag (
+  id serial NOT NULL PRIMARY KEY,
+  case_study INTEGER NOT NULL REFERENCES case_study(id) ON DELETE CASCADE,
+  tag integer NOT NULL REFERENCES tag(id) ON DELETE CASCADE,
+  CONSTRAINT case_study_tag_unique UNIQUE(case_study, tag)
+);
+--;;
+--;; Stakeholder relationship
+CREATE TYPE case_study_association AS
+  ENUM ('implementor', 'owner', 'donor', 'partner', 'resource_editor');
+-- ;;
+CREATE TABLE IF NOT EXISTS stakeholder_case_study (
+  id serial PRIMARY KEY,
+  stakeholder INTEGER NOT NULL REFERENCES stakeholder(id) ON DELETE CASCADE,
+  case_study INTEGER NOT NULL REFERENCES case_study(id) ON DELETE CASCADE,
+  association case_study_association NOT NULL,
+  remarks text,
+  created timestamptz NOT NULL DEFAULT now(),
+  modified timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(stakeholder, case_study, association)
+);
+--;;
+--;; Organisation relationship
+--;;
+CREATE TABLE IF NOT EXISTS organisation_case_study (
+  id serial PRIMARY KEY,
+  organisation INTEGER NOT NULL REFERENCES organisation(id) ON DELETE CASCADE,
+  case_study INTEGER NOT NULL REFERENCES case_study(id) ON DELETE CASCADE,
+  association case_study_association NOT NULL,
+  remarks text,
+  created timestamptz NOT NULL DEFAULT now(),
+  modified timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(organisation, case_study, association)
+);
+--;; Translations schema
+--;;
+CREATE TABLE IF NOT EXISTS case_study_translation (
+  case_study_id INTEGER,
+  translatable_field TEXT,
+  language VARCHAR(3),
+  value TEXT NOT NULL,
+  PRIMARY KEY (case_study_id, translatable_field, language),
+  FOREIGN KEY (case_study_id) REFERENCES case_study(id) ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY (language) REFERENCES language(iso_code) ON UPDATE CASCADE ON DELETE CASCADE
+);
+--;;
+COMMIT;

--- a/backend/resources/migrations/179-setup-case-study-res-type-schema.up.sql
+++ b/backend/resources/migrations/179-setup-case-study-res-type-schema.up.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS case_study (
   geo_coverage_type GEO_COVERAGE_TYPE NOT NULL,
   source RESOURCE_SOURCE NOT NULL DEFAULT 'gpml',
   publish_year SMALLINT,
-  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  created TIMESTAMP NOT NULL DEFAULT NOW(),
   last_modified_at TIMESTAMP NOT NULL DEFAULT NOW(),
   reviewed_at TIMESTAMP,
   reviewed_by INTEGER REFERENCES stakeholder(id) ON UPDATE CASCADE,
@@ -24,25 +24,25 @@ CREATE TABLE IF NOT EXISTS case_study (
 --;; Geo-coverage related schema
 CREATE TABLE IF NOT EXISTS case_study_geo_coverage (
   id SERIAL NOT NULL PRIMARY KEY,
-  case_study_id INTEGER NOT NULL REFERENCES case_study(id) ON DELETE CASCADE,
-  country_id INTEGER REFERENCES country(id) ON DELETE CASCADE ON UPDATE CASCADE,
-  country_group_id INTEGER REFERENCES country_group(id) ON DELETE CASCADE ON UPDATE CASCADE
+  case_study INTEGER NOT NULL REFERENCES case_study(id) ON DELETE CASCADE,
+  country INTEGER REFERENCES country(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  country_group INTEGER REFERENCES country_group(id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 --;;
 ALTER TABLE IF EXISTS case_study_geo_coverage
-  ADD CONSTRAINT case_study_geo_coverage_unique UNIQUE (case_study_id, country_id, country_group_id);
+  ADD CONSTRAINT case_study_geo_coverage_unique UNIQUE (case_study, country, country_group);
 --;;
-CREATE UNIQUE INDEX IF NOT EXISTS case_study_geo_coverage_case_study_id_country_id_idx
+CREATE UNIQUE INDEX IF NOT EXISTS case_study_geo_coverage_case_study_country_idx
   ON case_study_geo_coverage (
-    case_study_id,
-    country_id)
-  WHERE country_id IS NULL;
+    case_study,
+    country)
+  WHERE country IS NULL;
 --;;
-CREATE UNIQUE INDEX IF NOT EXISTS case_study_geo_coverage_case_study_id_country_group_id_idx
+CREATE UNIQUE INDEX IF NOT EXISTS case_study_geo_coverage_case_study_country_group_idx
   ON case_study_geo_coverage (
-    case_study_id,
-    country_group_id)
-  WHERE country_group_id IS NULL;
+    case_study,
+    country_group)
+  WHERE country_group IS NULL;
 --;;
 --;; Tags related schema
 --;;
@@ -55,7 +55,7 @@ CREATE TABLE IF NOT EXISTS case_study_tag (
 --;;
 --;; Stakeholder relationship
 CREATE TYPE case_study_association AS
-  ENUM ('implementor', 'owner', 'donor', 'partner', 'resource_editor');
+  ENUM ('implementor', 'owner', 'donor', 'partner', 'interested in', 'resource_editor');
 -- ;;
 CREATE TABLE IF NOT EXISTS stakeholder_case_study (
   id serial PRIMARY KEY,
@@ -91,5 +91,9 @@ CREATE TABLE IF NOT EXISTS case_study_translation (
   FOREIGN KEY (case_study_id) REFERENCES case_study(id) ON UPDATE CASCADE ON DELETE CASCADE,
   FOREIGN KEY (language) REFERENCES language(iso_code) ON UPDATE CASCADE ON DELETE CASCADE
 );
+--;;
+--;; Add additional topic type
+ALTER TYPE topic_type
+  ADD VALUE 'case_study';
 --;;
 COMMIT;

--- a/backend/src/gpml/constants.clj
+++ b/backend/src/gpml/constants.clj
@@ -3,7 +3,7 @@
 (def ^:const topic-tables
   "The list of tables considered as topics in the current model of the
   GPML platform as of 2022-03-16."
-  ["event" "technology" "policy" "initiative" "resource"])
+  ["event" "technology" "policy" "initiative" "case_study" "resource"])
 
 (def ^:const geo-coverage-entity-tables
   "The list of tables with geo coverage relations."
@@ -16,7 +16,7 @@
 (def topics
   (vec
    (sort
-    (apply conj resource-types ["event" "technology" "policy" "initiative" "stakeholder" "organisation" "non_member_organisation"]))))
+    (apply conj resource-types ["event" "technology" "policy" "initiative" "stakeholder" "organisation" "non_member_organisation" "case_study"]))))
 
 (def reviewer-review-status [:PENDING :ACCEPTED :REJECTED])
 

--- a/backend/src/gpml/db/case_study.clj
+++ b/backend/src/gpml/db/case_study.clj
@@ -1,0 +1,20 @@
+(ns gpml.db.case-study
+  {:ns-tracker/resource-deps ["case_study.sql"]}
+  (:require [gpml.util :as util]
+            [gpml.util.sql :as sql-util]
+            [hugsql.core :as hugsql]))
+
+(declare create-case-studies)
+
+(hugsql/def-db-fns "gpml/db/case_study.sql")
+
+(defn case-study->db-case-study
+  "Transform case study to be ready to be persisted in DB
+
+   We want to have a specific function for this, since thus we can keep untouched
+   the canonical entity representation."
+  [case-study]
+  (-> case-study
+      (util/update-if-not-nil :geo_coverage_type #(sql-util/keyword->pg-enum % "geo_coverage_type"))
+      (util/update-if-not-nil :review_status #(sql-util/keyword->pg-enum % "review_status"))
+      (util/update-if-not-nil :source #(sql-util/keyword->pg-enum % "resource_source"))))

--- a/backend/src/gpml/db/case_study.sql
+++ b/backend/src/gpml/db/case_study.sql
@@ -1,0 +1,4 @@
+-- :name create-case-studies :returning-execute :many
+-- :doc Create new case studies
+insert into case_study (:i*:insert-cols)
+values :t*:insert-values returning id;

--- a/backend/src/gpml/db/event.clj
+++ b/backend/src/gpml/db/event.clj
@@ -30,4 +30,5 @@
   (-> event
       (util/update-if-not-nil :brs_api_modified sql-util/instant->sql-timestamp)
       (util/update-if-not-nil :geo_coverage_type sql-util/keyword->pg-enum "geo_coverage_type")
-      (util/update-if-not-nil :review_status sql-util/keyword->pg-enum "review_status")))
+      (util/update-if-not-nil :review_status sql-util/keyword->pg-enum "review_status")
+      (util/update-if-not-nil :source #(sql-util/keyword->pg-enum % "resource_source"))))

--- a/backend/src/gpml/db/event.sql
+++ b/backend/src/gpml/db/event.sql
@@ -22,6 +22,7 @@ INSERT INTO event(
 --~ (when (contains? params :recording) ", recording")
 --~ (when (contains? params :subnational_city) ", subnational_city")
 --~ (when (contains? params :document_preview) ", document_preview")
+--~ (when (contains? params :source) ", source")
 )
 VALUES(
     :title,
@@ -45,6 +46,7 @@ VALUES(
 --~ (when (contains? params :recording) ", :recording")
 --~ (when (contains? params :subnational_city) ", :subnational_city")
 --~ (when (contains? params :document_preview) ", :document_preview")
+--~ (when (contains? params :source) ", :source")
 ) RETURNING id;
 
 -- :name add-event-language-urls :returning-execute :one

--- a/backend/src/gpml/db/initiative.clj
+++ b/backend/src/gpml/db/initiative.clj
@@ -38,4 +38,5 @@
       ;; FIXME: once initiative schema is refactored and geo coverage
       ;; type is a enum typed column, uncomment the next line.
       ;;(util/update-if-not-nil :geo_coverage_type sql-util/keyword->pg-enum "geo_coverage_type")
-      (util/update-if-not-nil :review_status sql-util/keyword->pg-enum "review_status")))
+      (util/update-if-not-nil :review_status sql-util/keyword->pg-enum "review_status")
+      (util/update-if-not-nil :source #(sql-util/keyword->pg-enum % "resource_source"))))

--- a/backend/src/gpml/db/policy.clj
+++ b/backend/src/gpml/db/policy.clj
@@ -33,4 +33,5 @@
       (util/update-if-not-nil :latest_amendment_date jt/sql-date)
       (util/update-if-not-nil :attachments sql-util/coll->pg-jsonb)
       (util/update-if-not-nil :topics #(pg-util/->JDBCArray % "text"))
+      (util/update-if-not-nil :source #(sql-util/keyword->pg-enum % "resource_source"))
       (dissoc :tags)))

--- a/backend/src/gpml/db/policy.sql
+++ b/backend/src/gpml/db/policy.sql
@@ -26,6 +26,7 @@ insert into policy(
 --~ (when (contains? params :topics) ", topics")
 --~ (when (contains? params :subnational_city) ", subnational_city")
 --~ (when (contains? params :document_preview) ", document_preview")
+--~ (when (contains? params :source) ", source")
 )
 values(
     :title,
@@ -53,6 +54,7 @@ values(
 --~ (when (contains? params :topics) ", :topics")
 --~ (when (contains? params :subnational_city) ", :subnational_city")
 --~ (when (contains? params :document_preview) ", :document_preview")
+--~ (when (contains? params :source) ", :source")
 )
 returning id;
 

--- a/backend/src/gpml/db/project.clj
+++ b/backend/src/gpml/db/project.clj
@@ -32,4 +32,5 @@
       (util/update-if-not-nil :checklist pg-util/val->jsonb)
       (util/update-if-not-nil :answers pg-util/val->jsonb)
       (util/update-if-not-nil :stage #(pg-util/->PGEnum % "project_stage"))
+      (util/update-if-not-nil :source #(pg-util/->PGEnum % "resource_source"))
       (dissoc :geo_coverage_countries :geo_coverage_country_groups)))

--- a/backend/src/gpml/db/resource.clj
+++ b/backend/src/gpml/db/resource.clj
@@ -20,4 +20,5 @@
   (-> resource
       (util/update-if-not-nil :brs_api_modified sql-util/instant->sql-timestamp)
       (util/update-if-not-nil :geo_coverage_type sql-util/keyword->pg-enum "geo_coverage_type")
-      (util/update-if-not-nil :review_status sql-util/keyword->pg-enum "review_status")))
+      (util/update-if-not-nil :review_status sql-util/keyword->pg-enum "review_status")
+      (util/update-if-not-nil :source #(sql-util/keyword->pg-enum % "resource_source"))))

--- a/backend/src/gpml/db/resource.sql
+++ b/backend/src/gpml/db/resource.sql
@@ -27,6 +27,7 @@ INSERT INTO resource(
 --~ (when (contains? params :capacity_building) ", capacity_building")
 --~ (when (contains? params :subnational_city) ", subnational_city")
 --~ (when (contains? params :document_preview) ", document_preview")
+--~ (when (contains? params :source) ", source")
 )
 VALUES(
     :title,
@@ -55,6 +56,7 @@ VALUES(
 --~ (when (contains? params :capacity_building) ", :capacity_building")
 --~ (when (contains? params :subnational_city) ", :subnational_city")
 --~ (when (contains? params :document_preview) ", :document_preview")
+--~ (when (contains? params :source) ", :source")
 )
 returning id;
 

--- a/backend/src/gpml/db/resource/related_content.sql
+++ b/backend/src/gpml/db/resource/related_content.sql
@@ -1,4 +1,4 @@
--- :name create-related-contents :insert :affected
+-- :name create-related-contents :execute :affected
 INSERT INTO related_content(:i*:insert-cols)
 VALUES :t*:insert-values;
 

--- a/backend/src/gpml/db/review.sql
+++ b/backend/src/gpml/db/review.sql
@@ -10,6 +10,7 @@ SELECT r.*, (CASE
    WHEN r.topic_type = 'resource' THEN (SELECT ARRAY[t.title, t.image] FROM resource t WHERE t.id = r.topic_id)
    WHEN r.topic_type = 'event' THEN (SELECT ARRAY[t.title, t.image] FROM event t WHERE t.id = r.topic_id)
    WHEN r.topic_type = 'policy' THEN (SELECT ARRAY[t.title, t.image] FROM policy t WHERE t.id = r.topic_id)
+   WHEN r.topic_type = 'case_study' THEN (SELECT ARRAY[t.title, t.image] FROM case_study t WHERE t.id = r.topic_id)
    WHEN r.topic_type = 'organisation' THEN (SELECT ARRAY[t.name, t.logo] FROM organisation t WHERE t.id = r.topic_id)
    WHEN r.topic_type = 'stakeholder' THEN (SELECT ARRAY[CONCAT(title, '. ', last_name,' ', first_name), t.picture] FROM stakeholder t WHERE t.id = r.topic_id)
 END) AS details,
@@ -46,6 +47,7 @@ SELECT r.*, (CASE
   WHEN r.topic_type = 'resource' THEN (SELECT t.title FROM resource t WHERE t.id = r.topic_id)
   WHEN r.topic_type = 'event' THEN (SELECT t.title FROM event t WHERE t.id = r.topic_id)
   WHEN r.topic_type = 'policy' THEN (SELECT t.title FROM policy t WHERE t.id = r.topic_id)
+  WHEN r.topic_type = 'case_study' THEN (SELECT t.title FROM case_study t WHERE t.id = r.topic_id)
   WHEN r.topic_type = 'organisation' THEN (SELECT t.name FROM organisation t WHERE t.id = r.topic_id)
   WHEN r.topic_type = 'stakeholder' THEN (SELECT CONCAT(title, '. ', last_name,' ', first_name) FROM stakeholder t WHERE t.id = r.topic_id)
 END) AS title

--- a/backend/src/gpml/db/submission.sql
+++ b/backend/src/gpml/db/submission.sql
@@ -40,6 +40,10 @@ submission AS (
     SELECT id, 'initiative' AS type, 'initiative' AS topic, replace(q2::text,'"','') as title, created_by, created, 'USER' as role, review_status, '' as image, featured
     FROM initiative
 --~ (when (:review_status params) " WHERE review_status = :review_status::review_status ")
+    UNION
+    SELECT id, 'case_study' AS type, 'case_study' AS topic, title, created_by, created, 'USER' as role, review_status, image, featured
+    FROM case_study
+--~ (when (:review_status params) " WHERE review_status = :review_status::review_status ")
     order by created
 ),
 authz AS (

--- a/backend/src/gpml/db/technology.sql
+++ b/backend/src/gpml/db/technology.sql
@@ -23,6 +23,7 @@ insert into technology(
 --~ (when (contains? params :subnational_city) ", subnational_city")
 --~ (when (contains? params :headquarter) ", headquarter")
 --~ (when (contains? params :document_preview) ", document_preview")
+--~ (when (contains? params :source) ", source")
 )
 values(
     :name,
@@ -47,6 +48,7 @@ values(
 --~ (when (contains? params :subnational_city) ", :subnational_city")
 --~ (when (contains? params :headquarter) ", :headquarter")
 --~ (when (contains? params :document_preview) ", :document_preview")
+--~ (when (contains? params :source) ", :source")
 )
 returning id;
 

--- a/backend/src/gpml/db/topic.clj
+++ b/backend/src/gpml/db/topic.clj
@@ -9,12 +9,13 @@
 
 (def ^:const generic-cte-opts
   "Common set of options for all CTE generation functions."
-  {:tables ["event" "technology" "policy" "initiative" "resource"]
+  {:tables ["event" "technology" "policy" "initiative" "resource" "case_study"]
    :search-text-fields {"event" ["title" "description" "remarks"]
                         "technology" ["name"]
                         "policy" ["title" "original_title" "abstract" "remarks"]
                         "initiative" ["q2" "q3"]
-                        "resource" ["title" "summary" "remarks"]}})
+                        "resource" ["title" "summary" "remarks"]
+                        "case_study" ["title" "description"]}})
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (def ^:const generic-entity-cte-opts
@@ -69,6 +70,10 @@
   "e.description AS summary,
    e.*")
 
+(def ^:const ^:private case-study-cols
+  "e.description AS summary,
+   e.*")
+
 (def ^:const ^:private technology-cols
   "e.name AS title,
    e.remarks AS summary,
@@ -113,6 +118,7 @@
     "policy" policy-cols
     "event" event-cols
     "technology" technology-cols
+    "case_study" case-study-cols
     "e.*"))
 
 (defn- build-topic-data-query

--- a/backend/src/gpml/domain/case_study.clj
+++ b/backend/src/gpml/domain/case_study.clj
@@ -1,0 +1,212 @@
+(ns gpml.domain.case-study
+  (:require [gpml.domain.related-content :as dom.rc]
+            [gpml.domain.types :as dom.types]
+            [gpml.util :as util]
+            [java-time :as jt]
+            [java-time.temporal]
+            [malli.core :as m]))
+
+(def ^:const entity-relation-keys
+  #{:geo_coverage_countries :geo_coverage_country_groups :tags
+    :individual_connections :entity_connections :related_content})
+
+;; TODO: Move Geo-Coverage part and other things to a shared space.
+(def CaseStudy
+  "The Case Study's entity model."
+  (m/schema
+   [:map
+    [:id
+     {:swagger
+      {:description "The Case Study's identifier"
+       :type "integer"}}
+     pos-int?]
+    [:title
+     {:swagger
+      {:description "The Case Study's title."
+       :type "string"
+       :allowEmptyValue false}}
+     [:string {:min 1}]]
+    [:description
+     {:optional true
+      :swagger
+      {:description "The Case Study's description."
+       :type "string"
+       :allowEmptyValue true}}
+     [:string {:min 1}]]
+    [:geo_coverage_type
+     {:decode/string keyword
+      :decode/json keyword
+      :swagger
+      {:description "The Case Study's geo_coverage_type."
+       :type "string"
+       :enum dom.types/geo-coverage-types
+       :allowEmptyValue false}}
+     (apply conj [:enum] (mapv keyword dom.types/geo-coverage-types))]
+    [:geo_coverage_countries
+     {:optional true
+      :swagger {:description "The Case Study's country reach."
+                :type "array"
+                :items {:type "integer"}}}
+     [:sequential
+      pos-int?]]
+    [:geo_coverage_country_groups
+     {:optional true
+      :swagger {:description "The Case Study's country groups reach."
+                :type "array"
+                :items {:type "integer"}}}
+     [:sequential
+      pos-int?]]
+    [:source
+     {:default dom.types/default-resource-source
+      :decode/string keyword
+      :decode/json keyword
+      :swagger {:description "Source platform of the Case Study"
+                :type "string"
+                :enum dom.types/resource-source-types}}
+     (apply conj [:enum] dom.types/resource-source-types)]
+    [:publish_year
+     {:optional true
+      :swagger
+      {:description "The Case Study's publication year."
+       :type "integer"}}
+     pos-int?]
+    [:created
+     {:optional true
+      :swagger
+      {:description "The Case Study's creation datetime."
+       :type "string"
+       :format "date-time"}
+      :decode/string (fn [s] (jt/instant s))}
+     inst?]
+    [:last_modified_at
+     {:optional true
+      :swagger
+      {:description "The Case Study's last modification datetime."
+       :type "string"
+       :format "date-time"}
+      :decode/string (fn [s] (jt/instant s))}
+     inst?]
+    [:reviewed_at
+     {:optional true
+      :swagger
+      {:description "The Case Study's review's datetime."
+       :type "string"
+       :format "date-time"}
+      :decode/string (fn [s] (jt/instant s))}
+     inst?]
+    [:reviewed_by
+     {:optional true
+      :swagger
+      {:type "integer"
+       :description "The Case Study's review's stakeholder reference."}}
+     pos-int?]
+    [:review_status
+     {:swagger
+      {:description "Review status of the Case Study"
+       :type "string"
+       :enum dom.types/review-statuses}}
+     (apply conj [:enum] dom.types/review-statuses)]
+    [:created_by
+     {:swagger
+      {:type "integer"
+       :description "The Case Study's creator's stakeholder reference."}}
+     pos-int?]
+    [:image
+     {:optional true
+      :swagger
+      {:description "The Case Study's image. Base64 encoded string."
+       :type "string"
+       :format "byte"}}
+     [:fn (comp util/base64? util/base64-headless)]]
+    [:thumbnail
+     {:optional true
+      :swagger
+      {:description "The Case Study's thumbnail image. Base64 encoded string."
+       :type "string"
+       :format "byte"}}
+     [:fn (comp util/base64? util/base64-headless)]]
+    [:language
+     {:swagger
+      {:description "The Case Study's default language (e.g., en)."
+       :type "string"}}
+     [string? {:min 2 :max 3}]]
+    [:featured
+     {:optional true
+      :swagger
+      {:description "Flag indicating if the Case Study is a featured resource."
+       :type "boolean"}}
+     boolean?]
+    [:capacity_building
+     {:optional true
+      :swagger
+      {:description "Flag indicating if the Case Study is a capacity building resource."
+       :type "boolean"}}
+     boolean?]
+    [:tags
+     {:optional true}
+     [:vector
+      [:map
+       [:id {:optional true} pos-int?]
+       [:tag string?]]]]
+    [:individual_connections
+     {:optional true
+      :swagger
+      {:description "The Case Study's individual connections from GPML platform."
+       :type "array"
+       :items
+       {:type "object"
+        :properties
+        {:stakeholder
+         {:description "A stakeholder identifier from the GPML platform."
+          :type "integer"}
+         :role
+         {:description "The role of the stakeholder for this specific case study."
+          :type "string"
+          :enum dom.types/association-types}}}}}
+     [:sequential
+      [:map
+       [:stakeholder pos-int?]
+       [:role (apply conj [:enum] dom.types/association-types)]]]]
+    [:entity_connections
+     {:optional true
+      :swagger
+      {:description "The Case Study's entity connections from GPML platform."
+       :type "array"
+       :items
+       {:type "object"
+        :properties
+        {:entity
+         {:description "An organisation identifier from the GPML platform."
+          :type "integer"}
+         :role
+         {:description "The role of the entity for this specific case study."
+          :type "string"
+          :enum dom.types/association-types}}}}}
+     [:sequential {:optional true}
+      [:map
+       [:entity pos-int?]
+       [:role (apply conj [:enum] dom.types/association-types)]]]]
+    [:related_content
+     {:optional true
+      :swagger
+      {:description "The Case Study's related content from GPML platform."
+       :type "array"
+       :items
+       {:type "object"
+        :properties
+        {:id
+         {:description "The related resource identifier."
+          :type "string"}
+         :type
+         {:description "The related resource type."
+          :type "string"
+          :enum dom.rc/resource-types}
+         :related_content_relation_type
+         {:description "The of relation with the resource."
+          :type "string"
+          :enum dom.rc/relation-types}}}}}
+     [:sequential
+      [:map
+       [:id pos-int?]
+       [:type (apply conj [:enum] dom.rc/resource-types)]
+       [:related_content_relation_type {:optional true} (apply conj [:enum] dom.rc/relation-types)]]]]]))

--- a/backend/src/gpml/domain/event.clj
+++ b/backend/src/gpml/domain/event.clj
@@ -43,4 +43,6 @@
     [:subnational_city {:optional true} [string? {:min 1}]]
     [:thumbnail {:optional true} [string? {:min 1}]]
     [:title {:optional false} [string? {:min 1}]]
-    [:url {:optional true} [string? {:min 1}]]]))
+    [:url {:optional true} [string? {:min 1}]]
+    [:source {:default dom.types/default-resource-source}
+     (apply conj [:enum] dom.types/resource-source-types)]]))

--- a/backend/src/gpml/domain/initiative.clj
+++ b/backend/src/gpml/domain/initiative.clj
@@ -25,4 +25,6 @@
     [:activities [string? {:min 1}]]
     [:qimage [string? {:min 1}]]
     [:brs_api_id [string? {:min 1}]]
-    [:brs_api_modified inst?]]))
+    [:brs_api_modified inst?]
+    [:source {:default dom.types/default-resource-source}
+     (apply conj [:enum] dom.types/resource-source-types)]]))

--- a/backend/src/gpml/domain/policy.clj
+++ b/backend/src/gpml/domain/policy.clj
@@ -355,6 +355,8 @@
       pos-int?]]
     [:source
      {:default dom.types/default-resource-source
+      :decode/string keyword
+      :decode/json keyword
       :swagger {:description "Source platform of the Policy"
                 :type "string"
                 :enum dom.types/resource-source-types}}

--- a/backend/src/gpml/domain/policy.clj
+++ b/backend/src/gpml/domain/policy.clj
@@ -352,4 +352,10 @@
      [:sequential
       {:min 1
        :error/message "Need at least one geo coverage value"}
-      pos-int?]]]))
+      pos-int?]]
+    [:source
+     {:default dom.types/default-resource-source
+      :swagger {:description "Source platform of the Policy"
+                :type "string"
+                :enum dom.types/resource-source-types}}
+     (apply conj [:enum] dom.types/resource-source-types)]]))

--- a/backend/src/gpml/domain/project.clj
+++ b/backend/src/gpml/domain/project.clj
@@ -91,10 +91,24 @@
                 :type "array"
                 :items {:type "integer"}}}
      [:sequential
-      pos-int?]]]))
+      pos-int?]]
+    [:source
+     {:default dom.types/default-resource-source
+      :swagger {:description "Source platform of the Project"
+                :type "string"
+                :enum dom.types/resource-source-types}}
+     (apply conj [:enum] dom.types/resource-source-types)]]))
 
 (defn create-project
   "Creates a new project entity adding the necessary default and unique
   values."
   [data]
-  (assoc data :id (util/uuid)))
+  (-> data
+      (assoc :id (util/uuid))
+      (update :source keyword)))
+
+(defn update-project
+  "Handle transformations to represent domain canonical entity."
+  [data]
+  (-> data
+      (util/update-if-not-nil :source keyword)))

--- a/backend/src/gpml/domain/project.clj
+++ b/backend/src/gpml/domain/project.clj
@@ -94,6 +94,8 @@
       pos-int?]]
     [:source
      {:default dom.types/default-resource-source
+      :decode/string keyword
+      :decode/json keyword
       :swagger {:description "Source platform of the Project"
                 :type "string"
                 :enum dom.types/resource-source-types}}
@@ -104,8 +106,7 @@
   values."
   [data]
   (-> data
-      (assoc :id (util/uuid))
-      (update :source keyword)))
+      (assoc :id (util/uuid))))
 
 (defn update-project
   "Handle transformations to represent domain canonical entity."

--- a/backend/src/gpml/domain/related_content.clj
+++ b/backend/src/gpml/domain/related_content.clj
@@ -12,7 +12,8 @@
     "technology"
     "financing_resource"
     "technical_resource"
-    "action_plan"})
+    "action_plan"
+    "case_study"})
 
 (def ^:const relation-types
   "Possible resource relation types.

--- a/backend/src/gpml/domain/resource.clj
+++ b/backend/src/gpml/domain/resource.clj
@@ -46,4 +46,6 @@
     [:valid_to {:optional true} [string? {:min 1}]]
     [:value {:optional true} [string? {:min 1}]]
     [:value_currency {:optional true} [string? {:min 1}]]
-    [:value_remarks {:optional true} [string? {:min 1}]]]))
+    [:value_remarks {:optional true} [string? {:min 1}]]
+    [:source {:default dom.types/default-resource-source}
+     (apply conj [:enum] dom.types/resource-source-types)]]))

--- a/backend/src/gpml/domain/translation.clj
+++ b/backend/src/gpml/domain/translation.clj
@@ -11,4 +11,5 @@
                  :other_tech_and_proc :other_monitoring :monitoring_protocol :monitored_data_access
                  :other_report_progress :other_reported_entity_progress :other_outcome_impact_eval
                  :kpis :co_benefits :other_lifecycle :other_impact_harm :other_sector
-                 :other_funding :other_duration}})
+                 :other_funding :other_duration}
+   :case_study #{:title :description}})

--- a/backend/src/gpml/domain/types.clj
+++ b/backend/src/gpml/domain/types.clj
@@ -26,3 +26,10 @@
     "resource_editor"
     "partner"
     "regulator"})
+
+(def ^:const default-resource-source "gpml")
+
+(def ^:const resource-source-types
+  "Source (platform) of a resource."
+  #{"gpml"
+    "cobsea"})

--- a/backend/src/gpml/domain/types.clj
+++ b/backend/src/gpml/domain/types.clj
@@ -2,34 +2,35 @@
   "Well-known domain global types definitions. These types are used
   across the domain model by several entities.")
 
+;; TODO: Refactor enums to be keywords instead of strings.
 (def ^:const review-statuses
   "Possible `review_status` values. This represent state of a domain
   model entity (Organisation, Stakeholder, Event, Policy, Technology,
   Resource, Initiative)."
   #{"APPROVED" "SUBMITTED" "REJECTED"})
 
+;; TODO: Refactor enums to be keywords instead of strings.
 (def ^:const geo-coverage-types
   "Possible `geo_coverage_type` values. This represent the geo coverage
   type of a domain model entity (Organisation, Stakeholder, Event,
   Policy, Technology, Resource, Initiative)."
   #{"global" "national" "transnational" "sub-national"})
 
+;; TODO: Refactor enums to be keywords instead of strings.
 (def ^:const association-types
   "Possible `<resource>_association` values. This represent
   association type of a domain model resource (Policy, Event,
   Technology, Resource and Initiative)."
   #{"implementor"
     "donor"
-    "reviewer"
     "interested in"
     "owner"
     "resource_editor"
-    "partner"
-    "regulator"})
+    "partner"})
 
-(def ^:const default-resource-source "gpml")
+(def ^:const default-resource-source :gpml)
 
 (def ^:const resource-source-types
   "Source (platform) of a resource."
-  #{"gpml"
-    "cobsea"})
+  #{:gpml
+    :cobsea})

--- a/backend/src/gpml/handler/case_study.clj
+++ b/backend/src/gpml/handler/case_study.clj
@@ -1,0 +1,167 @@
+(ns gpml.handler.case-study
+  (:require [clojure.java.jdbc :as jdbc]
+            [duct.logger :refer [log]]
+            [gpml.db.case-study :as db.case-study]
+            [gpml.db.favorite :as db.favorite]
+            [gpml.db.resource.geo-coverage :as db.res.geo-coverage]
+            [gpml.db.stakeholder :as db.stakeholder]
+            [gpml.domain.case-study :as dom.case-study]
+            [gpml.handler.auth :as h.auth]
+            [gpml.handler.image :as handler.image]
+            [gpml.handler.resource.related-content :as handler.resource.related-content]
+            [gpml.handler.resource.tag :as handler.resource.tag]
+            [gpml.handler.responses :as r]
+            [gpml.handler.util :as handler.util]
+            [gpml.util.email :as email]
+            [gpml.util.malli :as util.malli]
+            [gpml.util.sql :as sql-util]
+            [integrant.core :as ig]
+            [malli.util :as mu])
+  (:import [java.sql SQLException]))
+
+(defn- handle-geo-coverage
+  "FIXME: Add docstring"
+  [conn cs-id geo-coverage-countries geo-coverage-country-groups]
+  (let [geo-coverage-keys [:case_study :country :country_group]
+        geo-coverage-countries (map #(zipmap geo-coverage-keys [cs-id % nil]) geo-coverage-countries)
+        geo-coverage-country-groups (map #(zipmap
+                                           geo-coverage-keys
+                                           [cs-id nil %])
+                                         geo-coverage-country-groups)
+        geo-coverage (concat geo-coverage-countries geo-coverage-country-groups)
+        insert-values (sql-util/get-insert-values geo-coverage-keys geo-coverage)
+        inserted-values (db.res.geo-coverage/create-resource-geo-coverage
+                         conn
+                         {:table "case_study_geo_coverage"
+                          :insert-cols (map name geo-coverage-keys)
+                          :insert-values insert-values})]
+    (when-not (= (count inserted-values) (count geo-coverage))
+      (throw (ex-info "Failed to create case study's geo coverage" {:inserted-values (count inserted-values)})))))
+
+(defn- handle-related-content
+  "FIXME: Add docstring"
+  [conn logger cs-id related_content]
+  (when-not (:success? (handler.resource.related-content/create-related-contents
+                        conn
+                        logger
+                        cs-id
+                        "case_study"
+                        related_content))
+    (throw (ex-info "Failed to create case study's related content" {}))))
+
+;; TODO: Move it to share space or it will be removed when refactoring permissions.
+(defn- expand-entity-associations
+  [entity-connections resource-id]
+  (vec (for [connection entity-connections]
+         {:column_name "case_study"
+          :topic "case_study"
+          :topic_id resource-id
+          :organisation (:entity connection)
+          :association (:role connection)
+          :remarks nil})))
+
+;; TODO: Move it to share space or it will be removed when refactoring permissions.
+(defn- expand-individual-associations
+  [individual-connections resource-id]
+  (vec (for [connection individual-connections]
+         {:column_name "case_study"
+          :topic "case_study"
+          :topic_id resource-id
+          :stakeholder (:stakeholder connection)
+          :association (:role connection)
+          :remarks nil})))
+
+(defn- create-case-study
+  [{:keys [logger mailjet-config] :as config} conn {:keys [body]}]
+  (let [{:keys [geo_coverage_countries geo_coverage_country_groups tags
+                individual_connections entity_connections related_content
+                image thumbnail created_by]} body
+        case-study (apply dissoc body dom.case-study/entity-relation-keys)
+        image-url (handler.image/assoc-image config conn image "case_study")
+        thumbnail-url (handler.image/assoc-image config conn thumbnail "case_study")
+        api-individual-connections (handler.util/individual-connections->api-individual-connections
+                                    conn
+                                    individual_connections
+                                    created_by)
+        owners (map :stakeholder (filter #(= (:role %) "owner") individual_connections))
+        db-case-study (-> case-study
+                          (assoc :image image-url :thumbnail thumbnail-url)
+                          db.case-study/case-study->db-case-study)
+        insert-cols (sql-util/get-insert-columns-from-entity-col [db-case-study])
+        insert-values (sql-util/entity-col->persistence-entity-col [db-case-study])
+        cs-creation-result (db.case-study/create-case-studies
+                            conn
+                            {:insert-cols insert-cols
+                             :insert-values insert-values})
+        cs-id (-> cs-creation-result first :id)]
+    (when (not-empty tags)
+      (handler.resource.tag/create-resource-tags
+       conn
+       logger
+       mailjet-config
+       {:tags tags
+        :tag-category "general"
+        :resource-name "case_study"
+        :resource-id cs-id}))
+    (when (or (not-empty geo_coverage_country_groups)
+              (not-empty geo_coverage_countries))
+      (handle-geo-coverage conn cs-id geo_coverage_countries geo_coverage_country_groups))
+    (when (seq related_content)
+      (handle-related-content conn logger cs-id related_content))
+    (doseq [stakeholder-id owners]
+      (h.auth/grant-topic-to-stakeholder! conn {:topic-id cs-id
+                                                :topic-type "case_study"
+                                                :stakeholder-id stakeholder-id
+                                                :roles ["owner"]}))
+    (when (not-empty entity_connections)
+      (doseq [association (expand-entity-associations entity_connections cs-id)]
+        (db.favorite/new-organisation-association conn association)))
+    (when (not-empty api-individual-connections)
+      (doseq [association (expand-individual-associations api-individual-connections cs-id)]
+        (db.favorite/new-stakeholder-association conn association)))
+    (email/notify-admins-pending-approval
+     conn
+     mailjet-config
+     (merge case-study {:type "case_study"}))
+    cs-id))
+
+(defmethod ig/init-key :gpml.handler.case-study/post
+  [_ {:keys [db logger] :as config}]
+  (fn [{:keys [jwt-claims parameters]}]
+    (try
+      (let [stakeholder (db.stakeholder/stakeholder-by-email (:spec db) jwt-claims)]
+        (if-not (seq stakeholder)
+          (r/server-error {:success? false
+                           :reason :failed-to-get-stakeholder})
+          (jdbc/with-db-transaction [tx (:spec db)]
+            (let [cs-id (create-case-study
+                         config
+                         tx
+                         (assoc-in parameters [:body :created_by] (:id stakeholder)))]
+              (r/ok {:success? true
+                     :id cs-id})))))
+      (catch Exception e
+        (log logger :error ::failed-to-create-case-study {:exception-message (.getMessage e)})
+        (let [response {:success? false
+                        :reason :could-not-create-case-study}]
+
+          (if (instance? SQLException e)
+            (r/server-error response)
+            (r/server-error (assoc-in response [:error-details :error] (.getMessage e)))))))))
+
+(defmethod ig/init-key :gpml.handler.case-study/post-params
+  [_ _]
+  {:body (-> dom.case-study/CaseStudy
+             (util.malli/dissoc
+              [:id :created_by :created :last_modified_at :reviewed_at :reviewed_by :review_status]))})
+
+(defmethod ig/init-key :gpml.handler.case-study/post-responses
+  [_ _]
+  (let [case-study-id-properties {:swagger
+                                  {:description "The newly created Case Study's identifier."
+                                   :type "integer"}}
+        ok-response-schema-update-fn #(mu/update-properties % (constantly case-study-id-properties))]
+    {200 {:body (-> handler.util/default-ok-response-body-schema
+                    (mu/assoc :id pos-int?)
+                    (mu/update-in [:id] ok-response-schema-update-fn))}
+     500 {:body handler.util/default-error-response-body-schema}}))

--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -1,6 +1,7 @@
 (ns gpml.handler.detail
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.set :as set]
+            [clojure.string :as str]
             [duct.logger :refer [log]]
             [gpml.constants :as constants]
             [gpml.db.action :as db.action]
@@ -28,6 +29,7 @@
             [gpml.handler.stakeholder.tag :as handler.stakeholder.tag]
             [gpml.handler.util :as util]
             [gpml.model.topic :as model.topic]
+            [gpml.util :as generic-util]
             [gpml.util.postgresql :as pg-util]
             [integrant.core :as ig]
             [medley.core :as medley]
@@ -682,7 +684,11 @@
                  (let [status (db.detail/update-initiative conn-tx (-> params
                                                                        (dissoc :related_content :tags :entity_connections
                                                                                :individual_connections :urls :org :geo_coverage_countries
-                                                                               :geo_coverage_country_groups :qimage)))]
+                                                                               :geo_coverage_country_groups :qimage)
+                                                                       (generic-util/update-if-not-nil
+                                                                        :source
+                                                                        #(-> %
+                                                                             str/lower-case))))]
                    (handler.initiative/update-geo-initiative conn-tx id (handler.initiative/extract-geo-data params))
                    status))
         related-contents (:related_content data)]

--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -1,7 +1,6 @@
 (ns gpml.handler.detail
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.set :as set]
-            [clojure.string :as str]
             [duct.logger :refer [log]]
             [gpml.constants :as constants]
             [gpml.db.action :as db.action]
@@ -29,7 +28,6 @@
             [gpml.handler.stakeholder.tag :as handler.stakeholder.tag]
             [gpml.handler.util :as util]
             [gpml.model.topic :as model.topic]
-            [gpml.util :as generic-util]
             [gpml.util.postgresql :as pg-util]
             [integrant.core :as ig]
             [medley.core :as medley]
@@ -681,14 +679,12 @@
         params (merge {:id id} data)
         tags (remove nil? (:tags data))
         status (jdbc/with-db-transaction [conn-tx conn]
-                 (let [status (db.detail/update-initiative conn-tx (-> params
-                                                                       (dissoc :related_content :tags :entity_connections
-                                                                               :individual_connections :urls :org :geo_coverage_countries
-                                                                               :geo_coverage_country_groups :qimage)
-                                                                       (generic-util/update-if-not-nil
-                                                                        :source
-                                                                        #(-> %
-                                                                             str/lower-case))))]
+                 (let [status (db.detail/update-initiative
+                               conn-tx
+                               (dissoc params
+                                       :related_content :tags :entity_connections
+                                       :individual_connections :urls :org :geo_coverage_countries
+                                       :geo_coverage_country_groups :qimage))]
                    (handler.initiative/update-geo-initiative conn-tx id (handler.initiative/extract-geo-data params))
                    status))
         related-contents (:related_content data)]

--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -354,6 +354,9 @@
 (defmethod extra-details "financing_resource" [resource-type db resource]
   (add-extra-details db resource resource-type {}))
 
+(defmethod extra-details "case_study" [resource-type db resource]
+  (add-extra-details db resource resource-type {}))
+
 (defmethod extra-details "action_plan" [resource-type db resource]
   (add-extra-details db resource resource-type {}))
 
@@ -428,7 +431,8 @@
                    "organisation" (common-queries topic path true false true false)
                    "stakeholder" [["delete from stakeholder where id = ?" (:topic-id path)]]
                    "initiative" (common-queries topic path true false true true)
-                   "resource" (common-queries topic path true true true true))]
+                   "resource" (common-queries topic path true true true true)
+                   "case_study" (common-queries topic path true false true true))]
         (if authorized?
           (resp/response (do
                            (jdbc/with-db-transaction [tx-conn conn]
@@ -665,7 +669,8 @@
       (update-resource-tags conn logger mailjet-config table id tags))
     (when (seq related-contents)
       (handler.resource.related-content/update-related-contents conn logger id table related-contents))
-    (when-not (= "policy" topic-type)
+    (when-not (or (= "policy" topic-type)
+                  (= "case_study" topic-type))
       (update-resource-language-urls conn table id urls))
     (update-resource-geo-coverage-values conn table id updates)
     (when (contains? #{"resource"} table)

--- a/backend/src/gpml/handler/event.clj
+++ b/backend/src/gpml/handler/event.clj
@@ -1,6 +1,5 @@
 (ns gpml.handler.event
   (:require [clojure.java.jdbc :as jdbc]
-            [clojure.string :as str]
             [duct.logger :refer [log]]
             [gpml.auth :as auth]
             [gpml.constants :as constants]
@@ -75,7 +74,7 @@
                       :recording recording
                       :document_preview document_preview
                       :language language
-                      :source (-> source str/lower-case keyword)}
+                      :source source}
                (not (nil? capacity_building))
                (assoc :capacity_building capacity_building))
         event-id (->>
@@ -175,7 +174,9 @@
        [:id {:optional true} pos-int?]
        [:tag string?]]]]
     [:language string?]
-    [:source {:default dom.types/default-resource-source}
+    [:source {:default dom.types/default-resource-source
+              :decode/string keyword
+              :decode/json keyword}
      (apply conj [:enum] dom.types/resource-source-types)]
     auth/owners-schema]
    (into handler.geo/params-payload)))

--- a/backend/src/gpml/handler/event.clj
+++ b/backend/src/gpml/handler/event.clj
@@ -1,5 +1,6 @@
 (ns gpml.handler.event
   (:require [clojure.java.jdbc :as jdbc]
+            [clojure.string :as str]
             [duct.logger :refer [log]]
             [gpml.auth :as auth]
             [gpml.constants :as constants]
@@ -7,6 +8,7 @@
             [gpml.db.favorite :as db.favorite]
             [gpml.db.language :as db.language]
             [gpml.db.stakeholder :as db.stakeholder]
+            [gpml.domain.types :as dom.types]
             [gpml.handler.auth :as h.auth]
             [gpml.handler.geo :as handler.geo]
             [gpml.handler.image :as handler.image]
@@ -15,6 +17,7 @@
             [gpml.handler.util :as handler.util]
             [gpml.util :as util]
             [gpml.util.email :as email]
+            [gpml.util.sql :as sql-util]
             [integrant.core :as ig]
             [ring.util.response :as resp])
   (:import [java.sql SQLException]))
@@ -49,7 +52,7 @@
            created_by owners url info_docs sub_content_type
            recording document_preview related_content
            entity_connections individual_connections language
-           capacity_building]}]
+           capacity_building source]}]
   (let [data (cond-> {:title title
                       :start_date start_date
                       :end_date end_date
@@ -71,10 +74,13 @@
                       :sub_content_type sub_content_type
                       :recording recording
                       :document_preview document_preview
-                      :language language}
+                      :language language
+                      :source (-> source str/lower-case keyword)}
                (not (nil? capacity_building))
                (assoc :capacity_building capacity_building))
-        event-id (->> data (db.event/new-event tx) :id)
+        event-id (->>
+                  (update data :source #(sql-util/keyword->pg-enum % "resource_source"))
+                  (db.event/new-event tx) :id)
         api-individual-connections (handler.util/individual-connections->api-individual-connections tx individual_connections created_by)
         owners (distinct (remove nil? (flatten (conj owners
                                                      (map #(when (= (:role %) "owner")
@@ -169,17 +175,20 @@
        [:id {:optional true} pos-int?]
        [:tag string?]]]]
     [:language string?]
+    [:source {:default dom.types/default-resource-source}
+     (apply conj [:enum] dom.types/resource-source-types)]
     auth/owners-schema]
    (into handler.geo/params-payload)))
 
 (defmethod ig/init-key :gpml.handler.event/post
   [_ {:keys [db logger] :as config}]
-  (fn [{:keys [jwt-claims body-params] :as req}]
+  (fn [{:keys [jwt-claims body-params parameters] :as req}]
     (try
       (jdbc/with-db-transaction [tx (:spec db)]
         (let [result (create-event config tx (assoc body-params
                                                     :created_by
-                                                    (-> (db.stakeholder/stakeholder-by-email tx jwt-claims) :id)))]
+                                                    (-> (db.stakeholder/stakeholder-by-email tx jwt-claims) :id)
+                                                    :source (get-in parameters [:body :source])))]
           (resp/created (:referrer req) {:success? true
                                          :message "New event created"
                                          :id (:id result)})))

--- a/backend/src/gpml/handler/initiative.clj
+++ b/backend/src/gpml/handler/initiative.clj
@@ -1,5 +1,6 @@
 (ns gpml.handler.initiative
   (:require [clojure.java.jdbc :as jdbc]
+            [clojure.string :as str]
             [duct.logger :refer [log]]
             [gpml.db.favorite :as db.favorite]
             [gpml.db.initiative :as db.initiative]
@@ -7,12 +8,14 @@
             [gpml.db.resource.tag :as db.resource.tag]
             [gpml.db.stakeholder :as db.stakeholder]
             [gpml.db.tag :as db.tag]
+            [gpml.domain.types :as dom.types]
             [gpml.handler.auth :as h.auth]
             [gpml.handler.geo :as handler.geo]
             [gpml.handler.image :as handler.image]
             [gpml.handler.resource.related-content :as handler.resource.related-content]
             [gpml.handler.util :as util]
             [gpml.util.email :as email]
+            [gpml.util.sql :as sql-util]
             [integrant.core :as ig]
             [ring.util.response :as resp])
   (:import [java.sql SQLException]))
@@ -83,7 +86,8 @@
          new-tags)))))
 
 (defn- create-initiative
-  [{:keys [logger mailjet-config] :as config} tx
+  [{:keys [logger mailjet-config] :as config}
+   tx
    {:keys [tags owners related_content created_by
            entity_connections individual_connections qimage thumbnail capacity_building] :as initiative}]
   (let [data (cond-> initiative
@@ -96,8 +100,13 @@
                       :thumbnail (handler.image/assoc-image config tx thumbnail "initiative"))
 
                (not (nil? capacity_building))
-               (assoc :capacity_building capacity_building))
-        initiative-id (:id (db.initiative/new-initiative tx data))
+               (assoc :capacity_building capacity_building)
+
+               true
+               (update :source #(-> % str/lower-case keyword)))
+        initiative-id (:id (db.initiative/new-initiative
+                            tx
+                            (update data :source #(sql-util/keyword->pg-enum % "resource_source"))))
         api-individual-connections (util/individual-connections->api-individual-connections tx individual_connections created_by)
         owners (distinct (remove nil? (flatten (conj owners
                                                      (map #(when (= (:role %) "owner")
@@ -127,14 +136,15 @@
 
 (defmethod ig/init-key :gpml.handler.initiative/post
   [_ {:keys [db logger] :as config}]
-  (fn [{:keys [jwt-claims body-params] :as req}]
+  (fn [{:keys [jwt-claims body-params parameters] :as req}]
     (try
       (jdbc/with-db-transaction [tx (:spec db)]
         (let [user (db.stakeholder/stakeholder-by-email tx jwt-claims)
               initiative-id (create-initiative config
                                                tx
                                                (assoc body-params
-                                                      :created_by (:id user)))]
+                                                      :created_by (:id user)
+                                                      :source (get-in parameters [:body :source])))]
           (resp/created (:referrer req) {:success? true
                                          :message "New initiative created"
                                          :id initiative-id})))
@@ -183,4 +193,6 @@
   [:map
    [:version integer?]
    [:language string?]
-   [:capacity_building {:optional true} boolean?]])
+   [:capacity_building {:optional true} boolean?]
+   [:source {:default dom.types/default-resource-source}
+    (apply conj [:enum] dom.types/resource-source-types)]])

--- a/backend/src/gpml/handler/initiative.clj
+++ b/backend/src/gpml/handler/initiative.clj
@@ -1,6 +1,5 @@
 (ns gpml.handler.initiative
   (:require [clojure.java.jdbc :as jdbc]
-            [clojure.string :as str]
             [duct.logger :refer [log]]
             [gpml.db.favorite :as db.favorite]
             [gpml.db.initiative :as db.initiative]
@@ -100,10 +99,7 @@
                       :thumbnail (handler.image/assoc-image config tx thumbnail "initiative"))
 
                (not (nil? capacity_building))
-               (assoc :capacity_building capacity_building)
-
-               true
-               (update :source #(-> % str/lower-case keyword)))
+               (assoc :capacity_building capacity_building))
         initiative-id (:id (db.initiative/new-initiative
                             tx
                             (update data :source #(sql-util/keyword->pg-enum % "resource_source"))))
@@ -194,5 +190,7 @@
    [:version integer?]
    [:language string?]
    [:capacity_building {:optional true} boolean?]
-   [:source {:default dom.types/default-resource-source}
+   [:source {:default dom.types/default-resource-source
+             :decode/string keyword
+             :decode/json keyword}
     (apply conj [:enum] dom.types/resource-source-types)]])

--- a/backend/src/gpml/handler/policy.clj
+++ b/backend/src/gpml/handler/policy.clj
@@ -1,6 +1,5 @@
 (ns gpml.handler.policy
   (:require [clojure.java.jdbc :as jdbc]
-            [clojure.string :as str]
             [duct.logger :refer [log]]
             [gpml.db.favorite :as db.favorite]
             [gpml.db.policy :as db.policy]
@@ -84,7 +83,7 @@
                       :created_by created_by
                       :review_status "SUBMITTED"
                       :language language
-                      :source (-> source str/lower-case keyword)}
+                      :source source}
                (not (nil? capacity_building))
                (assoc :capacity_building capacity_building))
         policy-geo-coverage-insert-cols ["policy" "country_group" "country"]

--- a/backend/src/gpml/handler/policy.clj
+++ b/backend/src/gpml/handler/policy.clj
@@ -1,5 +1,6 @@
 (ns gpml.handler.policy
   (:require [clojure.java.jdbc :as jdbc]
+            [clojure.string :as str]
             [duct.logger :refer [log]]
             [gpml.db.favorite :as db.favorite]
             [gpml.db.policy :as db.policy]
@@ -14,6 +15,7 @@
             [gpml.util.email :as email]
             [gpml.util.malli :as util.malli]
             [gpml.util.postgresql :as pg-util]
+            [gpml.util.sql :as sql-util]
             [integrant.core :as ig]
             [malli.util :as mu]
             [ring.util.response :as resp])
@@ -40,7 +42,8 @@
           :remarks nil})))
 
 (defn- create-policy
-  [{:keys [logger mailjet-config] :as config} tx
+  [{:keys [logger mailjet-config] :as config}
+   tx
    {:keys [title original_title abstract url
            data_source type_of_law record_number
            first_publication_date latest_amendment_date
@@ -51,7 +54,7 @@
            owners info_docs sub_content_type
            document_preview related_content topics
            attachments remarks entity_connections individual_connections
-           capacity_building]}]
+           capacity_building source]}]
   (let [data (cond-> {:title title
                       :original_title original_title
                       :abstract abstract
@@ -80,11 +83,14 @@
                       :remarks remarks
                       :created_by created_by
                       :review_status "SUBMITTED"
-                      :language language}
+                      :language language
+                      :source (-> source str/lower-case keyword)}
                (not (nil? capacity_building))
                (assoc :capacity_building capacity_building))
         policy-geo-coverage-insert-cols ["policy" "country_group" "country"]
-        policy-id (->> data (db.policy/new-policy tx) :id)
+        policy-id (->>
+                   (update data :source #(sql-util/keyword->pg-enum % "resource_source"))
+                   (db.policy/new-policy tx) :id)
         api-individual-connections (handler.util/individual-connections->api-individual-connections tx individual_connections created_by)
         owners (distinct (remove nil? (flatten (conj owners
                                                      (map #(when (= (:role %) "owner")
@@ -125,14 +131,15 @@
 
 (defmethod ig/init-key :gpml.handler.policy/post
   [_ {:keys [db logger] :as config}]
-  (fn [{:keys [jwt-claims body-params] :as req}]
+  (fn [{:keys [jwt-claims body-params parameters] :as req}]
     (try
       (jdbc/with-db-transaction [tx (:spec db)]
         (let [user (db.stakeholder/stakeholder-by-email tx jwt-claims)
               policy-id (create-policy config
                                        tx
                                        (assoc body-params
-                                              :created_by (:id user)))]
+                                              :created_by (:id user)
+                                              :source (get-in parameters [:body :source])))]
           (resp/created (:referrer req) {:success? true
                                          :message "New policy created"
                                          :id policy-id})))

--- a/backend/src/gpml/handler/project.clj
+++ b/backend/src/gpml/handler/project.clj
@@ -134,6 +134,7 @@
       (let [{:keys [geo_coverage_countries geo_coverage_country_groups] :as body} (:body parameters)
             {:keys [id]} (:path parameters)
             db-project (-> body
+                           dom.prj/update-project
                            (db.prj/project->db-project))
             updated-values (db.prj/update-project conn
                                                   {:updates db-project

--- a/backend/src/gpml/handler/resource.clj
+++ b/backend/src/gpml/handler/resource.clj
@@ -1,6 +1,5 @@
 (ns gpml.handler.resource
   (:require [clojure.java.jdbc :as jdbc]
-            [clojure.string :as str]
             [duct.logger :refer [log]]
             [gpml.auth :as auth]
             [gpml.constants :as constants]
@@ -83,7 +82,7 @@
                       :latest_amendment_date latest_amendment_date
                       :document_preview document_preview
                       :language language
-                      :source (-> source str/lower-case keyword)}
+                      :source source}
                (not (nil? capacity_building))
                (assoc :capacity_building capacity_building))
         resource-id (:id (db.resource/new-resource
@@ -233,7 +232,9 @@
              [:tag string?]]]]
           [:language string?]
           [:source
-           {:default dom.types/default-resource-source}
+           {:default dom.types/default-resource-source
+            :decode/string keyword
+            :decode/json keyword}
            (apply conj [:enum] dom.types/resource-source-types)]
           auth/owners-schema]
          handler.geo/params-payload)])

--- a/backend/src/gpml/handler/submission.clj
+++ b/backend/src/gpml/handler/submission.clj
@@ -180,5 +180,6 @@
 (defmethod ig/init-key :gpml.handler.submission/put-params [_ _]
   [:map
    [:id int?]
-   [:item_type [:enum "stakeholder", "event", "policy", "technology", "resource", "organisation", "initiative" "tag"]]
+   [:item_type
+    [:enum "stakeholder", "event", "policy", "technology", "resource", "organisation", "initiative" "tag" "case_study"]]
    [:review_status [:enum "APPROVED", "REJECTED"]]])

--- a/backend/src/gpml/handler/technology.clj
+++ b/backend/src/gpml/handler/technology.clj
@@ -1,6 +1,5 @@
 (ns gpml.handler.technology
   (:require [clojure.java.jdbc :as jdbc]
-            [clojure.string :as str]
             [duct.logger :refer [log]]
             [gpml.auth :as auth]
             [gpml.constants :as constants]
@@ -83,7 +82,7 @@
                       :document_preview document_preview
                       :review_status "SUBMITTED"
                       :language language
-                      :source (-> source str/lower-case keyword)}
+                      :source source}
                (not (nil? capacity_building))
                (assoc :capacity_building capacity_building))
         technology-id (->>
@@ -208,7 +207,9 @@
            [:map [:lang string?] [:url [:string {:min 1}]]]]]
          [:language string?]
          [:capacity_building {:optional true} boolean?]
-         [:source {:default dom.types/default-resource-source}
+         [:source {:default dom.types/default-resource-source
+                   :decode/string keyword
+                   :decode/json keyword}
           (apply conj [:enum] dom.types/resource-source-types)]
          auth/owners-schema]
         handler.geo/params-payload))

--- a/backend/src/gpml/handler/technology.clj
+++ b/backend/src/gpml/handler/technology.clj
@@ -1,5 +1,6 @@
 (ns gpml.handler.technology
   (:require [clojure.java.jdbc :as jdbc]
+            [clojure.string :as str]
             [duct.logger :refer [log]]
             [gpml.auth :as auth]
             [gpml.constants :as constants]
@@ -8,6 +9,7 @@
             [gpml.db.language :as db.language]
             [gpml.db.stakeholder :as db.stakeholder]
             [gpml.db.technology :as db.technology]
+            [gpml.domain.types :as dom.types]
             [gpml.handler.auth :as h.auth]
             [gpml.handler.geo :as handler.geo]
             [gpml.handler.image :as handler.image]
@@ -16,6 +18,7 @@
             [gpml.handler.util :as handler.util]
             [gpml.util :as util]
             [gpml.util.email :as email]
+            [gpml.util.sql :as sql-util]
             [integrant.core :as ig]
             [ring.util.response :as resp])
   (:import [java.sql SQLException]))
@@ -53,7 +56,7 @@
            headquarter document_preview
            logo thumbnail attachments remarks
            entity_connections individual_connections language
-           capacity_building]}]
+           capacity_building source]}]
   (let [data (cond-> {:name name
                       :year_founded year_founded
                       :organisation_type organisation_type
@@ -79,10 +82,14 @@
                       :headquarter headquarter
                       :document_preview document_preview
                       :review_status "SUBMITTED"
-                      :language language}
+                      :language language
+                      :source (-> source str/lower-case keyword)}
                (not (nil? capacity_building))
                (assoc :capacity_building capacity_building))
-        technology-id (->> data (db.technology/new-technology tx) :id)
+        technology-id (->>
+                       (update data :source #(sql-util/keyword->pg-enum % "resource_source"))
+                       (db.technology/new-technology tx)
+                       :id)
         api-individual-connections (handler.util/individual-connections->api-individual-connections tx individual_connections created_by)
         owners (distinct (remove nil? (flatten (conj owners
                                                      (map #(when (= (:role %) "owner")
@@ -131,12 +138,13 @@
 
 (defmethod ig/init-key :gpml.handler.technology/post
   [_ {:keys [db logger] :as config}]
-  (fn [{:keys [jwt-claims body-params] :as req}]
+  (fn [{:keys [jwt-claims body-params parameters] :as req}]
     (try
       (jdbc/with-db-transaction [tx (:spec db)]
         (let [user (db.stakeholder/stakeholder-by-email tx jwt-claims)
               technology-id (create-technology config tx (assoc body-params
-                                                                :created_by (:id user)))]
+                                                                :created_by (:id user)
+                                                                :source (get-in parameters [:body :source])))]
           (resp/created (:referrer req) {:success? true
                                          :message "New technology created"
                                          :id technology-id})))
@@ -200,6 +208,8 @@
            [:map [:lang string?] [:url [:string {:min 1}]]]]]
          [:language string?]
          [:capacity_building {:optional true} boolean?]
+         [:source {:default dom.types/default-resource-source}
+          (apply conj [:enum] dom.types/resource-source-types)]
          auth/owners-schema]
         handler.geo/params-payload))
 

--- a/backend/src/gpml/scheduler/brs_api_importer.clj
+++ b/backend/src/gpml/scheduler/brs_api_importer.clj
@@ -36,15 +36,15 @@
               :geo_coverage_type :global
               :type "Technical Resource"
               :language "en"
-              :source (keyword dom.types/default-resource-source)}
+              :source dom.types/default-resource-source}
    :event {:review_status :APPROVED
            :language "en"
-           :source (keyword dom.types/default-resource-source)}
+           :source dom.types/default-resource-source}
    :initiative {:review_status :APPROVED
                 :language "en"
                 :version 2
                 :q36_1 {"USD" "USD United States dollar"}
-                :source (keyword dom.types/default-resource-source)}
+                :source dom.types/default-resource-source}
    :tag {:review_status :SUBMITTED}})
 
 (defn- get-entity-schema-keys

--- a/backend/src/gpml/scheduler/brs_api_importer.clj
+++ b/backend/src/gpml/scheduler/brs_api_importer.clj
@@ -17,6 +17,7 @@
             [gpml.domain.initiative :as dom.initiative]
             [gpml.domain.resource :as dom.resource]
             [gpml.domain.translation :as dom.translation]
+            [gpml.domain.types :as dom.types]
             [gpml.handler.image :as handler.img]
             [gpml.util :as util]
             [gpml.util.http-client :as http-client]
@@ -34,13 +35,16 @@
   {:resource {:review_status :APPROVED
               :geo_coverage_type :global
               :type "Technical Resource"
-              :language "en"}
+              :language "en"
+              :source (keyword dom.types/default-resource-source)}
    :event {:review_status :APPROVED
-           :language "en"}
+           :language "en"
+           :source (keyword dom.types/default-resource-source)}
    :initiative {:review_status :APPROVED
                 :language "en"
                 :version 2
-                :q36_1 {"USD" "USD United States dollar"}}
+                :q36_1 {"USD" "USD United States dollar"}
+                :source (keyword dom.types/default-resource-source)}
    :tag {:review_status :SUBMITTED}})
 
 (defn- get-entity-schema-keys

--- a/backend/src/gpml/util/sql.clj
+++ b/backend/src/gpml/util/sql.clj
@@ -50,8 +50,14 @@
    ",\n"
    (for [k (keys (dissoc data :id))]
      (str (str/replace (str k) ":" "")
-          (if (and (is-jsonb k) (get data k))
+          (cond
+            (= :source k)
+            (format "= %s::resource_source" k)
+
+            (and (is-jsonb k) (get data k))
             (format "= to_jsonb(:v%s)" k)
+
+            :else
             (format "= %s" k))))))
 
 (defn generate-update-resource
@@ -79,6 +85,9 @@
 
               (= key "geo_coverage_type")
               (str value "::geo_coverage_type")
+
+              (= key "source")
+              (str value "::resource_source")
 
               (contains? #{"end_date" "start_date"} key)
               (str value "::timestamptz")

--- a/backend/test/gpml/handler/event_test.clj
+++ b/backend/test/gpml/handler/event_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [gpml.db.event :as db.event]
             [gpml.db.stakeholder :as db.stakeholder]
+            [gpml.domain.types :as dom.types]
             [gpml.fixtures :as fixtures]
             [gpml.handler.event :as event]
             [gpml.handler.profile-test :as profile-test]
@@ -37,7 +38,8 @@
           _ (db.stakeholder/update-stakeholder-status db (assoc user :review_status "APPROVED"))
           resp-one (handler (-> (mock/request :post "/")
                                 (assoc :jwt-claims {:email "john@org"})
-                                (assoc :body-params payload)))
+                                (assoc :body-params payload)
+                                (assoc :parameters {:body {:source dom.types/default-resource-source}})))
           event-one (db.event/event-by-id db (:body resp-one))]
       (is (= 201 (:status resp-one)))
       (is (= (:url event-one) (:url payload))))))

--- a/backend/test/gpml/handler/initiative_test.clj
+++ b/backend/test/gpml/handler/initiative_test.clj
@@ -3,6 +3,7 @@
             [clojure.test :refer [deftest is testing use-fixtures]]
             [gpml.db.initiative :as db.initiative]
             [gpml.db.stakeholder :as db.stakeholder]
+            [gpml.domain.types :as dom.types]
             [gpml.fixtures :as fixtures]
             [gpml.handler.initiative :as initiative]
             [gpml.handler.profile-test :as profile-test]
@@ -32,7 +33,8 @@
                        :add-default-lang? true})
           resp (handler (-> (mock/request :post "/")
                             (assoc :jwt-claims {:email "john@org"})
-                            (assoc :body-params (assoc submission :version 1))))
+                            (assoc :body-params (assoc submission :version 1))
+                            (assoc :parameters {:body {:source dom.types/default-resource-source}})))
           data (db.initiative/initiative-by-id db (:body resp))]
       (is (= 201 (:status resp)))
       (is (= 1 (-> data :version)))

--- a/backend/test/gpml/handler/policy_test.clj
+++ b/backend/test/gpml/handler/policy_test.clj
@@ -4,6 +4,7 @@
             [gpml.db.policy :as db.policy]
             [gpml.db.stakeholder :as db.stakeholder]
             [gpml.db.tag :as db.tag]
+            [gpml.domain.types :as dom.types]
             [gpml.fixtures :as fixtures]
             [gpml.handler.policy :as policy]
             [gpml.handler.profile-test :as profile-test]
@@ -57,7 +58,8 @@
           ;; create John create new policy with available organisation
           resp-one (handler (-> (mock/request :post "/")
                                 (assoc :jwt-claims {:email "john@org"})
-                                (assoc :body-params (new-policy data))))
+                                (assoc :body-params (new-policy data))
+                                (assoc :parameters {:body {:source dom.types/default-resource-source}})))
           ;; create John create new policy with new organisation
           resp-two (handler (-> (mock/request :post "/")
                                 (assoc :jwt-claims {:email "john@org"})
@@ -65,7 +67,8 @@
                                                            {:id -1
                                                             :name "New Era"
                                                             :geo_coverage_type "global"
-                                                            :country (-> (:countries data) second :id)}))))
+                                                            :country (-> (:countries data) second :id)}))
+                                (assoc :parameters {:body {:source dom.types/default-resource-source}})))
           policy-one (db.policy/policy-by-id db (:body resp-one))
           policy-two (db.policy/policy-by-id db (:body resp-two))]
       (is (= 201 (:status resp-one)))

--- a/backend/test/gpml/handler/project_test.clj
+++ b/backend/test/gpml/handler/project_test.clj
@@ -24,7 +24,8 @@
    :checklist {"test item" false}
    :stage (rand-nth (vec dom.prj/project-stages))
    :geo_coverage_countries [724]
-   :geo_coverage_country_groups [151]})
+   :geo_coverage_country_groups [151]
+   :source dom.types/default-resource-source})
 
 (defn- create-random-project
   [db stakeholder-id]

--- a/backend/test/gpml/handler/resource_test.clj
+++ b/backend/test/gpml/handler/resource_test.clj
@@ -6,6 +6,7 @@
             [gpml.db.stakeholder :as db.stakeholder]
             [gpml.db.tag :as db.tag]
             [gpml.db.topic-stakeholder-auth :as db.ts-auth]
+            [gpml.domain.types :as dom.types]
             [gpml.fixtures :as fixtures]
             [gpml.handler.image :as image]
             [gpml.handler.profile-test :as profile-test]
@@ -68,7 +69,8 @@
           resp-one (with-redefs [image/upload-blob fake-upload-blob]
                      (handler (-> (mock/request :post "/")
                                   (assoc :jwt-claims {:email "john@org"})
-                                  (assoc :body-params payload))))
+                                  (assoc :body-params payload)
+                                  (assoc :parameters {:body {:source dom.types/default-resource-source}}))))
           ;; create John create new resource with new organisation
           resp-two (with-redefs [image/upload-blob fake-upload-blob]
                      (handler (-> (mock/request :post "/")
@@ -78,7 +80,8 @@
                                                 :org {:id -1
                                                       :name "New Era"
                                                       :geo_coverage_type "global"
-                                                      :country (-> (:countries data) second :id)})))))
+                                                      :country (-> (:countries data) second :id)}))
+                                  (assoc :parameters {:body {:source dom.types/default-resource-source}}))))
           resource-one (db.resource/resource-by-id db (:body resp-one))
           resource-two (db.resource/resource-by-id db (:body resp-two))]
       (is (not-empty (db.ts-auth/get-auth-by-topic db {:topic-id (:id resource-one) :topic-type "resource"})))

--- a/backend/test/gpml/handler/technology_test.clj
+++ b/backend/test/gpml/handler/technology_test.clj
@@ -4,6 +4,7 @@
             [gpml.db.stakeholder :as db.stakeholder]
             [gpml.db.tag :as db.tag]
             [gpml.db.technology :as db.technology]
+            [gpml.domain.types :as dom.types]
             [gpml.fixtures :as fixtures]
             [gpml.handler.profile-test :as profile-test]
             [gpml.handler.technology :as technology]
@@ -55,7 +56,8 @@
           ;; create John create new technology with available organisation
           resp-one (handler (-> (mock/request :post "/")
                                 (assoc :jwt-claims {:email "john@org"})
-                                (assoc :body-params (new-technology data))))
+                                (assoc :body-params (new-technology data))
+                                (assoc :parameters {:body {:source dom.types/default-resource-source}})))
           ;; create John create new technology with new organisation
           resp-two (handler (-> (mock/request :post "/")
                                 (assoc :jwt-claims {:email "john@org"})
@@ -65,7 +67,8 @@
                                                            {:id -1
                                                             :name "New Era"
                                                             :geo_coverage_type "global"
-                                                            :country (-> (:countries data) second :id)}))))
+                                                            :country (-> (:countries data) second :id)}))
+                                (assoc :parameters {:body {:source dom.types/default-resource-source}})))
           technology-one (db.technology/technology-by-id db (:body resp-one))
           technology-two (db.technology/technology-by-id db (:body resp-two))]
       (is (= 201 (:status resp-one)))


### PR DESCRIPTION
This PR includes:

- Support for new Case Study resource type, the same way as we do with other resources.
- Support for `source` property for all the existing resources, allowing two possible values:
  - `gpml` (default if omitted; used for already existing resources)
  - `cobsea`