### PR TITLE
Fix PS bookmark entity-type parsing for constraint violation check

### DIFF
--- a/backend/src/gpml/db/plastic_strategy/bookmark.clj
+++ b/backend/src/gpml/db/plastic_strategy/bookmark.clj
@@ -14,11 +14,12 @@
   [ps-bookmark]
   (-> ps-bookmark
       (util/update-if-not-nil :ps-bookmark-entity-col name)
-      (util/update-if-not-nil :ps-bookmark-table name)))
+      (util/update-if-not-nil :ps-bookmark-table name)
+      (dissoc :entity-type)))
 
 (defn create-ps-bookmark
-  [conn {:keys [ps-bookmark-entity-col] :as ps-bookmark}]
-  (let [entity-name (first (str/split (name ps-bookmark-entity-col) #"\_"))]
+  [conn {:keys [entity-type] :as ps-bookmark}]
+  (let [entity-name (name entity-type)]
     (jdbc-util/with-constraint-violation-check
       [{:type :unique
         :name (format "plastic_strategy_%s_bookmark_pkey" entity-name)

--- a/backend/src/gpml/db/plastic_strategy/bookmark.clj
+++ b/backend/src/gpml/db/plastic_strategy/bookmark.clj
@@ -1,7 +1,6 @@
 (ns gpml.db.plastic-strategy.bookmark
   {:ns-tracker/resource-deps ["plastic_strategy/bookmark.sql"]}
-  (:require [clojure.string :as str]
-            [gpml.db.jdbc-util :as jdbc-util]
+  (:require [gpml.db.jdbc-util :as jdbc-util]
             [gpml.util :as util]
             [hugsql.core :as hugsql]))
 

--- a/backend/src/gpml/service/plastic_strategy/bookmark.clj
+++ b/backend/src/gpml/service/plastic_strategy/bookmark.clj
@@ -9,7 +9,8 @@
                      :ps-bookmark-entity-col ps-bookmark-entity-col
                      :ps-id plastic-strategy-id
                      :ps-bookmark-entity-id entity-id
-                     :section-key section-key}]
+                     :section-key section-key
+                     :entity-type entity-type}]
     (if bookmark
       (db.ps.bookmark/create-ps-bookmark (:spec db) ps-bookmark)
       (db.ps.bookmark/delete-ps-bookmark (:spec db) ps-bookmark))))


### PR DESCRIPTION
[Re #1611]

* In cases where the entity type is "case_study" the "ps-bookmark-entity-col" splitting will produce a wrong "entity-name". So instead of doing all of this work of splitting the "ps-bookmark-entity-col" we can just pass the "entity-type" already available in our service layer.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205545816718924