### PR TITLE
1576 Fix stakeholder creation service

### DIFF
--- a/backend/src/gpml/handler/organisation.clj
+++ b/backend/src/gpml/handler/organisation.clj
@@ -200,7 +200,6 @@
             (resp/created referrer (assoc body-params :id org-id))))
         (r/forbidden {:message "Unauthorized"}))
       (catch Throwable t
-        (prn t)
         (let [log-data {:exception-message (ex-message t)
                         :exception-data (ex-data t)
                         :context-data (assoc body-params

--- a/backend/src/gpml/service/stakeholder.clj
+++ b/backend/src/gpml/service/stakeholder.clj
@@ -133,7 +133,7 @@
                                  :resource-id (:id org)
                                  :individual-connections [{:role "owner"
                                                            :stakeholder sth-id}]})]
-                    (if-not (:success? result)
+                    (if-not (-> result first :success?)
                       (assoc context
                              :success? false
                              :reason :failed-to-assign-sth-owner-role-to-organisation


### PR DESCRIPTION
[Re #1576]

We were not getting the result right from the roles assignment utility function, when we needed to create `resource-owner` role for created non-member organisation related to the stakeholder being created. Now we have fixed that.

Besides we also have removed a print of a exception catched, in a separated ns related to organisations.

Fix for #1576 issue.