### PR TITLE
1611 Support strengths prop filtering by PS code in Organisations GET endpoint

### DIFF
--- a/backend/src/gpml/db/organisation.clj
+++ b/backend/src/gpml/db/organisation.clj
@@ -87,6 +87,23 @@
          ) FILTER (WHERE oba.badge_id IS NOT NULL),
         '[]'::jsonb) AS assigned_badges,")))
 
+(defn list-organisations-strengths-cto
+  [{:keys [plastic-strategy-id]}]
+  (let [bookmarked-initiatives-join (if-not plastic-strategy-id
+                                      ""
+                                      (format
+                                       "INNER JOIN plastic_strategy_initiative_bookmark psib
+                                         ON (oi.initiative = psib.initiative_id AND psib.plastic_strategy_id = %d)"
+                                       plastic-strategy-id))]
+    (format "SELECT oi.organisation, %s AS initiative
+             FROM organisation_initiative oi
+             %s
+             WHERE oi.association IN ('owner', 'implementor', 'donor', 'partner')"
+            (if-not plastic-strategy-id
+              "oi.initiative"
+              "psib.initiative_id")
+            bookmarked-initiatives-join)))
+
 (defn list-organisations-cto-query-filter-and-params
   [params]
   (let [{:keys [filters plastic-strategy-id]} params

--- a/backend/src/gpml/db/organisation.sql
+++ b/backend/src/gpml/db/organisation.sql
@@ -147,9 +147,7 @@ WHERE 1=1
 -- :name list-organisations :query :many
 -- :doc List organisations with advanced filtering (for PSW mainly)
 WITH organisations_strengths_cte AS (
-  SELECT organisation, initiative
-  FROM organisation_initiative
-  WHERE association IN ('owner', 'implementor', 'donor', 'partner')
+--~ (#'gpml.db.organisation/list-organisations-strengths-cto params)
 ),
 organisations_cte AS (
   SELECT


### PR DESCRIPTION
endpoint

[Re #1611]

We need to filter the strengths count according to the provided PS iso code from the params, so only those bookmarked initiatives for the given PS are taking into account when the PS iso code is provided. In this case, we do not count again same bookmarks for different sections, as it is only relevant the PS used to bookmark those initiatives.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205859571336278