### PR TITLE
Fix browse API transnational filter typo

### DIFF
--- a/backend/src/gpml/handler/browse.clj
+++ b/backend/src/gpml/handler/browse.clj
@@ -196,7 +196,7 @@
     (assoc :geo-coverage country)
 
     (seq transnational)
-    (assoc :transnational 1)
+    (assoc :transnational transnational)
 
     (seq topic)
     (assoc :topic topic)


### PR DESCRIPTION
* Probably while refactoring we mistakenly changed this filter's value.