### PR TITLE
1611 add section keys to ps bookmark

### DIFF
--- a/backend/resources/migrations/199-add-section-key-to-ps-bookmark.up.sql
+++ b/backend/resources/migrations/199-add-section-key-to-ps-bookmark.up.sql
@@ -1,0 +1,38 @@
+BEGIN;
+--;;
+ALTER TABLE plastic_strategy_initiative_bookmark
+    ADD COLUMN section_key TEXT NOT NULL,
+    DROP CONSTRAINT plastic_strategy_initiative_bookmark_pkey,
+    ADD CONSTRAINT plastic_strategy_initiative_bookmark_pkey PRIMARY KEY (plastic_strategy_id, initiative_id, section_key);
+--;;
+ALTER TABLE plastic_strategy_case_study_bookmark
+    ADD COLUMN section_key TEXT NOT NULL,
+    DROP CONSTRAINT plastic_strategy_case_study_bookmark_pkey,
+    ADD CONSTRAINT plastic_strategy_case_study_bookmark_pkey PRIMARY KEY (plastic_strategy_id, case_study_id, section_key);
+--;;
+ALTER TABLE plastic_strategy_technology_bookmark
+    ADD COLUMN section_key TEXT NOT NULL,
+    DROP CONSTRAINT plastic_strategy_technology_bookmark_pkey,
+    ADD CONSTRAINT plastic_strategy_technology_bookmark_pkey PRIMARY KEY (plastic_strategy_id, technology_id, section_key);
+--;;
+ALTER TABLE plastic_strategy_policy_bookmark
+    ADD COLUMN section_key TEXT NOT NULL,
+    DROP CONSTRAINT plastic_strategy_policy_bookmark_pkey,
+    ADD CONSTRAINT plastic_strategy_policy_bookmark_pkey PRIMARY KEY (plastic_strategy_id, policy_id, section_key);
+--;;
+ALTER TABLE plastic_strategy_event_bookmark
+    ADD COLUMN section_key TEXT NOT NULL,
+    DROP CONSTRAINT plastic_strategy_event_bookmark_pkey,
+    ADD CONSTRAINT plastic_strategy_event_bookmark_pkey PRIMARY KEY (plastic_strategy_id, event_id, section_key);
+--;;
+ALTER TABLE plastic_strategy_resource_bookmark
+    ADD COLUMN section_key TEXT NOT NULL,
+    DROP CONSTRAINT plastic_strategy_resource_bookmark_pkey,
+    ADD CONSTRAINT plastic_strategy_resource_bookmark_pkey PRIMARY KEY (plastic_strategy_id, resource_id, section_key);
+--;;
+ALTER TABLE plastic_strategy_organisation_bookmark
+    ADD COLUMN section_key TEXT NOT NULL,
+    DROP CONSTRAINT plastic_strategy_organisation_bookmark_pkey,
+    ADD CONSTRAINT plastic_strategy_organisation_bookmark_pkey PRIMARY KEY (plastic_strategy_id, organisation_id, section_key);
+--;;
+COMMIT;

--- a/backend/src/gpml/db/plastic_strategy/bookmark.sql
+++ b/backend/src/gpml/db/plastic_strategy/bookmark.sql
@@ -1,8 +1,9 @@
 -- :name create-ps-bookmark* :execute :affected
-INSERT INTO :i:ps-bookmark-table(plastic_strategy_id, :i:ps-bookmark-entity-col)
-VALUES (:ps-id, :ps-bookmark-entity-id);
+INSERT INTO :i:ps-bookmark-table(plastic_strategy_id, :i:ps-bookmark-entity-col, section_key)
+VALUES (:ps-id, :ps-bookmark-entity-id, :section-key);
 
 -- :name delete-ps-bookmark* :execute :affected
 DELETE FROM :i:ps-bookmark-table
 WHERE plastic_strategy_id = :ps-id
-      AND :i:ps-bookmark-entity-col = :ps-bookmark-entity-id;
+      AND :i:ps-bookmark-entity-col = :ps-bookmark-entity-id
+      AND section_key = :section-key;

