### PR TITLE
1582 Fix experts invitations related permissions handling

### DIFF
--- a/backend/src/gpml/db/stakeholder.sql
+++ b/backend/src/gpml/db/stakeholder.sql
@@ -174,6 +174,7 @@ update stakeholder set
 --~ (when (contains? params :idp_usernames) "idp_usernames= :idp_usernames::jsonb,")
 --~ (when (contains? params :picture_id) "picture_id= :picture_id,")
 --~ (when (contains? params :cv_id) "cv_id= :cv_id, ")
+--~ (when (contains? params :review_status) "review_status= :review_status::review_status,")
     modified = now()
 where id = :id;
 

--- a/backend/src/gpml/handler/stakeholder.clj
+++ b/backend/src/gpml/handler/stakeholder.clj
@@ -201,11 +201,12 @@
   (fn [{:keys [body-params headers user]}]
     (try
       (let [tags (handler.stakeholder.tag/api-stakeholder-tags->stakeholder-tags body-params)]
-        (update-stakeholder config (assoc body-params
-                                          :id (:id user)
-                                          :picture {:payload (:picture body-params)
-                                                    :user-agent (get headers "user-agent")}
-                                          :tags tags))
+        (update-stakeholder config (-> body-params
+                                       (assoc :id (:id user)
+                                              :picture {:payload (:picture body-params)
+                                                        :user-agent (get headers "user-agent")}
+                                              :tags tags)
+                                       (dissoc :review_status)))
         (resp/status {:success? true} 204))
       (catch Exception e
         (log logger :error ::failed-to-update-stakeholder {:exception-message (.getMessage e)})


### PR DESCRIPTION
[Re #1582]

Fixed query to get experts results needed to be able to detect an expert user needs to be converted to an approved user.

Besides, we have instrumented the code of update stakeholder-related function to unassign unapproved user role from the expert user in case it is detected as such, and be able to assign the approved user role in that case as well. The added functions have their rollbacks as well and we have also added one for the update stakeholder's final function, to have a consistent behaviour.

On the other hand the endpoint to accept invitations looks not to be in use and such this looks like the only entrypoint to fix, but we will check.

Now we are also catching better the exceptions, using Throwable class.

This issue is related to #1530 and #1543  refactors.