### PR TITLE
1588 Avoid duplicate tags errors, using existing tags

### DIFF
--- a/backend/src/gpml/db/tag.sql
+++ b/backend/src/gpml/db/tag.sql
@@ -25,7 +25,7 @@ values (:tag, :tag_category) returning id
 -- :name new-tags :query :many
 -- :doc Insert new tag
 insert into tag (:i*:insert-cols)
-values :t*:tags RETURNING *;
+values :t*:tags ON CONFLICT (LOWER(tag)) DO UPDATE SET tag = tag.tag RETURNING *;
 
 -- :name tag-by-category :? :* :1
 -- :doc Get tag by category

--- a/backend/src/gpml/handler/stakeholder.clj
+++ b/backend/src/gpml/handler/stakeholder.clj
@@ -145,8 +145,6 @@
       (get-in result [:stakeholder :id])
       (throw (ex-info "Failed to update stakeholder" {:result result})))))
 
-;; FIXME: The permissions metadata adding part is not right, as we are re-creating org related to the new stakeholder,
-;; so we need to handle that and ensure we get the right resource-id for the permissions.
 (defn- save-stakeholder
   [{:keys [db logger mailjet-config] :as config}
    {{:keys [body]} :parameters

--- a/backend/src/gpml/service/permissions.clj
+++ b/backend/src/gpml/service/permissions.clj
@@ -58,6 +58,11 @@
     :parent-resource-id root-app-resource-id
     :parent-context-type root-app-context-type}))
 
+(defn get-resource-context
+  "FIXME: Add docstring"
+  [{:keys [conn logger]} context-type resource-id]
+  (rbac/get-context conn logger context-type resource-id))
+
 (defn create-resource-contexts-under-root
   "Create multiple rbac contexts under the same (root) parent
 


### PR DESCRIPTION
[Re #1588]

As explained in the issue, we want to avoid throwing duplicate tag errors and use the tags that exist when needed, making it transparent for the frontend. So in order to achieve that we avoid conflicts when we find duplicate tags during the creation process, returning the data of both newly created tags and the conflicting ones, making it transparent for the frontend.

Once we have tried to create all the tags, we try to fetch related rbac context to know if we need to create a new context or not, since we cannot just try to create it, as it would cause an SQL error that could abort any ongoing DB transaction.

Ideally the frontend should send the ids when we are dealing with existing tags and we should change the backend code to avoid trying to create already existing tags, but with this approach we tackle all the issues at the same time and we avoid throwing errors in those cases, making the code simpler as well.

Removed also an outdated unrelated comment found.