### PR TITLE
Fix organisations query to match all tags instead of any

### DIFF
--- a/backend/src/gpml/db/organisation.clj
+++ b/backend/src/gpml/db/organisation.clj
@@ -124,7 +124,7 @@
                           (contains? (set (keys filters)) :ps-bookmarked))
                      (str " AND psb.section_key IN (:v*:filters.ps-bookmark-sections-keys)"))
         having (when (seq tags)
-                 "HAVING array_agg(t.tag) FILTER (WHERE t.id IS NOT NULL) && ARRAY[:v*:filters.tags]::text[]")
+                 "HAVING array_agg(t.tag) FILTER (WHERE t.id IS NOT NULL) @> ARRAY[:v*:filters.tags]::text[]")
         ps-bookmark-group-by (if-not plastic-strategy-id
                                ""
                                ", psb.organisation_id")]


### PR DESCRIPTION
* Before the filter would match any of the tags passed as filters but we want to match all of them. So basically it's an AND instead of OR.