### PR TITLE
Fix Case Study update on detail API and comments fetching

### DIFF
--- a/backend/resources/migrations/184-add-case-study-to-resource-type-enum.up.sql
+++ b/backend/resources/migrations/184-add-case-study-to-resource-type-enum.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+--;;
+ALTER TYPE RESOURCE_TYPE ADD VALUE 'case_study';
+--;;
+COMMIT;

--- a/backend/src/gpml/handler/comment.clj
+++ b/backend/src/gpml/handler/comment.clj
@@ -3,6 +3,7 @@
             [gpml.db.comment :as db.comment]
             [gpml.db.stakeholder :as db.stakeholder]
             [gpml.db.stakeholder-association :as db.stakeholder-association]
+            [gpml.domain.types :as dom.types]
             [gpml.util :as util]
             [gpml.util.email :as email]
             [gpml.util.regular-expressions :as util.regex]
@@ -11,9 +12,6 @@
             [java-time.pre-java8 :as time-pre-j8]
             [java-time.temporal]
             [ring.util.response :as resp]))
-
-(def ^:const resource-types
-  [:policy :event :financing_resource :technical_resource :action_plan :initiative :technology])
 
 (def ^:const id-param
   [:id
@@ -57,10 +55,11 @@
 (def ^:const resource-type-param
   [:resource_type
    {:optional false
-    :swagger {:description (str "One of the following resource types: " (str/join "," (map name resource-types)))
+    :swagger {:description "The resource type the user commented on."
               :type "string"
+              :enum dom.types/resources-types
               :allowEmptyValue false}}
-   (vec (cons :enum (mapv name resource-types)))])
+   (apply conj [:enum] dom.types/resources-types)])
 
 (def ^:const title-param
   [:title

--- a/backend/src/gpml/handler/comment.clj
+++ b/backend/src/gpml/handler/comment.clj
@@ -1,6 +1,5 @@
 (ns gpml.handler.comment
-  (:require [clojure.string :as str]
-            [gpml.db.comment :as db.comment]
+  (:require [gpml.db.comment :as db.comment]
             [gpml.db.stakeholder :as db.stakeholder]
             [gpml.db.stakeholder-association :as db.stakeholder-association]
             [gpml.domain.types :as dom.types]

--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -620,6 +620,8 @@
                            :image :photo :logo :language :thumbnail
                            :geo_coverage_country_groups
                            :geo_coverage_countries
+                           :geo_coverage_country_states
+                           :geo_coverage_value_subnational
                            :entity_connections :related_content
                            :individual_connections
                            :resource_type)
@@ -677,8 +679,12 @@
                 conn
                 (dissoc initiative
                         :related_content :tags :entity_connections
-                        :individual_connections :urls :org :geo_coverage_countries
-                        :geo_coverage_country_groups :qimage))
+                        :individual_connections :urls :org
+                        :geo_coverage_countries
+                        :geo_coverage_country_states
+                        :geo_coverage_country_groups
+                        :geo_coverage_value_subnational
+                        :qimage))
         related-contents (:related_content initiative)]
     (doseq [[image-key image-data] (select-keys initiative [:qimage :thumbnail])]
       (update-resource-image config conn image-data image-key "initiative" id))


### PR DESCRIPTION
* Comment RESOURCE_TYPE enum was missing the case_study value.
* Detail API needs to remove all geo_coverage_* fields from the entity data before inserting into the db. Ideally we should use Malli to get the entity keys for each resource instead of doing it manually. This is a refactor candidate.