### PR TITLE
1611 plastic strategy files management

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -709,7 +709,27 @@
                                                                  #ig/ref :gpml.auth/auth-required]
                                                     :swagger {:tags ["plastic-strategy"] :security [{:id_token []}]}
                                                     :handler #ig/ref :gpml.handler.plastic-strategy.bookmark/post
-                                                    :parameters #ig/ref :gpml.handler.plastic-strategy.bookmark/post-params}}]]]]]]
+                                                    :parameters #ig/ref :gpml.handler.plastic-strategy.bookmark/post-params}}]]
+                                          ["/file"
+                                           [""
+                                            {:post {:summary "Uploads and creates a plastic strategy file "
+                                                    :middleware [#ig/ref :gpml.auth/auth-middleware
+                                                                 #ig/ref :gpml.auth/auth-required]
+                                                    :swagger {:tags ["plastic-strategy"] :security [{:id_token []}]}
+                                                    :handler #ig/ref :gpml.handler.plastic-strategy.file/post
+                                                    :parameters #ig/ref :gpml.handler.plastic-strategy.file/post-params}
+                                             :delete {:summary "Deletes a plastic strategy file "
+                                                      :middleware [#ig/ref :gpml.auth/auth-middleware
+                                                                   #ig/ref :gpml.auth/auth-required]
+                                                      :swagger {:tags ["plastic-strategy"] :security [{:id_token []}]}
+                                                      :handler #ig/ref :gpml.handler.plastic-strategy.file/delete
+                                                      :parameters #ig/ref :gpml.handler.plastic-strategy.file/delete-params}
+                                             :get {:summary "Gets a plastic strategy files"
+                                                   :middleware [#ig/ref :gpml.auth/auth-middleware
+                                                                #ig/ref :gpml.auth/auth-required]
+                                                   :swagger {:tags ["plastic-strategy"] :security [{:id_token []}]}
+                                                   :handler #ig/ref :gpml.handler.plastic-strategy.file/get
+                                                   :parameters #ig/ref :gpml.handler.plastic-strategy.file/get-params}}]]]]]]
                               :logger #ig/ref :duct.logger/timbre
                               :cors-allowed-origins #ig/ref :gpml.handler.main/cors-allowed-origins}
 
@@ -1000,6 +1020,12 @@
   :gpml.handler.plastic-strategy.bookmark/post-params {}
   :gpml.handler.plastic-strategy.team/delete-member #ig/ref :gpml.config/common
   :gpml.handler.plastic-strategy.team/delete-member-params {}
+  :gpml.handler.plastic-strategy.file/post #ig/ref :gpml.config/common
+  :gpml.handler.plastic-strategy.file/post-params {}
+  :gpml.handler.plastic-strategy.file/delete #ig/ref :gpml.config/common
+  :gpml.handler.plastic-strategy.file/delete-params {}
+  :gpml.handler.plastic-strategy.file/get #ig/ref :gpml.config/common
+  :gpml.handler.plastic-strategy.file/get-params {}
 
   :gpml.handler.programmatic.plastic-strategy/post #ig/ref :gpml.config/common
   :gpml.handler.programmatic.plastic-strategy/post-params {}

--- a/backend/resources/migrations/198-setup-plastic-strategy-files-model.up.sql
+++ b/backend/resources/migrations/198-setup-plastic-strategy-files-model.up.sql
@@ -1,0 +1,64 @@
+BEGIN;
+--;;
+CREATE TABLE plastic_strategy_file (
+    plastic_strategy_id INTEGER NOT NULL REFERENCES plastic_strategy (id),
+    file_id UUID NOT NULL REFERENCES file (id),
+    section_key TEXT NOT NULL,
+    CONSTRAINT plastic_strategy_file_pkey PRIMARY KEY (plastic_strategy_id, file_id, section_key)
+);
+--;;
+INSERT INTO rbac_permission (
+    id,
+    name,
+    description,
+    context_type_name)
+VALUES (
+    'c61a269f-68fc-4386-b354-a66b9b921650',
+    'plastic-strategy/create-file',
+    'Allows creating a plastic strategy file',
+    'plastic-strategy'),
+(
+    'bd5c06a0-43a9-4708-b744-8798024b8ad4',
+    'plastic-strategy/delete-file',
+    'Allows deleting a plastic strategy file',
+    'plastic-strategy'),
+(
+    '49f91a23-d338-40e6-8cdd-e89065bce617',
+    'plastic-strategy/list-files',
+    'Allows listing a plastic strategy files',
+    'plastic-strategy');
+--;;
+INSERT INTO rbac_role_permission (
+    role_id,
+    permission_id,
+    permission_value)
+VALUES (
+    '5422d5a9-89b4-494d-97a1-894657047803',
+    'c61a269f-68fc-4386-b354-a66b9b921650',
+    1),
+(
+    '5422d5a9-89b4-494d-97a1-894657047803',
+    'bd5c06a0-43a9-4708-b744-8798024b8ad4',
+    1),
+(
+    '5422d5a9-89b4-494d-97a1-894657047803',
+    '49f91a23-d338-40e6-8cdd-e89065bce617',
+    1),
+(
+    '982889c1-368c-489c-b8f4-234802e0781d',
+    'c61a269f-68fc-4386-b354-a66b9b921650',
+    1),
+(
+    '982889c1-368c-489c-b8f4-234802e0781d',
+    'bd5c06a0-43a9-4708-b744-8798024b8ad4',
+    1),
+(
+    '982889c1-368c-489c-b8f4-234802e0781d',
+    '49f91a23-d338-40e6-8cdd-e89065bce617',
+    1),
+(
+    '4c953c83-bc6e-41a0-bde7-d25a6a938a3c',
+    '49f91a23-d338-40e6-8cdd-e89065bce617',
+    1);
+--;;
+COMMIT;

--- a/backend/src/gpml/db/plastic_strategy/file.clj
+++ b/backend/src/gpml/db/plastic_strategy/file.clj
@@ -1,0 +1,70 @@
+(ns gpml.db.plastic-strategy.file
+  {:ns-tracker/resource-deps ["plastic_strategy/file.sql"]}
+  (:require [gpml.db.jdbc-util :as jdbc-util]
+            [gpml.util :as util]
+            [gpml.util.postgresql :as util.pgsql]
+            [hugsql.core :as hugsql]))
+
+(declare create-ps-file*
+         delete-ps-file*
+         get-ps-files*)
+
+(hugsql/def-db-fns "gpml/db/plastic_strategy/file.sql" {:quoting :ansi})
+
+(defn p-ps-file->ps-file
+  [p-ps-file]
+  (util/update-if-not-nil p-ps-file :visibility keyword))
+
+(defn create-ps-file
+  [conn ps-file]
+  (jdbc-util/with-constraint-violation-check
+    [{:type :unique
+      :name "plastic_strategy_file_pkey"
+      :error-reason :already-exists}]
+    (create-ps-file* conn ps-file)
+    {:success? true}))
+
+(defn delete-ps-file
+  [conn ps-file]
+  (try
+    (let [affected (delete-ps-file* conn ps-file)]
+      (if (= affected 1)
+        {:success? true}
+        {:success? false
+         :reason :unexpected-number-of-affected-rows
+         :error-details {:expected-affected-rows 1
+                         :actual-affected-rows affected}}))
+    (catch Throwable t
+      {:success? false
+       :reason :exception
+       :error-details {:msg (ex-message t)}})))
+
+(defn get-ps-files
+  [conn opts]
+  (try
+    (let [p-opts (update opts :filters #(util/update-if-not-nil % :files-ids util.pgsql/->JDBCArray "uuid"))]
+      {:success? true
+       :ps-files (->> (get-ps-files* conn p-opts)
+                      jdbc-util/db-result-snake-kw->db-result-kebab-kw
+                      (map p-ps-file->ps-file))})
+    (catch Throwable t
+      (prn t)
+      {:success? false
+       :reason :exception
+       :error-details {:msg (ex-message t)}})))
+
+(defn get-ps-file
+  [conn opts]
+  (try
+    (let [result (get-ps-files conn opts)]
+      (if-not (:success? result)
+        result
+        (if (= (count (:ps-files result)) 1)
+          {:success? true
+           :ps-file (-> result :ps-files first)}
+          {:success? false
+           :reason :not-found})))
+    (catch Throwable t
+      {:success? false
+       :reason :exception
+       :error-details {:msg (ex-message t)}})))

--- a/backend/src/gpml/db/plastic_strategy/file.sql
+++ b/backend/src/gpml/db/plastic_strategy/file.sql
@@ -1,0 +1,19 @@
+-- :name create-ps-file* :execute :affected
+INSERT INTO plastic_strategy_file(plastic_strategy_id, file_id, section_key)
+VALUES(:plastic-strategy-id, :file-id, :section-key);
+
+-- :name delete-ps-file* :execute :affected
+DELETE FROM plastic_strategy_file
+WHERE plastic_strategy_id = :plastic-strategy-id
+      AND file_id = :file-id
+      AND section_key = :section-key;
+
+-- :name get-ps-files* :query :many
+SELECT psf.plastic_strategy_id, psf.section_key, f.*
+FROM plastic_strategy_file psf
+JOIN file f ON psf.file_id = f.id
+WHERE 1=1
+--~(when (seq (get-in params [:filters :plastic-strategies-ids])) " AND psf.plastic_strategy_id IN (:v*:filters.plastic-strategies-ids)")
+--~(when (seq (get-in params [:filters :files-ids])) " AND psf.file_id IN (:v*:filters.files-ids)")
+--~(when (seq (get-in params [:filters :sections-keys])) " AND psf.section_key IN (:v*:filters.sections-keys)")
+;

--- a/backend/src/gpml/handler/plastic_strategy/file.clj
+++ b/backend/src/gpml/handler/plastic_strategy/file.clj
@@ -1,0 +1,151 @@
+(ns gpml.handler.plastic-strategy.file
+  (:require [camel-snake-kebab.core :refer [->kebab-case ->snake_case]]
+            [camel-snake-kebab.extras :as cske]
+            [clojure.string :as str]
+            [gpml.handler.resource.permission :as h.r.permission]
+            [gpml.handler.responses :as r]
+            [gpml.service.plastic-strategy :as srv.ps]
+            [gpml.service.plastic-strategy.file :as srv.ps.file]
+            [gpml.util :as util]
+            [integrant.core :as ig]
+            [malli.util :as mu]))
+
+(def ^:private common-ps-file-path-params-schema
+  [:map
+   [:iso_code_a2
+    {:swagger {:description "The country ISO Code Alpha 2."
+               :type "string"}}
+    [:string {:decode/string str/upper-case
+              :max 2}]]])
+
+(def ^:private create-ps-file-body-params-schema
+  [:map
+   [:section_key
+    {:swagger {:description "The plastic strategy section identifier where the file is uploaded."
+               :type "string"
+               :allowEmptyValue false}}
+    [:string {:min 1}]]
+   [:content
+    {:swagger {:description "The file content in base64 string format."
+               :type "string"
+               :format "byte"}}
+    [:fn (comp util/base64? util/base64-headless)]]])
+
+(def ^:private delete-ps-file-body-params-schema
+  (mu/union
+   (mu/select-keys create-ps-file-body-params-schema [:section_key])
+   [:map
+    [:file_id
+     {:swagger {:description "The file identifier."
+                :type "string"
+                :format "uuid"}}
+     [:uuid]]]))
+
+(def ^:private get-ps-files-query-params-schema
+  (mu/optional-keys (mu/select-keys create-ps-file-body-params-schema [:section_key])))
+
+(defn- create-ps-file
+  [config {:keys [user] {:keys [path body]} :parameters :as _req}]
+  (let [country-iso-code-a2 (:iso_code_a2 path)
+        search-opts {:filters {:countries-iso-codes-a2 [country-iso-code-a2]}}
+        {:keys [success? plastic-strategy reason] :as get-ps-result}
+        (srv.ps/get-plastic-strategy config search-opts)]
+    (if-not success?
+      (if (= reason :not-found)
+        (r/not-found {})
+        (r/server-error (dissoc get-ps-result :success?)))
+      (if-not (h.r.permission/operation-allowed? config
+                                                 {:user-id (:id user)
+                                                  :entity-type :plastic-strategy
+                                                  :entity-id (:id plastic-strategy)
+                                                  :custom-permission :create-file
+                                                  :root-context? false})
+        (r/forbidden {:message "Unauthorized"})
+        (let [body-params (-> (cske/transform-keys ->kebab-case body)
+                              (assoc :plastic-strategy-id (:id plastic-strategy)))
+              result (srv.ps.file/create-ps-file config
+                                                 body-params)]
+          (if (:success? result)
+            (r/ok {})
+            (r/server-error (dissoc result :success?))))))))
+
+(defn- delete-ps-file
+  [config {:keys [user] {:keys [path body]} :parameters :as _req}]
+  (let [country-iso-code-a2 (:iso_code_a2 path)
+        search-opts {:filters {:countries-iso-codes-a2 [country-iso-code-a2]}}
+        {:keys [success? plastic-strategy reason] :as get-ps-result}
+        (srv.ps/get-plastic-strategy config search-opts)]
+    (if-not success?
+      (if (= reason :not-found)
+        (r/not-found {})
+        (r/server-error (dissoc get-ps-result :success?)))
+      (if-not (h.r.permission/operation-allowed? config
+                                                 {:user-id (:id user)
+                                                  :entity-type :plastic-strategy
+                                                  :entity-id (:id plastic-strategy)
+                                                  :custom-permission :delete-file
+                                                  :root-context? false})
+        (r/forbidden {:message "Unauthorized"})
+        (let [body-params (-> (cske/transform-keys ->kebab-case body)
+                              (assoc :plastic-strategy-id (:id plastic-strategy)))
+              result (srv.ps.file/delete-ps-file config
+                                                 body-params)]
+          (if (:success? result)
+            (r/ok {})
+            (r/server-error (dissoc result :success?))))))))
+
+(defn- get-ps-files
+  [config {:keys [user] {:keys [path body]} :parameters :as _req}]
+  (let [country-iso-code-a2 (:iso_code_a2 path)
+        search-opts {:filters {:countries-iso-codes-a2 [country-iso-code-a2]}}
+        {:keys [success? plastic-strategy reason] :as get-ps-result}
+        (srv.ps/get-plastic-strategy config search-opts)]
+    (if-not success?
+      (if (= reason :not-found)
+        (r/not-found {})
+        (r/server-error (dissoc get-ps-result :success?)))
+      (if-not (h.r.permission/operation-allowed? config
+                                                 {:user-id (:id user)
+                                                  :entity-type :plastic-strategy
+                                                  :entity-id (:id plastic-strategy)
+                                                  :custom-permission :delete-file
+                                                  :root-context? false})
+        (r/forbidden {:message "Unauthorized"})
+        (let [search-opts {:filters (cond-> {:plastic-strategies-ids [(:id plastic-strategy)]}
+                                      (:section_key body)
+                                      (assoc :sections-keys [(:section_key body)]))}
+              result (srv.ps.file/get-ps-files config
+                                               search-opts)]
+          (if (:success? result)
+            (r/ok (cske/transform-keys ->snake_case (:ps-files result)))
+            (r/server-error (dissoc result :success?))))))))
+
+(defmethod ig/init-key :gpml.handler.plastic-strategy.file/post
+  [_ config]
+  (fn [req]
+    (create-ps-file config req)))
+
+(defmethod ig/init-key :gpml.handler.plastic-strategy.file/post-params
+  [_ _]
+  {:path common-ps-file-path-params-schema
+   :body create-ps-file-body-params-schema})
+
+(defmethod ig/init-key :gpml.handler.plastic-strategy.file/delete
+  [_ config]
+  (fn [req]
+    (delete-ps-file config req)))
+
+(defmethod ig/init-key :gpml.handler.plastic-strategy.file/delete-params
+  [_ _]
+  {:path common-ps-file-path-params-schema
+   :body delete-ps-file-body-params-schema})
+
+(defmethod ig/init-key :gpml.handler.plastic-strategy.file/get
+  [_ config]
+  (fn [req]
+    (get-ps-files config req)))
+
+(defmethod ig/init-key :gpml.handler.plastic-strategy.file/get-params
+  [_ _]
+  {:path common-ps-file-path-params-schema
+   :query get-ps-files-query-params-schema})

--- a/backend/src/gpml/service/plastic_strategy/file.clj
+++ b/backend/src/gpml/service/plastic_strategy/file.clj
@@ -1,0 +1,88 @@
+(ns gpml.service.plastic-strategy.file
+  (:require [duct.logger :refer [log]]
+            [gpml.db.plastic-strategy.file :as db.ps.file]
+            [gpml.domain.file :as dom.file]
+            [gpml.service.file :as srv.file]
+            [gpml.util.thread-transactions :as tht]))
+
+(defn create-ps-file
+  [{:keys [db logger] :as config} ps-file]
+  (let [transactions
+        [{:txn-fn
+          (fn tx-upload-ps-file-to-obj-storage
+            [{{:keys [content]} :ps-file :as context}]
+            (let [file (dom.file/base64->file content :plastic-strategy :docs :private)
+                  result (srv.file/create-file config (:spec db) file)]
+              (if (:success? result)
+                (assoc-in context [:ps-file :file-id] (:id file))
+                (assoc context
+                       :success? false
+                       :reason :failed-to-upload-ps-file
+                       :error-details {:result result}))))
+          :rollback-fn
+          (fn rollback-upload-ps-file
+            [{{:keys [id]} :ps-file :as context}]
+            (let [result (srv.file/delete-file config (:spec db)
+                                               {:filters {:id id}})]
+              (when-not (:success? result)
+                (log logger :error ::failed-to-rollback-upload-ps-file {:result result})))
+            (dissoc context :ps-file))}
+         {:txn-fn
+          (fn tx-create-ps-file
+            [{:keys [ps-file] :as context}]
+            (let [result (db.ps.file/create-ps-file (:spec db)
+                                                    (dissoc ps-file :content))]
+              (if (:success? result)
+                context
+                (assoc context
+                       :success? false
+                       :reason :failed-to-create-ps-file
+                       :error-details {:result result}))))}]
+        context {:success? true
+                 :ps-file ps-file}]
+    (tht/thread-transactions logger transactions context)))
+
+(defn delete-ps-file
+  [{:keys [db logger] :as config} ps-file]
+  (let [transactions
+        [{:txn-fn
+          (fn tx-delete-ps-file
+            [{:keys [ps-file] :as context}]
+            (let [result (db.ps.file/delete-ps-file (:spec db) ps-file)]
+              (if (:success? result)
+                context
+                (assoc context
+                       :success? false
+                       :reason :failed-to-delete-ps-file
+                       :error-details {:result result}))))
+          :rollback-fn
+          (fn rollback-delete-ps-file
+            [{:keys [ps-file] :as context}]
+            (let [result (db.ps.file/create-ps-file (:spec db)
+                                                    ps-file)]
+              (when-not (:success? result)
+                (log logger :error ::failed-to-rollback-delete-ps-file {:result result})))
+            context)}
+         {:txn-fn
+          (fn tx-delete-ps-file-from-obj-storage
+            [{:keys [ps-file] :as context}]
+            (let [result (srv.file/delete-file config
+                                               (:spec db)
+                                               {:id (:file-id ps-file)})]
+              (if (:success? result)
+                context
+                (assoc context
+                       :success? false
+                       :reason :failed-to-delete-ps-file-from-obj-storage
+                       :error-details {:result result}))))}]
+        context {:success? true
+                 :ps-file ps-file}]
+    (tht/thread-transactions logger transactions context)))
+
+(defn get-ps-files
+  [{:keys [db] :as config} opts]
+  (let [result (db.ps.file/get-ps-files (:spec db) opts)]
+    (if-not (:success? result)
+      result
+      {:success? true
+       :ps-files (srv.file/add-files-urls config (:ps-files result))})))


### PR DESCRIPTION
* Plastic strategy files are organized per section. So we store a
"section_key" metadata so the FE knows exactly where the file belongs
to.
* As per internal decision the BE will not limit the amount of files
per section key. Therefore, each section can have as many files as necessary.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205545816718928