### PR TITLE
1636 Fix expertise tags in `/api/organisation/{id}` GET endpoint

### DIFF
--- a/backend/src/gpml/db/organisation.clj
+++ b/backend/src/gpml/db/organisation.clj
@@ -11,7 +11,6 @@
          all-non-members
          new-organisation
          all-members
-         organisation-tags
          geo-coverage-v2
          get-organisation-files-to-migrate
          get-organisations)

--- a/backend/src/gpml/db/organisation.sql
+++ b/backend/src/gpml/db/organisation.sql
@@ -122,15 +122,6 @@ values :t*:geo RETURNING id;
 -- :doc remove geo coverage
 delete from organisation_geo_coverage where organisation = :id
 
-
--- :name organisation-tags :? :*
--- :doc get organisation tags
-select json_agg(st.tag) as tags, tc.category from organisation_tag st
-left join tag t on t.id = st.tag
-left join tag_category tc on t.tag_category = tc.id
-where st.organisation = :id
-group by tc.category;
-
 -- :name add-organisation-tags :<! :1
 -- :doc add organisation tags
 insert into organisation_tag(organisation, tag)

--- a/backend/src/gpml/db/resource/tag.sql
+++ b/backend/src/gpml/db/resource/tag.sql
@@ -28,7 +28,7 @@ FROM :i:table rt
 JOIN tag t ON rt.tag = t.id
 JOIN tag_category tg ON t.tag_category = tg.id
 WHERE rt.:i:resource-col = :resource-id
-AND t.review_status = 'APPROVED';
+--~(when (not (nil? (:review_status params))) " AND t.review_status = :review_status::review_status")
 
 -- :name get-tags-from-resources :query :many
 -- :doc Get all the tags for all the resources

--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -352,7 +352,8 @@
       tags?
       (assoc :tags (db.resource.tag/get-resource-tags conn {:table (str resource-type "_tag")
                                                             :resource-col resource-type
-                                                            :resource-id id}))
+                                                            :resource-id id
+                                                            :review_status "APPROVED"}))
 
       entity-connections?
       (assoc :entity_connections (db.resource.connection/get-resource-entity-connections conn {:resource-id id

--- a/backend/src/gpml/handler/initiative.clj
+++ b/backend/src/gpml/handler/initiative.clj
@@ -154,7 +154,8 @@
                          :stakeholder_connections stakeholder-connections
                          :tags (db.resource.tag/get-resource-tags conn {:table "initiative_tag"
                                                                         :resource-col "initiative"
-                                                                        :resource-id id})
+                                                                        :resource-id id
+                                                                        :review_status "APPROVED"})
                          :related_content (expand-related-initiative-content conn id)
                          :type "Initiative"}]
       (resp/response (merge data extra-details)))))

