### PR TITLE
Create chat account on add ps team member if required

### DIFF
--- a/backend/src/gpml/db/plastic_strategy/team.clj
+++ b/backend/src/gpml/db/plastic_strategy/team.clj
@@ -30,7 +30,7 @@
   [conn ps-team-member]
   (jdbc-util/with-constraint-violation-check
     [{:type :unique
-      :name "plastic_strategy_team_member_pkey"
+      :name "plastic_strategy_team_pkey"
       :error-reason :already-exists}]
     (add-ps-team-member* conn (ps-team-member->p-ps-team-member ps-team-member))
     {:success? true}))

--- a/backend/src/gpml/handler/plastic_strategy/team.clj
+++ b/backend/src/gpml/handler/plastic_strategy/team.clj
@@ -84,7 +84,9 @@
                                                      body-params)]
           (if (:success? result)
             (r/ok {})
-            (r/server-error (dissoc result :success?))))))))
+            (if (= (:reason result) :ps-team-member-already-exists)
+              (r/conflict {:reason :ps-team-member-already-exists})
+              (r/server-error (dissoc result :success?)))))))))
 
 (defn- update-ps-team-member
   [config {:keys [user] {:keys [path body]} :parameters}]

--- a/backend/src/gpml/service/plastic_strategy/team.clj
+++ b/backend/src/gpml/service/plastic_strategy/team.clj
@@ -1,6 +1,7 @@
 (ns gpml.service.plastic-strategy.team
   (:require [duct.logger :refer [log]]
             [gpml.db.plastic-strategy.team :as db.ps.team]
+            [gpml.db.stakeholder :as db.stakeholder]
             [gpml.service.chat :as srv.chat]
             [gpml.service.invitation :as srv.invitation]
             [gpml.service.permissions :as srv.permissions]
@@ -77,6 +78,35 @@
               (when-not (:success? result)
                 (log logger :error :failed-to-rollback-assign-role-to-user {:result result})))
             context)}
+         {:txn-fn
+          (fn tx-create-chat-account-if-required
+            [{:keys [ps-team-member] :as context}]
+            (if (seq (:chat-account-id ps-team-member))
+              context
+              (let [{:keys [success? chat-user-account] :as result}
+                    (srv.chat/create-user-account config (:id ps-team-member))]
+                (if success?
+                  (-> context
+                      (assoc-in [:ps-team-member :chat-account-id] (:id chat-user-account))
+                      (assoc :can-rollback-create-chat-account? true))
+                  (assoc context
+                         :success? false
+                         :reason :failed-to-create-ps-team-member-chat-account
+                         :error-details {:result result})))))
+          :rollback-fn
+          (fn rollback-create-chat-account-if-required
+            [{:keys [ps-team-member can-rollback-create-chat-account?] :as context}]
+            (if-not can-rollback-create-chat-account?
+              context
+              (let [result (srv.chat/delete-user-account config
+                                                         (:chat-account-id ps-team-member)
+                                                         {})]
+                (if-not (:success? result)
+                  (log logger :error ::failed-to-rollback-create-chat-account {:result result})
+                  (db.stakeholder/update-stakeholder (:spec db) {:id (:id ps-team-member)
+                                                                 :chat_account_id nil
+                                                                 :chat_account_status nil}))
+                context)))}
          {:txn-fn
           (fn tx-add-team-member-to-ps-chat-channel
             [{:keys [ps-team-member plastic-strategy] :as context}]


### PR DESCRIPTION
* Every user added to a plastic strategy needs to have a chat account enabled in order to add them to the PS channel. Therefore, I added an extra step to create a user account in RocketChat if it doesn't have one already. Since creating the "Forum" (i.e. RocketChat) account is completely transparent for the user using the platform, this is also something that only concerns the BE.
* Improved the error handling on the `add-ps-team-member` handler and service layer to return conflict if the team member already exists.