### PR TITLE
[#1531] Fix review endpoints review status malli schema

### DIFF
--- a/backend/src/gpml/domain/types.clj
+++ b/backend/src/gpml/domain/types.clj
@@ -9,6 +9,11 @@
   Resource, Initiative)."
   #{"APPROVED" "SUBMITTED" "REJECTED"})
 
+(def ^:const reviewer-review-statuses
+  "Possible `reviewer_review_status` values. This represent the state of
+  each review submitted to the platform."
+  #{"ACCEPTED" "PENDING" "REJECTED"})
+
 ;; TODO: Refactor enums to be keywords instead of strings.
 (def ^:const geo-coverage-types
   "Possible `geo_coverage_type` values. This represent the geo coverage

--- a/backend/src/gpml/handler/review.clj
+++ b/backend/src/gpml/handler/review.clj
@@ -25,7 +25,7 @@
        (db.review/reviews-by-reviewer-id conn opts)))
 
 (def ^:private review-status-re
-  (->> dom.types/review-statuses
+  (->> dom.types/reviewer-review-statuses
        (map symbol)
        (str/join "|")
        (format "^(%1$s)((,(%1$s))+)?$")
@@ -228,7 +228,7 @@
      [:re review-status-re]]]})
 
 (defmethod ig/init-key :gpml.handler.review/review-status-params [_ _]
-  (apply conj [:enum] dom.types/review-statuses))
+  (apply conj [:enum] dom.types/reviewer-review-statuses))
 
 (defmethod ig/init-key :gpml.handler.review/get-reviewers-responses [_ _]
   {200 {:body


### PR DESCRIPTION
* They were using the wrong set of review statuses, as it differs from review_status enum values. Which are used for resources only.

* Closes #1531