### PR TITLE
1611 support PS bookmarks in get organisations endpoint

### DIFF
--- a/backend/src/gpml/db/organisation.clj
+++ b/backend/src/gpml/db/organisation.clj
@@ -29,10 +29,22 @@
 (defn list-organisations-query-and-filters
   [params]
   (let [{:keys [count-only? limit page order-by descending]} params
-        order-by (when order-by
-                   (format "ORDER BY %s %s" order-by (if descending
-                                                       "DESC"
-                                                       "ASC")))
+        processed-order-by (if (= "not_ps_bookmarked" order-by)
+                             "ps_bookmarked"
+                             order-by)
+        order-by-order (cond (= "ps_bookmarked" order-by)
+                             "DESC NULLS LAST"
+
+                             (= "not_ps_bookmarked" order-by)
+                             "ASC NULLS FIRST"
+
+                             descending
+                             "DESC"
+
+                             :else
+                             "ASC")
+        order-by (when processed-order-by
+                   (format "ORDER BY %s %s" processed-order-by order-by-order))
         pagination (when (and (not count-only?)
                               limit
                               page)
@@ -46,10 +58,31 @@
               (or order-by "")
               (or pagination "")))))
 
+(defn list-organisations-ps-bookmark-partial-select
+  [params]
+  (let [{:keys [plastic-strategy-id]} params]
+    (when plastic-strategy-id
+      "json_agg(
+         DISTINCT jsonb_build_object(
+           'plastic_strategy_id', psb.plastic_strategy_id,
+           'organisation_id', psb.organisation_id,
+           'section_key', psb.section_key
+         )
+       ) FILTER (WHERE psb.plastic_strategy_id IS NOT NULL) AS plastic_strategy_bookmarks,
+       (psb.organisation_id IS NOT NULL)::boolean AS ps_bookmarked,")))
+
 (defn list-organisations-cto-query-filter-and-params
   [params]
-  (let [{:keys [filters]} params
-        {:keys [geo-coverage-types types review-status tags]} filters
+  (let [{:keys [filters plastic-strategy-id]} params
+        {:keys [geo-coverage-types types review-status tags ps-bookmark-sections-keys]} filters
+        ps-bookmark-section-keys-join-cond (if-not ps-bookmark-sections-keys
+                                             ""
+                                             " AND psb.section_key IN (:v*:filters.ps-bookmark-sections-keys)")
+        ps-bookmark-join (if-not plastic-strategy-id
+                           ""
+                           (format "LEFT JOIN plastic_strategy_organisation_bookmark psb ON (o.id = psb.organisation_id %s AND psb.plastic_strategy_id = %d)"
+                                   ps-bookmark-section-keys-join-cond
+                                   plastic-strategy-id))
         where-cond (cond-> "WHERE 1=1"
                      (seq review-status)
                      (str " AND o.review_status = :filters.review-status::REVIEW_STATUS")
@@ -64,11 +97,22 @@
                      (str " AND o.name ILIKE '%' || :filters.name || '%'")
 
                      (seq types)
-                     (str " AND o.type IN (:v*:filters.types)"))
+                     (str " AND o.type IN (:v*:filters.types)")
+
+                     (and plastic-strategy-id
+                          (seq ps-bookmark-sections-keys)
+                          (contains? (set (keys filters)) :ps-bookmarked))
+                     (str " AND psb.section_key IN (:v*:filters.ps-bookmark-sections-keys)"))
         having (when (seq tags)
-                 "HAVING array_agg(t.tag) FILTER (WHERE t.id IS NOT NULL) && ARRAY[:v*:filters.tags]::text[]")]
+                 "HAVING array_agg(t.tag) FILTER (WHERE t.id IS NOT NULL) && ARRAY[:v*:filters.tags]::text[]")
+        ps-bookmark-group-by (if-not plastic-strategy-id
+                               ""
+                               ", psb.organisation_id")]
     (format "%s
-             GROUP BY o.id
+             %s
+             GROUP BY o.id %s
              %s"
+            ps-bookmark-join
             where-cond
+            ps-bookmark-group-by
             (or having ""))))

--- a/backend/src/gpml/db/organisation.sql
+++ b/backend/src/gpml/db/organisation.sql
@@ -178,6 +178,7 @@ organisations_cte AS (
         'last_name', st.last_name
       )
     ) FILTER (WHERE st.id IS NOT NULL) AS focal_points,
+--~ (#'gpml.db.organisation/list-organisations-ps-bookmark-partial-select params)
     count(DISTINCT os_cte.initiative) as strengths
   FROM organisation o
   LEFT JOIN stakeholder_organisation sto ON (sto.organisation = o.id AND sto.association = 'focal-point')

--- a/backend/src/gpml/handler/organisation.clj
+++ b/backend/src/gpml/handler/organisation.clj
@@ -362,7 +362,10 @@
             results (db.organisation/list-organisations conn opts)]
         (r/ok {:success? true
                :results results
-               :counts (db.organisation/list-organisations conn (assoc opts :count-only? true))}))
+               :counts (->> (assoc opts :count-only? true)
+                            (db.organisation/list-organisations conn)
+                            first
+                            :count)}))
       (catch Throwable t
         (let [log-data {:exception-message (ex-message t)
                         :exception-data (ex-data t)


### PR DESCRIPTION
See commit's [message](https://github.com/akvo/unep-gpml/commit/4ed0e829d1c6d668c581f4b1c74bdfc04466c2cd) for the details.

In this PR we are also fixing the counter result shape of the total amount of organisations loaded in the endpoint (that differs from the paginated result's content).