### PR TITLE
1619 support private tags

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -253,6 +253,7 @@
                                          [""
                                           {:get {:summary "List tags grouped by category"
                                                  :swagger {:tags ["tag"]}
+                                                 :parameters {:query #ig/ref :gpml.handler.tag/get-all-query-params}
                                                  :handler #ig/ref :gpml.handler.tag/all}
                                            :post {:summary "Create a tag"
                                                   :swagger {:tags ["tag"]}
@@ -752,6 +753,7 @@
   :gpml.handler.tag/all {:db #ig/ref :duct.database/sql}
   :gpml.handler.tag/get-popular-topics-tags {:db #ig/ref :duct.database/sql}
   :gpml.handler.tag/get-popular-topics-tags-params {}
+  :gpml.handler.tag/get-all-query-params {}
   :gpml.handler.tag/post #ig/ref :gpml.config/common
   :gpml.handler.tag/post-params {}
   :gpml.handler.tag/put {:db #ig/ref :duct.database/sql}

--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -254,6 +254,12 @@
                                           {:get {:summary "List tags grouped by category"
                                                  :swagger {:tags ["tag"]}
                                                  :handler #ig/ref :gpml.handler.tag/all}
+                                           :post {:summary "Create a tag"
+                                                  :swagger {:tags ["tag"]}
+                                                  :middleware [#ig/ref :gpml.auth/auth-middleware
+                                                               #ig/ref :gpml.auth/auth-required]
+                                                  :parameters #ig/ref :gpml.handler.tag/post-params
+                                                  :handler #ig/ref :gpml.handler.tag/post}
                                            :put {:summary "Update a tag"
                                                  :swagger {:tags ["tag"]}
                                                  :middleware [#ig/ref :gpml.auth/auth-middleware
@@ -746,6 +752,8 @@
   :gpml.handler.tag/all {:db #ig/ref :duct.database/sql}
   :gpml.handler.tag/get-popular-topics-tags {:db #ig/ref :duct.database/sql}
   :gpml.handler.tag/get-popular-topics-tags-params {}
+  :gpml.handler.tag/post #ig/ref :gpml.config/common
+  :gpml.handler.tag/post-params {}
   :gpml.handler.tag/put {:db #ig/ref :duct.database/sql}
   :gpml.handler.tag/put-params {}
   :gpml.handler.tag/put-response {}

--- a/backend/resources/migrations/194-support-private-tags.up.sql
+++ b/backend/resources/migrations/194-support-private-tags.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+--;;
+ALTER TABLE tag
+  ADD COLUMN IF NOT EXISTS private BOOLEAN DEFAULT false;
+--;;
+COMMIT;

--- a/backend/src/gpml/db/tag.sql
+++ b/backend/src/gpml/db/tag.sql
@@ -34,10 +34,11 @@ select * from tag WHERE tag_category in
 
 -- :name all-tags :? :*
 -- :doc Get all tags
-select tg.category, t.id, t.tag
+select tg.category, t.id, t.tag, t.private
  from tag_category tg, tag t
 where tg.id = t.tag_category
 and t.review_status = 'APPROVED'
+--~ (when-not (nil? (:private params)) " AND private = (:v:private)")
 order by tg.category, t.tag
 
 -- :name get-popular-topics-tags :? :*

--- a/backend/src/gpml/domain/tag.clj
+++ b/backend/src/gpml/domain/tag.clj
@@ -21,20 +21,53 @@
   "The Tag entity schema."
   (m/schema
    [:map
-    [:id pos-int?]
-    [:tag_category pos-int?]
-    [:tag [string? {:min 1}]]
+    [:id
+     {:swagger
+      {:description "The Tag's identifier"
+       :type "integer"}}
+     pos-int?]
+    [:tag_category
+     {:swagger
+      {:type "integer"
+       :description "The Tag's category reference."}}
+     pos-int?]
+    [:tag
+     {:swagger
+      {:type "string"
+       :description "The Tag's content."}}
+     [string? {:min 1}]]
     [:review_status
      {:default default-review-status
-      :swagger {:description "Review status of the Tag"
+      :swagger {:description "Review status of the Tag. By default `APPROVED` value will be used."
                 :type "string"
                 :enum dom.types/review-statuses}}
      (apply conj [:enum] dom.types/review-statuses)]
-    [:reviewed_by {:optional true} pos-int?]
-    [:reviewed_at {:optional true} inst?]
-    [:private {:optional true} boolean?]
-    [:definition {:optional true} [string? {:min 1}]]
-    [:ontology_ref_link {:optional true}
+    [:reviewed_by
+     {:optional true
+      :swagger
+      {:type "integer"
+       :description "The Tag's review's stakeholder reference."}}
+     pos-int?]
+    [:reviewed_at
+     {:optional true
+      :swagger {:description "The Tag's review's datetime."
+                :type "string"
+                :format "date-time"}}
+     inst?]
+    [:private
+     {:optional true
+      :swagger {:description "It indicates if the tag is meant for private usage."
+                :type "boolean"}}
+     boolean?]
+    [:definition
+     {:optional true
+      :swagger {:description "Not used currently (legacy)."
+                :type "string"}}
+     [string? {:min 1}]]
+    [:ontology_ref_link
+     {:optional true
+      :swagger {:description "Not used currently (legacy)."
+                :type "string"}}
      [:and
       [string? {:min 1}]
       [:fn util/try-url-str]]]]))

--- a/backend/src/gpml/domain/tag.clj
+++ b/backend/src/gpml/domain/tag.clj
@@ -13,6 +13,10 @@
     "product by design"
     "source to sea"})
 
+(def ^:const default-review-status
+  "Default review status for a tag."
+  "APPROVED")
+
 (def Tag
   "The Tag entity schema."
   (m/schema
@@ -20,9 +24,15 @@
     [:id pos-int?]
     [:tag_category pos-int?]
     [:tag [string? {:min 1}]]
-    [:review_status (apply conj [:enum] dom.types/review-statuses)]
+    [:review_status
+     {:default default-review-status
+      :swagger {:description "Review status of the Tag"
+                :type "string"
+                :enum dom.types/review-statuses}}
+     (apply conj [:enum] dom.types/review-statuses)]
     [:reviewed_by {:optional true} pos-int?]
     [:reviewed_at {:optional true} inst?]
+    [:private {:optional true} boolean?]
     [:definition {:optional true} [string? {:min 1}]]
     [:ontology_ref_link {:optional true}
      [:and

--- a/backend/src/gpml/handler/tag.clj
+++ b/backend/src/gpml/handler/tag.clj
@@ -120,11 +120,11 @@
         created-tag-ids))))
 
 (defn all-tags
-  [db]
+  [db query]
   (reduce-kv (fn [m k v]
                (assoc m k (mapv #(dissoc % :category) v)))
              {}
-             (group-by :category (db.tag/all-tags db))))
+             (group-by :category (db.tag/all-tags db query))))
 
 (defn- api-opts->opts
   [{:keys [limit tags]}]
@@ -171,8 +171,8 @@
     (resp/response (popular-tags (:spec db) (api-opts->opts query)))))
 
 (defmethod ig/init-key :gpml.handler.tag/all [_ {:keys [db]}]
-  (fn [_]
-    (resp/response (all-tags (:spec db)))))
+  (fn [{{:keys [query]} :parameters}]
+    (resp/response (all-tags (:spec db) query))))
 
 (defmethod ig/init-key :gpml.handler.tag/put
   [_ config]
@@ -220,3 +220,11 @@
   {:body (-> dom.tag/Tag
              (util.malli/dissoc [:id])
              (mu/assoc :tag_category string?))})
+
+(def ^:private get-all-query-params
+  [:map
+   [:private {:optional true}
+    boolean?]])
+
+(defmethod ig/init-key :gpml.handler.tag/get-all-query-params [_ _]
+  get-all-query-params)

--- a/backend/src/gpml/handler/tag.clj
+++ b/backend/src/gpml/handler/tag.clj
@@ -219,7 +219,11 @@
   [_ _]
   {:body (-> dom.tag/Tag
              (util.malli/dissoc [:id])
-             (mu/assoc :tag_category string?))})
+             (mu/assoc
+              :tag_category
+              [string?
+               {:swagger {:description "The name of the Tag's category it belongs to."
+                          :type "string"}}]))})
 
 (def ^:private get-all-query-params
   [:map


### PR DESCRIPTION
This PR provides support for private tags in the following ways:
- Support creating tags for super admins with new `private` property (`api/tag` POST endpoint). By default current tags will have the value as `false` (so they are publicly available).
- Support for Updating tags with the new mentioned property, for super admins. Here we have made some corrections to the endpoint as well.
- Ability to get the new property and use it for filtering in the public `/api/tag` GET endpoint. Besides this property is provided in other endpoints out of the box.