### PR TITLE
1543 fix resource file updates

### DIFF
--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -609,12 +609,12 @@
   [config conn resource-type resource-id file-id-key old-file-id]
   (let [result (srv.file/delete-file config conn {:id old-file-id})]
     (if (:success? result)
-      (throw (ex-info "Failed to delete old resource image file" {:result result}))
       (db.detail/update-resource-table
        conn
        {:table resource-type
         :id resource-id
-        :updates {file-id-key nil}}))))
+        :updates {file-id-key nil}})
+      (throw (ex-info "Failed to delete old resource image file" {:result result})))))
 
 (defn- update-resource-image**
   [config conn resource-type resource-id file-id-key image-payload]
@@ -642,13 +642,13 @@
                              image-payload)
     (let [result (srv.file/delete-file config conn {:id old-file-id})]
       (if (:success? result)
-        (throw (ex-info "Failed to delete old resource image file" {:result result}))
         (update-resource-image** config
                                  conn
                                  resource-type
                                  resource-id
                                  file-id-key
-                                 image-payload)))))
+                                 image-payload)
+        (throw (ex-info "Failed to delete old resource image file" {:result result}))))))
 
 (defn update-resource-image
   [config conn resource-type resource-id image-key image-payload]

--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -607,14 +607,20 @@
 
 (defn update-blank-resource-image
   [config conn resource-type resource-id file-id-key old-file-id]
-  (let [result (srv.file/delete-file config conn {:id old-file-id})]
-    (if (:success? result)
-      (db.detail/update-resource-table
-       conn
-       {:table resource-type
-        :id resource-id
-        :updates {file-id-key nil}})
-      (throw (ex-info "Failed to delete old resource image file" {:result result})))))
+  (if old-file-id
+    (let [result (srv.file/delete-file config conn {:id old-file-id})]
+      (if (:success? result)
+        (db.detail/update-resource-table
+         conn
+         {:table resource-type
+          :id resource-id
+          :updates {file-id-key nil}})
+        (throw (ex-info "Failed to delete old resource image file" {:result result}))))
+    (db.detail/update-resource-table
+     conn
+     {:table resource-type
+      :id resource-id
+      :updates {file-id-key nil}})))
 
 (defn- update-resource-image**
   [config conn resource-type resource-id file-id-key image-payload]

--- a/backend/test/gpml/handler/detail_test.clj
+++ b/backend/test/gpml/handler/detail_test.clj
@@ -36,7 +36,6 @@
    :remarks nil
    :review_status nil
    :document_preview false
-   :image nil
    :language default-lang-iso-code})
 
 (def technology-data
@@ -53,8 +52,6 @@
    :year_founded 2021
    :review_status nil
    :document_preview false
-   :image nil
-   :logo nil
    :tags nil
    :language default-lang-iso-code})
 
@@ -69,7 +66,6 @@
    :remarks nil
    :document_preview false
    :review_status nil
-   :image nil
    :tags nil
    :language default-lang-iso-code})
 


### PR DESCRIPTION
This PR addresses 3 issues during the image update process when updating a resource:

- Fix the logic to finish image replacement after the old image is successfully deleted: the logic was inverted so we would be rolling back the process if the old images were deleted ok.
- Stop trying to delete old images that did not exist when updating a resource to remove a given image. Now we check if there is an actual previous image to be deleted before trying to do so.
- Fix limbo image state when failing resource update process. Now we delete removed image references in the DB after the images have been removed from GCS. So next time the user can try to upload the images that were meant to be replaced, without seeing broken links.