### PR TITLE
1572 Fix GET Translations endpoint permissions check

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -379,6 +379,7 @@
                                          ["/{topic-type}/{topic-id}"
                                           {:get {:summary "Get the translations for a specific resource"
                                                  :swagger {:tags ["get resource translations"]}
+                                                 :middleware [#ig/ref :gpml.auth/auth-middleware]
                                                  :parameters {:path [:map
                                                                      [:topic-type
                                                                       #ig/ref :gpml.handler.resource.translation/topics]


### PR DESCRIPTION
[Re #1572]

As described by the #1572 issue , we have needed to provide the endpoint with the auth middleware in order to inject the user in the request when it's available. Thus, we can correctly use the user info to check the permissions when we are dealing with non-published (draft) resource translations.