### PR TITLE
1638 Fix emptying tags in resource/org edition

### DIFF
--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -726,7 +726,7 @@
         sth-associations (:individual_connections updates)]
     (doseq [[image-key image-data] (select-keys updates [:image :thumbnail])]
       (update-resource-image config conn table id image-key image-data))
-    (when (seq tags)
+    (when (contains? (set (keys updates)) :tags)
       (update-resource-tags conn logger mailjet-config table id tags))
     (when (seq related-contents)
       (handler.resource.related-content/update-related-contents conn logger id table related-contents))
@@ -780,7 +780,7 @@
       (update-resource-image config conn "initiative" id image-key image-data))
     (when (seq related-contents)
       (handler.resource.related-content/update-related-contents conn logger id "initiative" related-contents))
-    (when (seq tags)
+    (when (contains? (set (keys initiative)) :tags)
       (update-resource-tags conn logger mailjet-config "initiative" id tags))
     (handler.geo/update-resource-geo-coverage conn
                                               :initiative

--- a/backend/src/gpml/handler/organisation.clj
+++ b/backend/src/gpml/handler/organisation.clj
@@ -110,7 +110,7 @@
                                               {:countries geo_coverage_countries
                                                :country-groups geo_coverage_country_groups
                                                :country-states geo_coverage_country_states})
-    (when (seq (:tags org))
+    (when (contains? (set (keys org)) :tags)
       (handler.resource.tag/update-resource-tags conn logger mailjet-config {:tags (:tags org)
                                                                              :tag-category "general"
                                                                              :resource-name "organisation"

--- a/backend/src/gpml/handler/resource/tag.clj
+++ b/backend/src/gpml/handler/resource/tag.clj
@@ -70,9 +70,13 @@
              :error-details {:message (.getMessage e)}}))))))
 
 (defn update-resource-tags
-  "Updates existing relations between a resource `resource-name` and tags."
+  "Updates existing relations between a resource `resource-name` and tags.
+
+  If the tags relations are empty or nil we just remove all of them."
   [conn logger mailjet-config {:keys [resource-name resource-id] :as opts}]
   (db.resource.tag/delete-resource-tags conn {:table (str resource-name "_tag")
                                               :resource-col resource-name
                                               :resource-id resource-id})
-  (create-resource-tags conn logger mailjet-config opts))
+  (if (seq (:tags opts))
+    (create-resource-tags conn logger mailjet-config opts)
+    {:success? true}))


### PR DESCRIPTION
[Re #1638]

As described in the issue, now we check in the affected API endpoints whether we get the `tags` key at all in the payload, so we know if we need to remove all the tag relationships, add/remove some of them or we just ignore tags during the update (in case we do not receive such property at all).

We have needed to update the generic tag update code to allow this use-case.