### PR TITLE
1543 Fix files migration for case studies in API

### DIFF
--- a/backend/src/gpml/db/case_study.sql
+++ b/backend/src/gpml/db/case_study.sql
@@ -23,8 +23,10 @@ ORDER BY id
 --~ (when (:limit params) " LIMIT :limit")
 ;
 
--- :name update-case-study
+-- :name update-case-study :execute :affected
 -- :doc this query is for file migration purposes and will be removed.
+UPDATE case_study
+SET
 /*~
 (str/join ","
   (for [[field _] (:updates params)]


### PR DESCRIPTION
[Re #1543]

The DB query used to update the case studies with the migrated images was missing the actual `update table set` prefix before the dynamic HugSQL-related part. After this the API should also work for migrating images that were not stored previously in GCS.