### PR TITLE
1597 Remove non-approved users from profile suggestions

### DIFF
--- a/backend/src/gpml/db/stakeholder.sql
+++ b/backend/src/gpml/db/stakeholder.sql
@@ -234,6 +234,7 @@ WITH suggested_stakeholders AS (
 SELECT *
 FROM
     suggested_stakeholders
+WHERE review_status = 'APPROVED'
 LIMIT :limit
 OFFSET :offset;
 
@@ -246,6 +247,7 @@ FROM
     stakeholder s
     JOIN activity a ON s.id = a.owner_id
     WHERE s.id NOT IN (:v*:stakeholder-ids)
+    AND s.review_status = 'APPROVED'
 ORDER BY
     s.id,
     a.created_at DESC


### PR DESCRIPTION
[Re #1597]

As explained in the issue we have needed to remove the non-approved stakeholders from the results of profile suggestions. In this case, we have applied the filter in two different DB queries, including one to get latest activity from stakeholders, where it was not sensible to make this filter optional.