### PR TITLE
1616 Load `name` property for Orgs in Detail GET endpoint

### DIFF
--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -500,7 +500,10 @@
   [{:keys [db] :as config} topic-id topic-type query]
   (let [conn (:spec db)
         resource-details (-> (get-detail* conn topic-type topic-id query)
-                             (dissoc :tags :remarks :name :abstract :description))]
+                             (dissoc :tags :remarks :abstract :description))
+        resource-details (if-not (= "organisation" topic-type)
+                           (dissoc resource-details :name)
+                           resource-details)]
     (if (seq resource-details)
       {:success? true
        :resource-details (extra-details config topic-type resource-details)}


### PR DESCRIPTION
[Re #1616]

As specified in the issue we now provide the `name` property when getting Organisation detail in the related GET resource Detail endpoint.