### PR TITLE
Fix topic query PS bookmark duplicates

### DIFF
--- a/backend/src/gpml/db/topic.clj
+++ b/backend/src/gpml/db/topic.clj
@@ -156,9 +156,10 @@
                                    entity-name entity-name plastic-strategy-id))
         ps-bookmark-select (if-not plastic-strategy-id
                              ""
-                             (format "json_agg(json_build_object('plastic_strategy_id', psb.plastic_strategy_id,
-                                                                 '%s_id', psb.%s_id,
-                                                                 'section_key', psb.section_key)) AS plastic_strategy_bookmarks,"
+                             (format "json_agg(DISTINCT jsonb_build_object('plastic_strategy_id', psb.plastic_strategy_id,
+									   '%s_id', psb.%s_id,
+									   'section_key', psb.section_key))
+				      FILTER (WHERE psb.plastic_strategy_id IS NOT NULL) AS plastic_strategy_bookmarks,"
                                      entity-name
                                      entity-name))
         ps-bookmark-group-by (if-not plastic-strategy-id


### PR DESCRIPTION
[Re #1611]

* PS bookmark would be duplicated in some occurrences. This might be due to the query complexity of `LEFT JOIN`s generating multiple rows for a single entity even after grouping. For now this is a quick fix but we should take quality time to refactor this query to make it right.