### PR TITLE
Refactor and fix GET detail API parameters handling

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -367,9 +367,7 @@
                                           {:get {:middleware [#ig/ref :gpml.auth/auth-middleware]
                                                  :summary "Get the details for a specific resource"
                                                  :swagger {:tags ["resource detail"]}
-                                                 :parameters {:path [:map
-                                                                     [:topic-type #ig/ref :gpml.handler.detail/topics]
-                                                                     [:topic-id int?]]}
+                                                 :parameters #ig/ref :gpml.handler.detail/get-params
                                                  :handler #ig/ref :gpml.handler.detail/get}
                                            :delete {:middleware [#ig/ref :gpml.auth/auth-middleware
                                                                  #ig/ref :gpml.auth/auth-required]
@@ -932,6 +930,7 @@
   :gpml.handler.comment/delete-response {}
   :gpml.handler.detail/topics {}
   :gpml.handler.detail/get #ig/ref :gpml.config/common
+  :gpml.handler.detail/get-params {}
   :gpml.handler.detail/delete #ig/ref :gpml.config/common
   :gpml.handler.detail/put #ig/ref :gpml.config/common
   :gpml.handler.detail/put-params {}

--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -511,6 +511,33 @@
       {:success? false
        :reason :not-found})))
 
+(def ^:private get-detail-path-params-schema
+  [:map
+   [:topic-type
+    {:swagger {:description "The topic type (or entity type) to get details from."
+               :type "string"
+               :enum dom.types/topic-types}}
+    ;; TODO: refactor to use dom.types/get-type-schema.
+    (apply conj [:enum] dom.types/topic-types)]
+   [:topic-id
+    {:swagger {:description "The topic ID (or entity ID)."
+               :type "integer"}}
+    [:int {:min 1}]]])
+
+(def ^:private get-detail-query-params-schema
+  [:map
+   [:badges
+    {:optional true
+     :swagger {:description "Flag to include assigned badges."
+               :type "boolean"
+               :allowEmptyValue false}}
+    [:boolean]]])
+
+(defmethod ig/init-key :gpml.handler.detail/get-params
+  [_ _]
+  {:path get-detail-path-params-schema
+   :query get-detail-query-params-schema})
+
 (defmethod ig/init-key :gpml.handler.detail/get
   [_ {:keys [db logger] :as config}]
   (fn [{{:keys [path query]} :parameters user :user}]


### PR DESCRIPTION
* Query parameters were being discarded because it was not defined for coercion.