### PR TITLE
Fix topic query when using sub_content_type filter

### DIFF
--- a/backend/src/gpml/db/detail.sql
+++ b/backend/src/gpml/db/detail.sql
@@ -1,6 +1,6 @@
 -- :name get-topic-details :query :one
 -- :doc Get details about a particular topic
---~ (#'gpml.db.topic/generate-topic-query params {:tables [(:topic-type params)]})
+--~ (#'gpml.db.topic/generate-topic-query (assoc params :topic [(:topic-type params)]))
 SELECT * FROM cte_topic;
 
 -- :name get-entity-details :query :one

--- a/backend/src/gpml/db/landing.sql
+++ b/backend/src/gpml/db/landing.sql
@@ -2,7 +2,7 @@
 -- :doc Gets the entity count per country.
 -- :require [gpml.db.topic]
 /*~ (if (= (:entity-group params) :topic)
-(#'gpml.db.topic/generate-topic-query params gpml.db.topic/generic-cte-opts)
+(#'gpml.db.topic/generate-topic-query params)
 (#'gpml.db.topic/generate-entity-topic-query params gpml.db.topic/generic-entity-cte-opts))
 ~*/
 ,
@@ -11,8 +11,8 @@ filtered_entities AS (
 ),
 transnational_counts_per_country AS (
   SELECT cgc.country AS country_id,
-         topic,
-         COUNT(DISTINCT json->>'id') AS topic_count
+	 topic,
+	 COUNT(DISTINCT json->>'id') AS topic_count
   FROM filtered_entities
   LEFT JOIN json_array_elements_text((json->>'geo_coverage_values')::JSON) cgcs
   ON json->>'geo_coverage_values' IS NOT NULL
@@ -23,8 +23,8 @@ transnational_counts_per_country AS (
 ),
 country_group_counts AS (
   SELECT (country_groups.value)::TEXT::INT AS country_group_id,
-         topic,
-         COUNT(topic) AS topic_count
+	 topic,
+	 COUNT(topic) AS topic_count
   FROM filtered_entities
   LEFT JOIN json_array_elements_text((json->>'geo_coverage_country_groups')::JSON) country_groups
   ON json->>'geo_coverage_country_groups' IS NOT NULL
@@ -34,8 +34,8 @@ country_group_counts AS (
 country_counts AS (
 /*~ (if (= (:entity-group params) :topic) */
   SELECT (countries.value)::TEXT::INT AS country_id,
-         topic,
-         COUNT(topic) AS topic_count
+	 topic,
+	 COUNT(topic) AS topic_count
   FROM filtered_entities
   LEFT JOIN json_array_elements_text((json->>'geo_coverage_countries')::JSON) countries
   ON json->>'geo_coverage_countries' IS NOT NULL
@@ -82,285 +82,285 @@ country_group_counts_agg AS (
 -- :doc Get summary of count of entities and number of countries
 WITH initiative_countries AS (
     SELECT
-        c.id
+	c.id
     FROM
-        initiative_geo_coverage ig,
-        country_group_country cgc
-        JOIN country c ON cgc.country = c.id
+	initiative_geo_coverage ig,
+	country_group_country cgc
+	JOIN country c ON cgc.country = c.id
     WHERE
-        ig.country_group = cgc.country_group
+	ig.country_group = cgc.country_group
     UNION
     SELECT
-        ig.country AS id
+	ig.country AS id
     FROM
-        initiative_geo_coverage ig
+	initiative_geo_coverage ig
     WHERE
-        ig.country IS NOT NULL
+	ig.country IS NOT NULL
 ),
 resource_countries AS (
     SELECT
-        c.id,
-        r.type
+	c.id,
+	r.type
     FROM
-        resource_geo_coverage rg
-        LEFT JOIN resource r ON rg.resource = r.id,
-        country_group_country cgc
-        JOIN country c ON cgc.country = c.id
+	resource_geo_coverage rg
+	LEFT JOIN resource r ON rg.resource = r.id,
+	country_group_country cgc
+	JOIN country c ON cgc.country = c.id
     WHERE
-        rg.country_group = cgc.country_group
+	rg.country_group = cgc.country_group
     UNION
     SELECT
-        rg.country AS id,
-        r.type
+	rg.country AS id,
+	r.type
     FROM
-        resource_geo_coverage rg
-        LEFT JOIN resource r ON rg.resource = r.id
+	resource_geo_coverage rg
+	LEFT JOIN resource r ON rg.resource = r.id
     WHERE
-        rg.country IS NOT NULL
+	rg.country IS NOT NULL
 ),
 event_countries AS (
     SELECT
-        c.id
+	c.id
     FROM
-        event_geo_coverage e,
-        country_group_country cgc
-        JOIN country c ON cgc.country = c.id
+	event_geo_coverage e,
+	country_group_country cgc
+	JOIN country c ON cgc.country = c.id
     WHERE
-        e.country_group = cgc.country_group
+	e.country_group = cgc.country_group
     UNION
     SELECT
-        e.country AS id
+	e.country AS id
     FROM
-        event_geo_coverage e
+	event_geo_coverage e
     WHERE
-        e.country IS NOT NULL
+	e.country IS NOT NULL
 ),
 policy_countries AS (
     SELECT
-        c.id
+	c.id
     FROM
-        policy_geo_coverage p,
-        country_group_country cgc
-        JOIN country c ON cgc.country = c.id
+	policy_geo_coverage p,
+	country_group_country cgc
+	JOIN country c ON cgc.country = c.id
     WHERE
-        p.country_group = cgc.country_group
+	p.country_group = cgc.country_group
     UNION
     SELECT
-        p.country AS id
+	p.country AS id
     FROM
-        policy_geo_coverage p
+	policy_geo_coverage p
     WHERE
-        p.country IS NOT NULL
+	p.country IS NOT NULL
 ),
 technology_countries AS (
     SELECT
-        c.id
+	c.id
     FROM
-        technology_geo_coverage t,
-        country_group_country cgc
-        JOIN country c ON cgc.country = c.id
+	technology_geo_coverage t,
+	country_group_country cgc
+	JOIN country c ON cgc.country = c.id
     WHERE
-        t.country_group = cgc.country_group
+	t.country_group = cgc.country_group
     UNION
     SELECT
-        t.country AS id
+	t.country AS id
     FROM
-        technology_geo_coverage t
+	technology_geo_coverage t
     WHERE
-        t.country IS NOT NULL
+	t.country IS NOT NULL
 ),
 stakeholder_countries AS (
     SELECT
-        country AS id
+	country AS id
     FROM
-        stakeholder
+	stakeholder
     WHERE
-        country IS NOT NULL
-        AND review_status = 'APPROVED'
+	country IS NOT NULL
+	AND review_status = 'APPROVED'
 ),
 organisation_countries AS (
     WITH approved_orgs AS (
-        SELECT
-            o.country,
-            o.country_group
-        FROM
-            organisation_geo_coverage o
-        LEFT JOIN organisation org ON o.organisation = org.id
+	SELECT
+	    o.country,
+	    o.country_group
+	FROM
+	    organisation_geo_coverage o
+	LEFT JOIN organisation org ON o.organisation = org.id
     WHERE
-        org.review_status = 'APPROVED' AND is_member IS TRUE
+	org.review_status = 'APPROVED' AND is_member IS TRUE
 )
     SELECT
-        c.id
+	c.id
     FROM
-        approved_orgs o,
-        country_group_country cgc
-        JOIN country c ON cgc.country = c.id
+	approved_orgs o,
+	country_group_country cgc
+	JOIN country c ON cgc.country = c.id
     WHERE
-        o.country_group = cgc.country_group
+	o.country_group = cgc.country_group
     UNION
     SELECT
-        o.country AS id
+	o.country AS id
     FROM
-        approved_orgs o
+	approved_orgs o
     WHERE
-        o.country IS NOT NULL
+	o.country IS NOT NULL
 ),
 non_member_organisation_countries AS (
     WITH approved_orgs AS (
-        SELECT
-            o.organisation,
-            o.country,
-            o.country_group
-        FROM
-            organisation_geo_coverage o
-        LEFT JOIN organisation org ON o.organisation = org.id
-        WHERE
-            org.review_status = 'APPROVED'
-            AND org.is_member IS FALSE
+	SELECT
+	    o.organisation,
+	    o.country,
+	    o.country_group
+	FROM
+	    organisation_geo_coverage o
+	LEFT JOIN organisation org ON o.organisation = org.id
+	WHERE
+	    org.review_status = 'APPROVED'
+	    AND org.is_member IS FALSE
 ),
     country_counts AS (
-        SELECT
-            o.organisation AS id,
-            COUNT(c.id) AS country_count
-        FROM
-           approved_orgs o,
-           country_group_country cgc
-        JOIN country c ON cgc.country = c.id
-        WHERE
-           o.country_group = cgc.country_group
-        GROUP BY
-           o.organisation
-        UNION
-        SELECT
-           o.organisation AS id,
-           COUNT(o.country) AS country_count
-        FROM
-           approved_orgs o
-        WHERE
-           o.country IS NOT NULL
-        GROUP BY
-           o.organisation
+	SELECT
+	    o.organisation AS id,
+	    COUNT(c.id) AS country_count
+	FROM
+	   approved_orgs o,
+	   country_group_country cgc
+	JOIN country c ON cgc.country = c.id
+	WHERE
+	   o.country_group = cgc.country_group
+	GROUP BY
+	   o.organisation
+	UNION
+	SELECT
+	   o.organisation AS id,
+	   COUNT(o.country) AS country_count
+	FROM
+	   approved_orgs o
+	WHERE
+	   o.country IS NOT NULL
+	GROUP BY
+	   o.organisation
 )
     SELECT
-        id,
-        SUM(country_count) AS country_count
+	id,
+	SUM(country_count) AS country_count
     FROM
-        country_counts
+	country_counts
     GROUP BY
-        id
+	id
 ),
 country_counts AS (
     SELECT
-        COUNT(*) AS country,
-        'initiative' AS data
+	COUNT(*) AS country,
+	'initiative' AS data
     FROM
-        initiative_countries
+	initiative_countries
     UNION
     SELECT
-        COUNT(*) AS country,
-        replace(lower(type), ' ', '_') AS data
+	COUNT(*) AS country,
+	replace(lower(type), ' ', '_') AS data
     FROM
-        resource_countries
+	resource_countries
     WHERE
-        type IS NOT NULL
+	type IS NOT NULL
     GROUP BY
-        data
+	data
     UNION
     SELECT
-        COUNT(*) AS country,
-        'event' AS data
+	COUNT(*) AS country,
+	'event' AS data
     FROM
-        event_countries
+	event_countries
     UNION
     SELECT
-        COUNT(*) AS country,
-        'policy' AS data
+	COUNT(*) AS country,
+	'policy' AS data
     FROM
-        policy_countries
+	policy_countries
     UNION
     SELECT
-        COUNT(*) AS country,
-        'technology' AS data
+	COUNT(*) AS country,
+	'technology' AS data
     FROM
-        technology_countries
+	technology_countries
     UNION
     SELECT
-        COUNT(*) AS country,
-        'organisation' AS data
+	COUNT(*) AS country,
+	'organisation' AS data
     FROM
-        organisation_countries
+	organisation_countries
     UNION
     SELECT
-        COUNT(*) AS country,
-        'stakeholder' AS data
+	COUNT(*) AS country,
+	'stakeholder' AS data
     FROM
-        stakeholder_countries
+	stakeholder_countries
 ),
 totals AS (
     SELECT
-        COUNT(*) AS total,
-        'initiative' AS data,
-        1 AS o
+	COUNT(*) AS total,
+	'initiative' AS data,
+	1 AS o
     FROM
-        initiative
+	initiative
     WHERE
-        review_status = 'APPROVED'
+	review_status = 'APPROVED'
     UNION
     SELECT
-        COUNT(*) AS total,
-        REPLACE(LOWER(type), ' ', '_') AS data,
-        2 AS o
+	COUNT(*) AS total,
+	REPLACE(LOWER(type), ' ', '_') AS data,
+	2 AS o
     FROM
-        resource
+	resource
     WHERE
-        review_status = 'APPROVED'
-        AND type IS NOT NULL
+	review_status = 'APPROVED'
+	AND type IS NOT NULL
     GROUP BY
-        data
+	data
     UNION
     SELECT
-        COUNT(*) AS total,
-        'event' AS data,
-        3 AS o
+	COUNT(*) AS total,
+	'event' AS data,
+	3 AS o
     FROM
-        event
+	event
     WHERE
-        event.review_status = 'APPROVED'
+	event.review_status = 'APPROVED'
     UNION
     SELECT
-        COUNT(*) AS total,
-        'policy' AS data,
-        4 AS o
+	COUNT(*) AS total,
+	'policy' AS data,
+	4 AS o
     FROM
-        policy
+	policy
     WHERE
-        review_status = 'APPROVED'
+	review_status = 'APPROVED'
     UNION
     SELECT
-        COUNT(*) AS total,
-        'technology' AS data,
-        5 AS o
+	COUNT(*) AS total,
+	'technology' AS data,
+	5 AS o
     FROM
-        technology
+	technology
     WHERE
-        review_status = 'APPROVED'
+	review_status = 'APPROVED'
     UNION
     SELECT
-        COUNT(*) AS total,
-        'organisation' AS data,
-        6 AS o
+	COUNT(*) AS total,
+	'organisation' AS data,
+	6 AS o
     FROM
-        organisation
+	organisation
     WHERE
-        review_status = 'APPROVED'
-        AND is_member IS TRUE
+	review_status = 'APPROVED'
+	AND is_member IS TRUE
     UNION
     SELECT
-        COUNT(*) AS total,
-        'stakeholder' AS data,
-        7 AS o
+	COUNT(*) AS total,
+	'stakeholder' AS data,
+	7 AS o
     FROM
-        stakeholder
+	stakeholder
     WHERE
     review_status = 'APPROVED'
 )

--- a/backend/src/gpml/db/stakeholder_association.sql
+++ b/backend/src/gpml/db/stakeholder_association.sql
@@ -1,104 +1,104 @@
 -- :name get-stakeholder-associated-topics :? :*
 -- :doc Get stakeholder associatiated topics based on the association type
 -- :require [gpml.db.topic]
---~ (#'gpml.db.topic/generate-topic-query {} gpml.db.topic/generic-cte-opts)
+--~ (#'gpml.db.topic/generate-topic-query {})
 ,
 stakeholder_association AS (
     SELECT
-        REPLACE(LOWER(r.type), ' ', '_') AS topic,
-        sr.stakeholder,
-        sr.resource AS id,
-        sr.association::text AS association,
-        sr.remarks,
-        json_agg(json_build_object('id', sr.id, 'stakeholder_id', sr.stakeholder, 'role', sr.association, 'stakeholder',
-        concat_ws(' ', s.first_name, s.last_name), 'image', s.picture,  'stakeholder_role', s.role)) AS stakeholder_connections,
-        json_agg(json_build_object('id', orgr.id, 'entity_id', orgr.organisation, 'role', orgr.association, 'entity',
-        o.name, 'image', o.logo))
-        AS entity_connections
+	REPLACE(LOWER(r.type), ' ', '_') AS topic,
+	sr.stakeholder,
+	sr.resource AS id,
+	sr.association::text AS association,
+	sr.remarks,
+	json_agg(json_build_object('id', sr.id, 'stakeholder_id', sr.stakeholder, 'role', sr.association, 'stakeholder',
+	concat_ws(' ', s.first_name, s.last_name), 'image', s.picture,  'stakeholder_role', s.role)) AS stakeholder_connections,
+	json_agg(json_build_object('id', orgr.id, 'entity_id', orgr.organisation, 'role', orgr.association, 'entity',
+	o.name, 'image', o.logo))
+	AS entity_connections
     FROM
-        stakeholder_resource sr
-        JOIN resource r ON r.id = sr.resource
-        LEFT JOIN stakeholder s ON s.id = sr.stakeholder
-        LEFT JOIN organisation_resource orgr ON orgr.resource = sr.resource
-        LEFT JOIN organisation o ON orgr.organisation = o.id
+	stakeholder_resource sr
+	JOIN resource r ON r.id = sr.resource
+	LEFT JOIN stakeholder s ON s.id = sr.stakeholder
+	LEFT JOIN organisation_resource orgr ON orgr.resource = sr.resource
+	LEFT JOIN organisation o ON orgr.organisation = o.id
     GROUP BY
-          r.type, sr.stakeholder, sr.resource, sr.association, sr.remarks
+	  r.type, sr.stakeholder, sr.resource, sr.association, sr.remarks
     UNION ALL
     SELECT
-        'event'::text AS topic,
-        se.stakeholder,
-        se.event AS id,
-        se.association::text AS association,
-        se.remarks,
-        json_agg(json_build_object('id', se.id, 'stakeholder_id', se.stakeholder, 'role', se.association, 'stakeholder',
-        concat_ws(' ', s.first_name, s.last_name), 'image', s.picture,  'stakeholder_role', s.role)) AS stakeholder_connections,
-        json_agg(json_build_object('id', oe.id, 'entity_id', oe.organisation, 'role', oe.association, 'entity', o.name,
-        'image', o.logo)) AS
-        entity_connections
+	'event'::text AS topic,
+	se.stakeholder,
+	se.event AS id,
+	se.association::text AS association,
+	se.remarks,
+	json_agg(json_build_object('id', se.id, 'stakeholder_id', se.stakeholder, 'role', se.association, 'stakeholder',
+	concat_ws(' ', s.first_name, s.last_name), 'image', s.picture,  'stakeholder_role', s.role)) AS stakeholder_connections,
+	json_agg(json_build_object('id', oe.id, 'entity_id', oe.organisation, 'role', oe.association, 'entity', o.name,
+	'image', o.logo)) AS
+	entity_connections
     FROM
-        stakeholder_event se
-        LEFT JOIN stakeholder s ON se.stakeholder = s.id
-        LEFT JOIN organisation_event oe ON oe.event = se.event
-        LEFT JOIN organisation o ON o.id = oe.organisation
+	stakeholder_event se
+	LEFT JOIN stakeholder s ON se.stakeholder = s.id
+	LEFT JOIN organisation_event oe ON oe.event = se.event
+	LEFT JOIN organisation o ON o.id = oe.organisation
     GROUP BY
-        se.stakeholder, se.event, se.association, se.remarks
+	se.stakeholder, se.event, se.association, se.remarks
     UNION ALL
     SELECT
-        'technology'::text AS topic,
-        st.stakeholder,
-        st.technology AS id,
-        st.association::text AS association,
-        st.remarks,
-        json_agg(json_build_object('id', st.id, 'stakeholder_id', st.stakeholder, 'role', st.association, 'stakeholder',
-        concat_ws(' ', s.first_name, s.last_name), 'image', s.picture,  'stakeholder_role', s.role)) AS stakeholder_connections,
-        json_agg(json_build_object('id', ot.id, 'entity_id', ot.organisation, 'role', ot.association, 'entity', o.name,
-        'image', o.logo)) AS
-        entity_connections
+	'technology'::text AS topic,
+	st.stakeholder,
+	st.technology AS id,
+	st.association::text AS association,
+	st.remarks,
+	json_agg(json_build_object('id', st.id, 'stakeholder_id', st.stakeholder, 'role', st.association, 'stakeholder',
+	concat_ws(' ', s.first_name, s.last_name), 'image', s.picture,  'stakeholder_role', s.role)) AS stakeholder_connections,
+	json_agg(json_build_object('id', ot.id, 'entity_id', ot.organisation, 'role', ot.association, 'entity', o.name,
+	'image', o.logo)) AS
+	entity_connections
     FROM
-        stakeholder_technology st
-        LEFT JOIN stakeholder s ON s.id = st.stakeholder
-        LEFT JOIN organisation_technology ot ON ot.technology = st.technology
-        LEFT JOIN organisation o ON o.id = ot.organisation
+	stakeholder_technology st
+	LEFT JOIN stakeholder s ON s.id = st.stakeholder
+	LEFT JOIN organisation_technology ot ON ot.technology = st.technology
+	LEFT JOIN organisation o ON o.id = ot.organisation
     GROUP BY
-        st.stakeholder, st.technology, st.association, st.remarks
+	st.stakeholder, st.technology, st.association, st.remarks
     UNION ALL
     SELECT
-        'policy'::text AS topic,
-        sp.stakeholder,
-        sp.policy AS id,
-        sp.association::text AS association,
-        sp.remarks,
-        json_agg(json_build_object('id', sp.id, 'stakeholder_id', sp.stakeholder, 'role', sp.association, 'stakeholder',
-        concat_ws(' ', s.first_name, s.last_name), 'image', s.picture,  'stakeholder_role', s.role)) AS stakeholder_connections,
-        json_agg(json_build_object('id', op.id, 'entity_id', op.organisation, 'role', op.association, 'entity', o.name,
-        'image', o.logo)) AS
-        entity_connections
+	'policy'::text AS topic,
+	sp.stakeholder,
+	sp.policy AS id,
+	sp.association::text AS association,
+	sp.remarks,
+	json_agg(json_build_object('id', sp.id, 'stakeholder_id', sp.stakeholder, 'role', sp.association, 'stakeholder',
+	concat_ws(' ', s.first_name, s.last_name), 'image', s.picture,  'stakeholder_role', s.role)) AS stakeholder_connections,
+	json_agg(json_build_object('id', op.id, 'entity_id', op.organisation, 'role', op.association, 'entity', o.name,
+	'image', o.logo)) AS
+	entity_connections
     FROM
-        stakeholder_policy sp
-        LEFT JOIN stakeholder s ON sp.stakeholder = s.id
-        LEFT JOIN organisation_policy op ON op.policy = sp.policy
-        LEFT JOIN organisation o ON o.id = op.organisation
+	stakeholder_policy sp
+	LEFT JOIN stakeholder s ON sp.stakeholder = s.id
+	LEFT JOIN organisation_policy op ON op.policy = sp.policy
+	LEFT JOIN organisation o ON o.id = op.organisation
     GROUP BY
-        sp.stakeholder, sp.policy, sp.association, sp.remarks
+	sp.stakeholder, sp.policy, sp.association, sp.remarks
     UNION ALL
     SELECT
-        'initiative'::text AS topic,
-        si.stakeholder,
-        si.initiative AS id,
-        si.association::text AS association,
-        si.remarks,
-        json_agg(json_build_object('id', si.id, 'stakeholder_id', si.stakeholder, 'role', si.association, 'stakeholder',
-        concat_ws(' ', s.first_name, s.last_name), 'image', s.picture,  'stakeholder_role', s.role)) AS stakeholder_connections,
-        json_agg(json_build_object('id', oi.id, 'entity_id', oi.organisation, 'role', oi.association, 'entity', o.name,
-        'image', o.logo)) AS
-        entity_connections
+	'initiative'::text AS topic,
+	si.stakeholder,
+	si.initiative AS id,
+	si.association::text AS association,
+	si.remarks,
+	json_agg(json_build_object('id', si.id, 'stakeholder_id', si.stakeholder, 'role', si.association, 'stakeholder',
+	concat_ws(' ', s.first_name, s.last_name), 'image', s.picture,  'stakeholder_role', s.role)) AS stakeholder_connections,
+	json_agg(json_build_object('id', oi.id, 'entity_id', oi.organisation, 'role', oi.association, 'entity', o.name,
+	'image', o.logo)) AS
+	entity_connections
     FROM
-        stakeholder_initiative si
-        LEFT JOIN stakeholder s ON s.id = si.stakeholder
-        LEFT JOIN organisation_initiative oi ON oi.initiative = si.initiative
-        LEFT JOIN organisation o ON o.id = oi.organisation
+	stakeholder_initiative si
+	LEFT JOIN stakeholder s ON s.id = si.stakeholder
+	LEFT JOIN organisation_initiative oi ON oi.initiative = si.initiative
+	LEFT JOIN organisation o ON o.id = oi.organisation
     GROUP BY
-        si.stakeholder, si.initiative, si.association, si.remarks
+	si.stakeholder, si.initiative, si.association, si.remarks
 ),
 associated_topics AS (
 SELECT DISTINCT ON (t.topic, (COALESCE(t.json ->> 'start_date', t.json ->> 'created'))::timestamptz,

--- a/backend/src/gpml/db/topic.clj
+++ b/backend/src/gpml/db/topic.clj
@@ -302,9 +302,17 @@
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn generate-topic-query
   "Generates the SQL to query topic's (resources) data."
-  [params opts]
-  (let [opts (merge generic-cte-opts (when (seq (:tables opts))
-                                       (update opts :tables rename-tables)))
+  [{:keys [topic sub-content-type] :as params}]
+  (let [tables (if (seq topic)
+                 topic
+                 (:tables gpml.db.topic/generic-cte-opts))
+        ;; If we ever need to add
+        ;; `sub_content_type` to case study, remove
+        ;; this conditional and binding.
+        filtered-tables (if (seq sub-content-type)
+                          (vec (remove #{"case_study"} tables))
+                          tables)
+        opts (merge generic-cte-opts {:tables (rename-tables filtered-tables)})
         topic-data-ctes (generate-ctes :data params opts)
         topic-ctes (generate-ctes :topic params opts)
         topic-cte (generate-topic-cte {} opts)]

--- a/backend/src/gpml/db/topic.sql
+++ b/backend/src/gpml/db/topic.sql
@@ -1,7 +1,7 @@
 -- :name get-topics :? :*
 -- :doc Gets the list of topics. If count-only? parameter is set to true, the query will only group and count the topics.
 -- :require [gpml.db.topic]
---~ (#'gpml.db.topic/generate-topic-query params (if (seq (:topic params)) {:tables (:topic params)} gpml.db.topic/generic-cte-opts))
+--~ (#'gpml.db.topic/generate-topic-query params)
 ,
 cte_results AS (
 --~ (#'gpml.db.topic/generate-filter-topic-snippet params)
@@ -362,11 +362,11 @@ UNION ALL
     LEFT JOIN related_content rc ON i.id = rc.resource_id AND resource_table_name = 'initiative'::regclass
     LEFT JOIN organisation_initiative oe ON oe.initiative = i.id
     LEFT JOIN organisation o ON o.id = oe.organisation
-        --~ (when (:review-status params) "WHERE i.review_status = (:v:review-status)::review_status")
+	--~ (when (:review-status params) "WHERE i.review_status = (:v:review-status)::review_status")
   GROUP BY i.id
 UNION ALL
   SELECT
-  	'policy'::text AS topic,
+	'policy'::text AS topic,
     p.id,
     0 AS version,
     NULL::json AS submitting_as,


### PR DESCRIPTION
[Re #1544]

* This filter would break the query if the topic is case_study. Since case study do not have the `sub_content_type` filter, we remove it from the tables' list if the `sub_content_type` filter is used.