### PR TITLE
1608 build img urls for get-members endpoint

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -742,7 +742,7 @@
 
   :gpml.handler.organisation-detail/get-content {:db #ig/ref :duct.database/sql}
   :gpml.handler.organisation-detail/get-content-params {}
-  :gpml.handler.organisation-detail/get-members {:db #ig/ref :duct.database/sql}
+  :gpml.handler.organisation-detail/get-members #ig/ref :gpml.config/common
   :gpml.handler.organisation-detail/get-members-params {}
 
   :gpml.handler.activity/get-recent #ig/ref :gpml.config/common

--- a/backend/src/gpml/db/organisation_detail.clj
+++ b/backend/src/gpml/db/organisation_detail.clj
@@ -2,4 +2,8 @@
   {:ns-tracker/resource-deps ["organisation_detail.sql"]}
   (:require [hugsql.core :as hugsql]))
 
+(declare get-content-by-org ;; FIXME: remove this method as it is not used.
+         get-associated-content-by-org
+         get-org-members)
+
 (hugsql/def-db-fns "gpml/db/organisation_detail.sql")

--- a/backend/src/gpml/db/organisation_detail.sql
+++ b/backend/src/gpml/db/organisation_detail.sql
@@ -216,7 +216,17 @@ SELECT
 -- :doc Get all members belonging to a particular organisation
 WITH org_members AS(
   SELECT
-    id, concat_ws(' ', s.first_name, s.last_name) as name, picture, email, linked_in, twitter, url, about
+    s.id,
+    concat_ws(' ', s.first_name, s.last_name) as name,
+    s.email,
+    s.linked_in,
+    s.twitter,
+    s.url,
+    s.about,
+    s.picture_id,
+    f.object_key AS picture_object_key,
+    f.visibility AS picture_visibility
   FROM stakeholder s
+  LEFT JOIN file f ON s.picture_id = f.id
   WHERE affiliation = :id)
 --~(if (:count-only? params) "SELECT COUNT(*) FROM org_members;" "SELECT * FROM org_members LIMIT :limit OFFSET :offset;")

--- a/backend/src/gpml/handler/organisation_detail.clj
+++ b/backend/src/gpml/handler/organisation_detail.clj
@@ -33,7 +33,7 @@
       :else
       content)))
 
-(defmethod ig/init-key ::get-content
+(defmethod ig/init-key :gpml.handler.organisation-detail/get-content
   [_ {:keys [db]}]
   (fn [{:keys [parameters]}]
     (let [conn (:spec db)
@@ -48,7 +48,8 @@
       (resp/response {:results api-associated-content
                       :count (-> associated-content-count first :count)}))))
 
-(defmethod ig/init-key ::get-content-params [_ _]
+(defmethod ig/init-key :gpml.handler.organisation-detail/get-content-params
+  [_ _]
   {:path [:map [:id pos-int?]]
    :query [:map
            [:page {:optional true
@@ -58,7 +59,7 @@
                     :default "3"}
             string?]]})
 
-(defmethod ig/init-key ::get-members
+(defmethod ig/init-key :gpml.handler.organisation-detail/get-members
   [_ {:keys [db] :as config}]
   (fn [{:keys [parameters user]}]
     (if (h.r.permission/operation-allowed?
@@ -79,7 +80,8 @@
                         :count (-> members-count first :count)}))
       (r/forbidden {:message "Unauthorized"}))))
 
-(defmethod ig/init-key ::get-members-params [_ _]
+(defmethod ig/init-key :gpml.handler.organisation-detail/get-members-params
+  [_ _]
   {:path [:map [:id pos-int?]]
    :query [:map
            [:page {:optional true


### PR DESCRIPTION
* Some cosmetic changes:
  *  Use the long-version of the integrant key names on the `organisation_detail.clj` handlers.
  * Declare HugSQL functions in the `db/organisation_detail.clj`.
* Fixes:
  * Add picture file details to org members.
  * Add picture file's url to org members.
  * Use GPML common configuration object for `get-members` handler.