### PR TITLE
1619 Provide `private` property of tags in GET Resource Detail endpoint

### DIFF
--- a/backend/src/gpml/db/resource/tag.sql
+++ b/backend/src/gpml/db/resource/tag.sql
@@ -22,7 +22,7 @@ DELETE FROM :i:table WHERE :i:resource-col = :resource-id;
 
 -- :name get-resource-tags :query :many
 -- :doc Get resource tags
-SELECT rt.:i:resource-col, t.id, t.tag, tg.category AS tag_category
+SELECT rt.:i:resource-col, t.id, t.tag, t.private, tg.category AS tag_category
 --~(when (= (:table params) "stakeholder_tag") ", rt.tag_relation_category")
 FROM :i:table rt
 JOIN tag t ON rt.tag = t.id


### PR DESCRIPTION
[Re #1619]

We have been requested to load the mentioned property among the tags data related to the target resource data obtained in the GET Resource Details-related endpoint.

As a side effect, we will also load it in other use-cases, but that is not harmful and it can be even better for the future.