--- a/backend/src/gpml/handler/browse.clj
+++ b/backend/src/gpml/handler/browse.clj
@@ -187,14 +187,25 @@ This filter requires the 'ps_country_iso_code_a2' to be set."
       [:string {:min 1}]]]]
    [:fn
     {:error/fn
-     (fn [_ _]
-       "Upcoming parameter is only supported for the 'event' topic.")}
-    (fn [{:keys [upcoming topic]}]
-      (if-not (true? upcoming)
-        true
+     (fn [{{:keys [ps_bookmark_sections_keys ps_country_iso_code_a2 upcoming topic]} :value} _]
+       (cond
+         (and ps_bookmark_sections_keys (not ps_country_iso_code_a2))
+         "The 'ps_country_iso_code_a2' parameter is required when using 'ps_bookmark_sections_keys'."
+
+         (not (and upcoming
+                   (= (count topic) 1)
+                   (= (first topic) "event")))
+         "Upcoming parameter is only supported for the 'event' topic."))}
+    (fn [{:keys [upcoming topic ps_country_iso_code_a2 ps_bookmark_sections_keys]}]
+      (and
+       (or
+        (not upcoming)
         (and upcoming
              (= (count topic) 1)
-             (= (first topic) "event"))))]])
+             (= (first topic) "event")))
+       (or
+        (not ps_bookmark_sections_keys)
+        (and ps_bookmark_sections_keys ps_country_iso_code_a2))))]])
 
 (defn api-filters->filters
   "Transforms API query parameters into a map of database filters."

--- a/backend/src/gpml/handler/browse.clj
+++ b/backend/src/gpml/handler/browse.clj
@@ -175,7 +175,16 @@
      [:string
       {:decode/string str/upper-case
        :max 2
-       :min 2}]]]
+       :min 2}]]
+    [:ps_bookmark_sections_keys
+     {:optional true
+      :swagger {:description "The plastic strategy bookmark sections keys to filter by bookmark sections.
+This filter requires the 'ps_country_iso_code_a2' to be set."
+                :type "string"
+                :allowEmptyValue false}}
+     [:vector
+      {:decode/string (fn [s] (str/split s #","))}
+      [:string {:min 1}]]]]
    [:fn
     {:error/fn
      (fn [_ _]
@@ -191,7 +200,8 @@
   "Transforms API query parameters into a map of database filters."
   [{:keys [limit offset startDate endDate user-id favorites country transnational
            topic tag affiliation representativeGroup subContentType entity orderBy
-           descending q incCountsForTags featured capacity_building upcoming ps_country_iso_code_a2]
+           descending q incCountsForTags featured capacity_building upcoming
+           ps_country_iso_code_a2 ps_bookmark_sections_keys]
     :or {limit default-limit
          offset default-offset}}]
   (cond-> {}
@@ -257,6 +267,9 @@
 
     ps_country_iso_code_a2
     (assoc :ps-country-iso-code-a2 ps_country_iso_code_a2)
+
+    ps_bookmark_sections_keys
+    (assoc :ps-bookmark-sections-keys ps_bookmark_sections_keys)
 
     true
     (assoc :review-status "APPROVED")))

--- a/backend/src/gpml/handler/plastic_strategy/bookmark.clj
+++ b/backend/src/gpml/handler/plastic_strategy/bookmark.clj
@@ -31,7 +31,12 @@
     {:swagger {:description "The entity type to un/bookmark."
                :type "string"
                :enum (map name dom.types/plastic-strategy-bookmarkable-entity-types)}}
-    (dom.types/get-type-schema :plastic-strategy-bookmarkable-entity-type)]])
+    (dom.types/get-type-schema :plastic-strategy-bookmarkable-entity-type)]
+   [:section_key
+    {:swagger {:description "The section key where the bookmark belongs to."
+               :type "string"
+               :allowEmptyValue false}}
+    [:string {:min 1}]]])
 
 (defn- handle-ps-bookmark
   [config {:keys [user parameters]}]

--- a/backend/src/gpml/service/plastic_strategy/bookmark.clj
+++ b/backend/src/gpml/service/plastic_strategy/bookmark.clj
@@ -2,15 +2,14 @@
   (:require [gpml.db.plastic-strategy.bookmark :as db.ps.bookmark]))
 
 (defn handle-ps-bookmark
-  [{:keys [db]} {:keys [bookmark entity-type entity-id plastic-strategy-id]}]
+  [{:keys [db]} {:keys [bookmark entity-type entity-id plastic-strategy-id section-key]}]
   (let [ps-bookmark-table (keyword (format "plastic_strategy_%s_bookmark" (name entity-type)))
-        ps-bookmark-entity-col (keyword (format "%s_id" (name entity-type)))]
+        ps-bookmark-entity-col (keyword (format "%s_id" (name entity-type)))
+        ps-bookmark {:ps-bookmark-table ps-bookmark-table
+                     :ps-bookmark-entity-col ps-bookmark-entity-col
+                     :ps-id plastic-strategy-id
+                     :ps-bookmark-entity-id entity-id
+                     :section-key section-key}]
     (if bookmark
-      (db.ps.bookmark/create-ps-bookmark (:spec db) {:ps-bookmark-table ps-bookmark-table
-                                                     :ps-bookmark-entity-col ps-bookmark-entity-col
-                                                     :ps-id plastic-strategy-id
-                                                     :ps-bookmark-entity-id entity-id})
-      (db.ps.bookmark/delete-ps-bookmark (:spec db) {:ps-bookmark-table ps-bookmark-table
-                                                     :ps-bookmark-entity-col ps-bookmark-entity-col
-                                                     :ps-id plastic-strategy-id
-                                                     :ps-bookmark-entity-id entity-id}))))
+      (db.ps.bookmark/create-ps-bookmark (:spec db) ps-bookmark)
+      (db.ps.bookmark/delete-ps-bookmark (:spec db) ps-bookmark))))


### PR DESCRIPTION
* Bookmarks are organized by sections not globally just by plastic
strategy. A resource can be bookmark in multiple sections of a plastic
strategy.
* Initially the "section_key" is of text type as per internal decision
of making PS sections content opaque for the BE. So transforming it
into an enum would contradict that decision.