--- a/backend/src/gpml/handler/stakeholder.clj
+++ b/backend/src/gpml/handler/stakeholder.clj
@@ -234,7 +234,8 @@
         (let [{page :page limit :limit} (:query parameters)
               tags (db.resource.tag/get-resource-tags (:spec db) {:table "stakeholder_tag"
                                                                   :resource-col "stakeholder"
-                                                                  :resource-id (:id stakeholder)})
+                                                                  :resource-id (:id stakeholder)
+                                                                  :review_status "APPROVED"})
               offerings-ids (->> tags
                                  (filter #(= (:tag_relation_category %) "offering"))
                                  (mapv #(get % :id)))

--- a/backend/src/gpml/handler/stakeholder/tag.clj
+++ b/backend/src/gpml/handler/stakeholder/tag.clj
@@ -76,14 +76,15 @@
     :or {update? false}}]
   (let [db-params {:table "stakeholder_tag"
                    :resource-col "stakeholder"
-                   :resource-id stakeholder-id}
+                   :resource-id stakeholder-id
+                   :review_status "APPROVED"}
         old-tags (db.resource.tag/get-resource-tags conn db-params)
         tags (tag-diff tags old-tags)]
     (when (seq tags)
       (let [categories (->> tags (group-by :tag_category) keys)
             grouped-tags (group-by :tag_category (add-tags-ids-for-categories conn tags categories))]
         (when update?
-          (db.resource.tag/delete-resource-tags conn db-params))
+          (db.resource.tag/delete-resource-tags conn (dissoc db-params :review_status)))
         (let [create-res-tags-results (mapv (fn [[tag-category tags]]
                                               (let [opts {:tags tags
                                                           :tag-category tag-category

--- a/backend/src/gpml/handler/submission.clj
+++ b/backend/src/gpml/handler/submission.clj
@@ -98,7 +98,8 @@
        item
        (let [tags (db.resource.tag/get-resource-tags conn {:table "stakeholder_tag"
                                                            :resource-col "stakeholder"
-                                                           :resource-id (:id item)})]
+                                                           :resource-id (:id item)
+                                                           :review_status "APPROVED"})]
          (merge item (handler.stakeholder.tag/unwrap-tags (assoc item :tags tags))))))
    submission-data))
 
@@ -218,7 +219,8 @@
         org (db.organisation/organisation-by-id conn {:id (:affiliation stakeholder)})
         tags (db.resource.tag/get-resource-tags conn {:table "stakeholder_tag"
                                                       :resource-col "stakeholder"
-                                                      :resource-id (:id stakeholder)})]
+                                                      :resource-id (:id stakeholder)
+                                                      :review_status "APPROVED"})]
     (cond-> stakeholder
       (seq org)
       (assoc :affiliation org)

--- a/backend/src/gpml/service/stakeholder.clj
+++ b/backend/src/gpml/service/stakeholder.clj
@@ -274,7 +274,8 @@
                            {:success? true
                             :tags (db.resource.tag/get-resource-tags conn {:table "stakeholder_tag"
                                                                            :resource-col "stakeholder"
-                                                                           :resource-id (:id stakeholder)})}
+                                                                           :resource-id (:id stakeholder)
+                                                                           :review_status "APPROVED"})}
                            (catch Throwable t
                              {:success? false
                               :error-details {:exception-message (ex-message t)}}))]
@@ -476,7 +477,8 @@
                             :tags (db.resource.tag/get-resource-tags conn
                                                                      {:table "stakeholder_tag"
                                                                       :resource-col "stakeholder"
-                                                                      :resource-id (:id stakeholder)})}
+                                                                      :resource-id (:id stakeholder)
+                                                                      :review_status "APPROVED"})}
                            (catch Throwable t
                              {:success? true
                               :error-details {:exception-message (ex-message t)}}))]

--- a/backend/test/gpml/handler/profile_test.clj
+++ b/backend/test/gpml/handler/profile_test.clj
@@ -300,7 +300,8 @@
                                                       :tags (map #(vector 10001 % "seeking") tags)})
           created-resource-tags (db.resource.tag/get-resource-tags db {:table "stakeholder_tag"
                                                                        :resource-col "stakeholder"
-                                                                       :resource-id sth-id})
+                                                                       :resource-id sth-id
+                                                                       :review_status "APPROVED"})
           geo (db.stakeholder/add-stakeholder-geo db {:geo [[10001 nil 1] [10001 nil 2]]})
           ;; dashboard check if this guy has profile
           req (handler (-> (mock/request :get "/")


### PR DESCRIPTION
[Re #1636]

As explained in the issue, we need to return all the tags related to the target organisation, for the endpoint mentioned above. Hence, we have removed the legacy DB query to use the generic one for the resource details get functionality. Obviously we no longer get tags grouped by category and we avoid the strange random get of the first group of tags, so we just return a collection with the ids of all the found tags.

In order to re-use the shared mentioned get resource tag's DB query, we have needed to modify it so we can optionally pass a filter to be used in the current places it was being used, so only approved tags were considered there, while we can use the query without filters for the use-case we are dealing with here.