### PR TITLE
1611 Add new endpoint for GET Organisations in Stakeholder Map step in Plastic Strategy Workflow

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -330,6 +330,13 @@
                                                   :swagger {:tags ["organisation detail"]}
                                                   :parameters #ig/ref :gpml.handler.organisation-detail/get-content-params
                                                   :handler #ig/ref :gpml.handler.organisation-detail/get-content}}]]]
+                                        ["/organisations"
+                                         [""
+                                          {:get {:summary "List all organisations with advanced filtering/sorting.
+                                                           The list of properties are limited to the Plastic Strategy feature needs"
+                                                 :swagger {:tags ["organisation" "plastic-strategy"]}
+                                                 :parameters {:query #ig/ref :gpml.handler.organisation/list-params}
+                                                 :handler #ig/ref :gpml.handler.organisation/list}}]]
                                         ["/favorite" {:middleware [#ig/ref :gpml.auth/auth-middleware
                                                                    #ig/ref :gpml.auth/auth-required]}
                                          [""
@@ -867,6 +874,8 @@
 
   :gpml.handler.non-member-organisation/get #ig/ref :gpml.config/common
   :gpml.handler.organisation/get #ig/ref :gpml.config/common
+  :gpml.handler.organisation/list #ig/ref :gpml.config/common
+  :gpml.handler.organisation/list-params {}
   :gpml.handler.organisation/post #ig/ref :gpml.config/common
   :gpml.handler.organisation/put #ig/ref :gpml.config/common
   :gpml.handler.organisation/post-params {}

--- a/backend/src/gpml/db/organisation.clj
+++ b/backend/src/gpml/db/organisation.clj
@@ -13,7 +13,8 @@
          all-members
          geo-coverage-v2
          get-organisation-files-to-migrate
-         get-organisations)
+         get-organisations
+         list-organisations)
 
 (hugsql/def-db-fns "gpml/db/organisation.sql" {:quoting :ansi})
 
@@ -24,3 +25,50 @@
   (-> resource
       (util/update-if-not-nil :geo_coverage_type sql-util/keyword->pg-enum "geo_coverage_type")
       (util/update-if-not-nil :review_status sql-util/keyword->pg-enum "review_status")))
+
+(defn list-organisations-query-and-filters
+  [params]
+  (let [{:keys [count-only? limit page order-by descending]} params
+        order-by (when order-by
+                   (format "ORDER BY %s %s" order-by (if descending
+                                                       "DESC"
+                                                       "ASC")))
+        pagination (when (and (not count-only?)
+                              limit
+                              page)
+                     (format "LIMIT %d OFFSET %d" limit (* limit page)))]
+    (if count-only?
+      "SELECT count(*) FROM organisations_cte cte_orgs;"
+      (format "SELECT cte_orgs.*
+               FROM organisations_cte cte_orgs
+               %s
+               %s;"
+              (or order-by "")
+              (or pagination "")))))
+
+(defn list-organisations-cto-query-filter-and-params
+  [params]
+  (let [{:keys [filters]} params
+        {:keys [geo-coverage-types types review-status tags]} filters
+        where-cond (cond-> "WHERE 1=1"
+                     (seq review-status)
+                     (str " AND o.review_status = :filters.review-status::REVIEW_STATUS")
+
+                     (contains? (set (keys filters)) :is-member)
+                     (str " AND o.is_member = :filters.is-member")
+
+                     (seq geo-coverage-types)
+                     (str " AND o.geo_coverage_type = ANY(ARRAY[:v*:filters.geo-coverage-types]::GEO_COVERAGE_TYPE[])")
+
+                     (seq (:name filters))
+                     (str " AND o.name ILIKE '%' || :filters.name || '%'")
+
+                     (seq types)
+                     (str " AND o.type IN (:v*:filters.types)"))
+        having (when (seq tags)
+                 "HAVING array_agg(t.tag) FILTER (WHERE t.id IS NOT NULL) && ARRAY[:v*:filters.tags]::text[]")]
+    (format "%s
+             GROUP BY o.id
+             %s"
+            where-cond
+            (or having ""))))

--- a/backend/src/gpml/handler/organisation.clj
+++ b/backend/src/gpml/handler/organisation.clj
@@ -1,10 +1,12 @@
 (ns gpml.handler.organisation
   (:require [clojure.java.jdbc :as jdbc]
+            [clojure.string :as str]
             [duct.logger :refer [log]]
             [gpml.db.organisation :as db.organisation]
             [gpml.db.resource.tag :as db.resource.tag]
             [gpml.db.stakeholder :as db.stakeholder]
             [gpml.domain.organisation :as dom.organisation]
+            [gpml.domain.types :as dom.types]
             [gpml.handler.file :as handler.file]
             [gpml.handler.resource.geo-coverage :as handler.geo]
             [gpml.handler.resource.permission :as h.r.permission]
@@ -289,3 +291,129 @@
    :body (-> dom.organisation/Organisation
              (util.malli/dissoc
               [:id :is_member :created :modified :reviewed_at :reviewed_by :review_status]))})
+(def ^:const ^:private default-list-api-limit 50)
+(def ^:const ^:private default-list-api-page 0)
+(defn- list-api-params->opts
+  [{:keys [geo_coverage_types is_member types tags limit page order_by descending]
+    :or {limit default-list-api-limit
+         page default-list-api-page}
+    :as api-params}]
+  (cond-> {}
+    page
+    (assoc :page page)
+
+    limit
+    (assoc :limit limit)
+
+    (seq geo_coverage_types)
+    (assoc-in [:filters :geo-coverage-types] (->> geo_coverage_types
+                                                  (mapv str/lower-case)))
+
+    (seq types)
+    (assoc-in [:filters :types] types)
+
+    (seq tags)
+    (assoc-in [:filters :tags] tags)
+
+    (not (nil? is_member))
+    (assoc-in [:filters :is-member] is_member)
+
+    (seq order_by)
+    (assoc :order-by order_by)
+
+    (not (nil? descending))
+    (assoc :descending descending)
+
+    (seq (:name api-params))
+    (assoc-in [:filters :name] (:name api-params))))
+(defmethod ig/init-key :gpml.handler.organisation/list
+  [_ {:keys [db logger]}]
+  (fn [req]
+    (try
+      (let [conn (:spec db)
+            query-params (get-in req [:parameters :query])
+            opts (-> (list-api-params->opts query-params)
+                     (assoc-in [:filters :review-status] "APPROVED"))
+            results (db.organisation/list-organisations conn opts)]
+        (r/ok {:success? true
+               :results results
+               :counts (db.organisation/list-organisations conn (assoc opts :count-only? true))}))
+      (catch Throwable t
+        (let [log-data {:exception-message (ex-message t)
+                        :exception-data (ex-data t)
+                        :context-data (get-in req [:parameters :query])}]
+          (log logger :error :failed-to-list-organisations log-data)
+          (log logger :debug :failed-to-list-organisations (assoc log-data :stack-trace (.getStackTrace t)))
+          (r/server-error {:success? false
+                           :reason :failed-to-list-organisations
+                           :error-details {:msg (:exception-message log-data)}}))))))
+
+(def ^:const order-by-fields
+  #{"name"
+    "type"
+    "geo_coverage_type"})
+
+(defmethod ig/init-key :gpml.handler.organisation/list-params [_ _]
+  [:map
+   [:geo_coverage_types
+    {:optional true
+     :swagger {:description (format "List of geo coverage types to filter: %s"
+                                    (str/join "," dom.types/geo-coverage-types))
+               :type "string"
+               :allowEmptyValue true}}
+    [:vector
+     {:decode/string (fn [x] (if (string? x) [x] x))}
+     (apply conj [:enum] dom.types/geo-coverage-types)]]
+   [:is_member {:optional true
+                :swagger {:description "Filter member/non-member organisations"
+                          :type "boolean"
+                          :allowEmptyValue true}}
+    [:boolean]]
+   [:types
+    {:optional true
+     :swagger {:description (format "List of types to filter: %s"
+                                    (str/join "," dom.organisation/types))
+               :type "string"
+               :allowEmptyValue true}}
+    [:vector
+     {:decode/string (fn [x] (if (string? x) [x] x))}
+     (apply conj [:enum] dom.organisation/types)]]
+   [:name
+    {:optional true
+     :swagger {:description "Organisation name pattern to use it as partial matching filter"
+               :type "string"
+               :allowEmptyValue true}}
+    [:string]]
+   [:tags
+    {:optional true
+     :swagger {:description "List of tags to filter"
+               :type "string"
+               :allowEmptyValue true}}
+    [:vector
+     {:decode/string (fn [x] (if (string? x) [x] x))}
+     [:string
+      {:min 1}]]]
+   [:limit
+    {:optional true
+     :swagger {:description "Limit the number of entries per page"
+               :type "int"
+               :allowEmptyValue false}}
+    [:int
+     {:min 0}]]
+   [:page
+    {:optional true
+     :swagger {:description "Retrieve entries for a given page number"
+               :type "int"
+               :allowEmptyValue false}}
+    [:int {:min 0}]]
+   [:order_by {:optional true
+               :swagger {:description (format "One of the following properties to order the list of results: %s"
+                                              (str/join "," order-by-fields))
+                         :type "string"
+                         :allowEmptyValue true}}
+    (apply conj [:enum] order-by-fields)]
+   [:descending {:optional true
+                 :swagger {:description "Order results in descending order: true or false"
+                           :type "boolean"
+                           :allowEmptyValue false}}
+    [:boolean]]])


### PR DESCRIPTION
[Re #1611]

As we needed to get Plastic Strategy Workflow feature-specific new information related to organisations, which includes advance sorting and filtering capabilities, we have decided to implement a new endpoint just for that, which will be also useful in the future for other use-cases.

The reason not to use Browse API for this was to avoid adding more complexity to that query, as in the past we removed organisations as resource type to be provided through Browse API, in order to keep performance and complexity in the right balance. On the other hand, community members related endpoint was mixing stakeholders with the organisations data and it would be a mess as well to re-use this endpoint for the Stakeholder Map view in PSW.

PSW Bookmarking related capabilities are yet to be added to this new endpoint.

All details about the endpoint [here](https://app.asana.com/0/0/1205678318305796/f). Besides, documentation has been added to Swagger, as usual.