### PR TITLE
1517 - Add new Contact endpoint for Cobsea

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -602,6 +602,11 @@
                                                  :swagger {:tags ["subscribe"]}
                                                  :handler #ig/ref :gpml.handler.subscribe/post
                                                  :parameters #ig/ref :gpml.handler.subscribe/post-params}}]
+                                        ["/contact"
+                                         {:post {:summary "Send an contact email from different sources"
+                                                 :swagger {:tags ["contact"]}
+                                                 :handler #ig/ref :gpml.handler.contact/post
+                                                 :parameters #ig/ref :gpml.handler.contact/post-params}}]
                                         ["/case-study" {:middleware [#ig/ref :gpml.auth/auth-middleware
                                                                      #ig/ref :gpml.auth/auth-required
                                                                      #ig/ref :gpml.auth/approved-user]}
@@ -645,7 +650,8 @@
    :app-user-admin #duct/env ["APP_USER_ADMIN" Str]
    :storage-bucket-name #duct/env ["GCS_BUCKET_NAME" Str]
    :brs-entities-to-import #ig/ref :gpml.config/brs-gpml-entities-mapping
-   :subscribe-settings {:management-dest-email #duct/env ["SUBSCRIPTIONS_MANAGEMENT_EMAIL" Str]}}
+   :subscribe-settings {:management-dest-email #duct/env ["SUBSCRIPTIONS_MANAGEMENT_EMAIL" Str]}
+   :contact-settings {:cobsea {:dest-email #duct/env ["CONTACT_COBSEA_MANAGEMENT_EMAIL" Str]}}}
   ;; Handlers
 
   :duct.server.http/jetty {:handler #ig/ref :gpml.handler.main/handler}
@@ -860,6 +866,9 @@
 
   :gpml.handler.subscribe/post #ig/ref :gpml.config/common
   :gpml.handler.subscribe/post-params {}
+
+  :gpml.handler.contact/post #ig/ref :gpml.config/common
+  :gpml.handler.contact/post-params {}
 
   :gpml.handler.programmatic.country-state/post #ig/ref :gpml.config/common
   :gpml.handler.programmatic.country-state/post-params {}

--- a/backend/src/gpml/handler/contact.clj
+++ b/backend/src/gpml/handler/contact.clj
@@ -1,0 +1,63 @@
+(ns gpml.handler.contact
+  (:require [duct.logger :refer [log]]
+            [gpml.domain.types :as dom.types]
+            [gpml.handler.responses :as r]
+            [gpml.util :as util]
+            [gpml.util.email :as email]
+            [integrant.core :as ig]))
+
+(defmethod ig/init-key :gpml.handler.contact/post
+  [_ {:keys [contact-settings mailjet-config logger]}]
+  (fn [{{:keys [body]} :parameters}]
+    (try
+      (let [source (:source body)
+            dest-email (get-in contact-settings [source :dest-email])]
+        (if (seq dest-email)
+          (let [{:keys [status reason-phrase]} (email/notify-about-new-contact
+                                                mailjet-config
+                                                (assoc body :dest-email dest-email))]
+            (if (<= 200 status 299)
+              (r/ok {:success? true})
+              (r/server-error {:success? false
+                               :reason :could-not-send-new-contact-email
+                               :error-details reason-phrase})))
+          (r/server-error {:success? false
+                           :reason :could-not-send-new-contact-email
+                           :error-details "Destination email address missing in config"})))
+      (catch Throwable e
+        (log logger :error :failed-to-send-contact-email {:exception-message (ex-message e)
+                                                          :exception-class (class e)})
+        (r/server-error {:success? false
+                         :reason :could-not-send-new-contact-email
+                         :error-details {:error (ex-message e)}})))))
+
+(defmethod ig/init-key :gpml.handler.contact/post-params [_ _]
+  {:body [:map
+          [:email
+           {:swagger {:description "Email related to the contact form's sender"
+                      :type :string}}
+           [:fn {:error/message "It must be a valid email."}
+            util/email?]]
+          [:name
+           {:swagger {:description "Name related to the contact form's sender"
+                      :type :string}}
+           [:string {:min 1}]]
+          [:subject
+           {:swagger {:description "Subject of the contact form"
+                      :type :string}}
+           [:string {:min 1}]]
+          [:organization
+           {:swagger {:description "Organization related to the contact form"
+                      :type :string}}
+           [:string {:min 1}]]
+          [:message
+           {:swagger {:description "Message content for the contact form"
+                      :type :string}}
+           [:string {:min 1}]]
+          [:source
+           {:decode/string keyword
+            :decode/json keyword
+            :swagger {:description "Source platform for the contact form"
+                      :type "string"
+                      :enum dom.types/resource-source-types}}
+           (apply conj [:enum] dom.types/resource-source-types)]]})

--- a/backend/src/gpml/util/email.clj
+++ b/backend/src/gpml/util/email.clj
@@ -157,6 +157,29 @@ again, please visit this URL: %s/edit-%s/%s
         htmls (repeat nil)]
     (send-email mailjet-config sender subject receivers texts htmls)))
 
+(defn notify-about-new-contact
+  "Send email about a new contact request
+   The plural format for texts and receivers is because the sending shared email function expects a list of messages
+   to be sent. That is why we provide an infinite sequence for non-used `htmls` option. Besides, we make `sender` and
+   `texts` a collection of a single element, since in this case we are sending a single message."
+  [mailjet-config {dest-email :dest-email
+                   req-email :email
+                   name :name
+                   organization :organization
+                   msg :message
+                   subject :subject}]
+  (let [msg-body (format "Name: %s\nEmail: %s\nOrganization: %s\nMessage: \n%s"
+                         name
+                         req-email
+                         organization
+                         msg)
+        sender unep-sender
+        receivers [{:Name "Contact Management"
+                    :Email dest-email}]
+        texts [msg-body]
+        htmls (repeat nil)]
+    (send-email mailjet-config sender subject receivers texts htmls)))
+
 (comment
   (require 'dev)
   (let [db (dev/db-conn)


### PR DESCRIPTION
[Re #1517]

Added new endpoint similar to the Subscribe one, but in this case we are sending contact form data.

We support only Cobsea contact form case (that is the only case for now), but we have the endpoint ready for other cases, as long as we provide some configuration about destination email address.

We have decided to make the `source` parameter mandatory, as it's a different case as with other endpoints, since this would be mainly used from Cobsea and better be explicit.