### PR TITLE
[#1522] Fix country filter on topic query

### DIFF
--- a/backend/src/gpml/db/landing.sql
+++ b/backend/src/gpml/db/landing.sql
@@ -1,4 +1,4 @@
--- :name map-counts :? :one
+-- :name map-counts :query :one
 -- :doc Gets the entity count per country.
 -- :require [gpml.db.topic]
 /*~ (if (= (:entity-group params) :topic)

--- a/backend/src/gpml/db/topic.clj
+++ b/backend/src/gpml/db/topic.clj
@@ -414,11 +414,11 @@
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn generate-filter-topic-snippet
   "Generates the SQL to apply filters to the topics aggregate."
-  [{:keys [favorites user-id topic start-date end-date transnational
-           geo-coverage resource-types geo-coverage-countries
+  [{:keys [favorites user-id topic start-date end-date
+           geo-coverage-country-groups
+           geo-coverage-countries resource-types
            affiliation]}]
-  (let [geo-coverage? (seq geo-coverage)
-        transnational? (seq transnational)
+  (let [geo-coverage-country-groups? (seq geo-coverage-country-groups)
         geo-coverage-countries? (seq geo-coverage-countries)]
     (str/join
      " "
@@ -447,18 +447,10 @@
           (seq end-date)
           " AND TO_DATE(json->>'end_date', 'YYYY-MM-DD') <= :end-date::date"))
       (cond
-        (and geo-coverage-countries? transnational?)
-        (str " AND (" (generic-json-array-lookup-cond "t.json->>'geo_coverage_values'" "geo-coverage-countries")
+        (and geo-coverage-countries? geo-coverage-country-groups?)
+        (str " AND (" (generic-json-array-lookup-cond "t.json->>'geo_coverage_countries'" "geo-coverage-countries")
              " OR t.json->>'geo_coverage_type'='transnational'
-               AND " (generic-json-array-lookup-cond "t.json->>'geo_coverage_country_groups'" "transnational") ")")
-
-        (and geo-coverage? transnational?)
-        (str " AND (" (generic-json-array-lookup-cond "t.json->>'geo_coverage_countries'" "geo-coverage")
-             " OR t.json->>'geo_coverage_type'='transnational'
-                 AND " (generic-json-array-lookup-cond "t.json->>'geo_coverage_country_groups'" "transnational") ")")
-
-        geo-coverage?
-        (str " AND " (generic-json-array-lookup-cond "t.json->>'geo_coverage_countries'" "geo-coverage"))
+               AND " (generic-json-array-lookup-cond "t.json->>'geo_coverage_country_groups'" "geo-coverage-country-groups") ")")
 
         geo-coverage-countries?
-        (str " AND " (generic-json-array-lookup-cond "t.json->>'geo_coverage_values'" "geo-coverage-countries")))))))
+        (str " AND " (generic-json-array-lookup-cond "t.json->>'geo_coverage_countries'" "geo-coverage-countries")))))))

--- a/backend/test/gpml/db/landing_test.clj
+++ b/backend/test/gpml/db/landing_test.clj
@@ -128,8 +128,8 @@
                                 set)
             landing-counts-by-country (filter #(= country-id (:country_id %)) country_counts)
             browse (db.topic/get-topics conn {:topic #{"financing_resource"}
-                                              :geo-coverage [country-id]
-                                              :transnational transnationals
+                                              :geo-coverage-countries [country-id]
+                                              :geo-coverage-country-groups transnationals
                                               :count-only? true
                                               :limit 8
                                               :offset 0})]

--- a/backend/test/gpml/handler/browse_test.clj
+++ b/backend/test/gpml/handler/browse_test.clj
@@ -56,7 +56,7 @@
       (is (= (browse/get-db-filter (decode-params {})) {:offset 0 :limit 50 :review-status "APPROVED"})))
     (testing "Country is not empty"
       (is (= (browse/get-db-filter (decode-params {:country "73,106,107"}))
-             {:geo-coverage #{107 73 106} :offset 0 :limit 50 :review-status "APPROVED"})))
+             {:countries #{107 73 106} :offset 0 :limit 50 :review-status "APPROVED"})))
     (testing "Topic is not empty"
       (is (= (browse/get-db-filter (decode-params {:topic "technology"}))
              {:topic #{"technology"} :offset 0 :limit 50 :review-status "APPROVED"})))
@@ -78,7 +78,7 @@
                                      :country "253"
                                      :topic "initiative,event"}))
              {:search-text "eco"
-              :geo-coverage #{253}
+              :countries #{253}
               :topic #{"initiative" "event"}
               :offset 0 :limit 50
               :review-status "APPROVED"})))))


### PR DESCRIPTION
* Changing the topic query logic affects the landing and browse API which needed to be refactored as well.
* Now we use the actual entity names instead of geo-coverage and transnational. API endpoint parameters still on pending as it requires FE intervention.

* See #1522
* Closes #1522