### PR TITLE
1543 Fix access to get private file URLs

### DIFF
--- a/backend/src/gpml/service/file.clj
+++ b/backend/src/gpml/service/file.clj
@@ -1,6 +1,7 @@
 (ns gpml.service.file
   (:require [clj-gcp.storage.core :as storage-client]
             [duct.logger :refer [log]]
+            [gpml.boundary.adapter.storage-client.gcs]      ;; We need to require it to extend the Record there
             [gpml.boundary.port.storage-client :as storage-client-ext]
             [gpml.db.file :as db.file]
             [gpml.util :as util]
@@ -54,6 +55,7 @@
   [{:keys [storage-client-adapter
            private-storage-bucket-name
            private-storage-signed-url-lifespan]} file]
+  (prn "get private url method")
   (storage-client-ext/get-blob-signed-url storage-client-adapter
                                           private-storage-bucket-name
                                           (:object-key file)


### PR DESCRIPTION
[Re #1543]

We were not including the namespace that extends the GCSStorageClient protocol with the methods to get blob signed URL and delete blob-related functionality, that was preventing the reading of private image files from GCS. This was not reproduced locally, since there we load always all the namespaces, which is not the case with the Uberjar. So now we require the mentioned file as part of the File service, that is required already, fixing the issue.