### PR TITLE
Forum: Channel details for non-logged-in user

### DIFF
--- a/frontend/src/pages/forum/[channelName].jsx
+++ b/frontend/src/pages/forum/[channelName].jsx
@@ -15,7 +15,7 @@ const DynamicForumIframe = dynamic(
   }
 )
 
-const ForumDetails = () => {
+const ForumDetails = ({ isAuthenticated, loadingProfile, setLoginVisible }) => {
   const [preload, setPreload] = useState(true)
   const [loading, setLoading] = useState(true)
   const [forums, setForums] = useState([])
@@ -77,10 +77,27 @@ const ForumDetails = () => {
     getMyForums()
   }, [getMyForums])
 
+  useEffect(() => {
+    /**
+     * Handle non-logged in users
+     */
+    if (!loadingProfile && !isAuthenticated && loading) {
+      setLoading(false)
+      /**
+       * Show login modal directly if current channel is private.
+       * p = private
+       * Just in case someone who noticed the URL pattern
+       */
+      if (channelType === 'p') {
+        setLoginVisible(true)
+      }
+    }
+  }, [loading, isAuthenticated, loadingProfile, channelType])
+
   return (
     <Layout>
       <Sider className={styles.channelSidebar} width={335}>
-        <h5>My Forums</h5>
+        {isAuthenticated && <h5>My Forums</h5>}
         <Skeleton loading={loading} paragraph={{ rows: 3 }} active>
           <Menu defaultSelectedKeys={[channelName]}>
             {forums.map((forum) => {
@@ -104,7 +121,15 @@ const ForumDetails = () => {
       </Sider>
       <Layout className={styles.channelContent}>
         {channelName && (
-          <DynamicForumIframe {...{ channelName, channelType }} />
+          <DynamicForumIframe
+            {...{
+              channelName,
+              channelType,
+              isAuthenticated,
+              loadingProfile,
+              setLoginVisible,
+            }}
+          />
         )}
       </Layout>
     </Layout>

--- a/frontend/src/pages/forum/channel.module.scss
+++ b/frontend/src/pages/forum/channel.module.scss
@@ -57,8 +57,20 @@
 
 .channelContent {
   :global {
-    iframe {
+    iframe,
+    .ant-skeleton,
+    .ant-result {
       height: calc(100vh - 90px) !important;
+    }
+    .ant-skeleton {
+      margin: 16px;
+    }
+    .ant-result {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
     }
   }
 }


### PR DESCRIPTION
## Task
If the user attempts to take an action (Join a forum, request to join) then we show the Login modal. After login it should redirect to /forum so that we enable the forum for the user.

## TODO/DONE

- [x] Join iframe eventListener to trigger the Login form
- [x] Sync with the FE team about this approach
- [x] Do not allow non-logged in user to open public channel iframe view.

