### PR TITLE
Add featured order by to browse API

### DIFF
--- a/backend/src/gpml/db/topic.clj
+++ b/backend/src/gpml/db/topic.clj
@@ -380,6 +380,9 @@
                           (and upcoming (= (first topic) "event"))
                           "ORDER BY json->>'start_date' ASC"
 
+                          (= order-by "featured")
+                          "ORDER BY json->>'featured' DESC, (json->>'created')::timestamptz DESC"
+
                           (seq order-by)
                           (format "ORDER BY json->>'%s' %s" order-by order)
 

--- a/backend/src/gpml/handler/browse.clj
+++ b/backend/src/gpml/handler/browse.clj
@@ -13,7 +13,7 @@
   (:import [java.sql SQLException]))
 
 (def ^:const topic-re (util.regex/comma-separated-enums-re dom.types/topic-types))
-(def ^:const ^:private order-by-fields ["title" "description" "id"])
+(def ^:const ^:private order-by-fields ["title" "description" "id" "featured"])
 (def ^:const ^:private default-limit 50)
 (def ^:const ^:private default-offset 0)
 


### PR DESCRIPTION
[Re #1537]

* The `featured` order by parameter will order in DESC mode as PostgreSQL booleans are 0 and 1 at the of the day. This way we always get the featured resources first in the list. In order to avoid the list being chaotic, subsequent resources will be ordered by `created`. So, we at least keep some meaningful order of resources.