### PR TITLE
Remove string check on badge-id-or-name as it can be an integer too

### DIFF
--- a/backend/src/gpml/handler/badge.clj
+++ b/backend/src/gpml/handler/badge.clj
@@ -54,7 +54,7 @@
      {:description "The Badge's name or its id."
       :allowEmptyValue false}}
     [:or
-     pos-int?
+     [:int {:min 1}]
      [:string {:min 1}]]]])
 
 (def ^:private handle-badge-assignment-body-params-schema
@@ -82,8 +82,7 @@
   (fn [{:keys [parameters user]}]
     (try
       (let [badge-id-or-name (get-in parameters [:path :id-or-name])
-            {:keys [badge success?] :as result} (when (string? badge-id-or-name)
-                                                  (get-badge-by-id-or-name config badge-id-or-name))]
+            {:keys [badge success?] :as result} (get-badge-by-id-or-name config badge-id-or-name)]
         (if-not success?
           (r/server-error result)
           (if-not (h.r.permission/operation-allowed? config


### PR DESCRIPTION
* This would prevent the usage of the badge ID and result in a 500 status could with no explanation about the error because the "result" would be always "nil" in case "badge-id-or-name" is an integer.
* Use a more idiomatic Malli schema for positive integers.