### PR TITLE
1611 Support badges-metadata in Organisations List endp.

### DIFF
--- a/backend/src/gpml/db/organisation.sql
+++ b/backend/src/gpml/db/organisation.sql
@@ -179,6 +179,7 @@ organisations_cte AS (
       )
     ) FILTER (WHERE st.id IS NOT NULL) AS focal_points,
 --~ (#'gpml.db.organisation/list-organisations-ps-bookmark-partial-select params)
+--~ (#'gpml.db.organisation/list-organisations-badges-partial-select params)
     count(DISTINCT os_cte.initiative) as strengths
   FROM organisation o
   LEFT JOIN stakeholder_organisation sto ON (sto.organisation = o.id AND sto.association = 'focal-point')

--- a/backend/src/gpml/handler/organisation.clj
+++ b/backend/src/gpml/handler/organisation.clj
@@ -308,7 +308,8 @@
 
 (defn- list-api-params->opts
   [{:keys [geo_coverage_types is_member types tags limit ps_bookmarked
-           page order_by descending ps_country_iso_code_a2 ps_bookmark_sections_keys]
+           page order_by descending ps_country_iso_code_a2 ps_bookmark_sections_keys
+           badges]
     :or {limit default-list-api-limit
          page default-list-api-page}
     :as api-params}]
@@ -348,7 +349,10 @@
     (assoc-in [:filters :ps-bookmark-sections-keys] ps_bookmark_sections_keys)
 
     (not (nil? ps_bookmarked))
-    (assoc-in [:filters :ps-bookmarked] ps_bookmarked)))
+    (assoc-in [:filters :ps-bookmarked] ps_bookmarked)
+
+    (not (nil? badges))
+    (assoc :badges badges)))
 
 (defmethod ig/init-key :gpml.handler.organisation/list
   [_ {:keys [db logger] :as config}]
@@ -471,4 +475,9 @@
                                             Besides, bookmarking is related to `ps_country_iso_code_a2` param."
                               :type "boolean"
                               :allowEmptyValue false}}
+    [:boolean]]
+   [:badges {:optional true
+             :swagger {:description "Boolean flag to load badges-related metadata"
+                       :type "boolean"
+                       :allowEmptyValue false}}
     [:boolean]]])


### PR DESCRIPTION
[Re #1611]

We need to include the same information we are adding in other APIs such as Submission one, in order to conditionally load Badges assignation-related metadata for the listed organisations.

So, now the endpoint allows a `badge` query param boolean value to be able to load badges-related metadata.