### PR TITLE
Forum: Fix forum section isn't fully loaded

### DIFF
--- a/frontend/src/modules/workspace/view.jsx
+++ b/frontend/src/modules/workspace/view.jsx
@@ -153,7 +153,10 @@ const Workspace = ({ profile }) => {
           api.get('/chat/channel/all'),
           api.get('/chat/user/channel'),
         ]
-        const [allForums, myForums] = await Promise.all(endpoints)
+        const [
+          { value: allForums },
+          { value: myForums },
+        ] = await Promise.allSettled(endpoints)
         const { data: _myForums } = myForums || {}
         const { data: _allForums } = allForums || {}
         const _forums = _myForums?.length


### PR DESCRIPTION
This problem occurs because using promise all requires all request statuses to be `fulfilled`, when one of them has an error the other requests will stop. For that, we need to replace `Promise.all` with `Promise.allSettled` to execute all requests to completion even if some fail.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205646367469922