### PR TITLE
1730 Provide generic endpoint to get Policy enums

### DIFF
--- a/backend/resources/gpml/config.edn
+++ b/backend/resources/gpml/config.edn
@@ -751,7 +751,12 @@
                                                                 #ig/ref :gpml.auth/auth-required]
                                                    :swagger {:tags ["badge"] :security [{:id_token []}]}
                                                    :handler #ig/ref :gpml.handler.badge.assign/post
-                                                   :parameters #ig/ref :gpml.handler.badge.assign/post-params}}]]]]]
+                                                   :parameters #ig/ref :gpml.handler.badge.assign/post-params}}]]]
+                                        ["/enums/{entity-type}"
+                                         {:get {:summary "Get all the enum options for a given entity type"
+                                                :swagger {:tags ["enums"]}
+                                                :parameters #ig/ref :gpml.handler.enums/get-params
+                                                :handler #ig/ref :gpml.handler.enums/get}}]]]
                               :logger #ig/ref :duct.logger/timbre
                               :cors-allowed-origins #ig/ref :gpml.handler.main/cors-allowed-origins}
 
@@ -1062,6 +1067,9 @@
 
   :gpml.handler.programmatic.badge/post #ig/ref :gpml.config/common
   :gpml.handler.programmatic.badge/post-params {}
+
+  :gpml.handler.enums/get {}
+  :gpml.handler.enums/get-params {}
 
   :clj-gcp.storage/client {}
 

--- a/backend/src/gpml/domain/types.clj
+++ b/backend/src/gpml/domain/types.clj
@@ -112,6 +112,9 @@
     :partner-verified
     :coe-verified})
 
+(def ^:const get-enums-entity-types
+  #{:policy})
+
 (def ^:const enum-types
   {:review-status review-statuses
    :reviewer-status reviewer-review-statuses
@@ -127,7 +130,8 @@
    :plastic-strategy-team-role plastic-strategy-team-roles
    :plastic-strategy-bookmarkable-entity-type plastic-strategy-bookmarkable-entity-types
    :badge-assignable-entity-type badge-assignable-entity-types
-   :badge-type badge-type})
+   :badge-type badge-type
+   :get-enums-entity-types get-enums-entity-types})
 
 (defn get-type-schema
   [type-name]

--- a/backend/src/gpml/handler/enums.clj
+++ b/backend/src/gpml/handler/enums.clj
@@ -1,0 +1,47 @@
+(ns gpml.handler.enums
+  (:require [gpml.domain.policy :as dom.policy]
+            [gpml.domain.related-content :as dom.rc]
+            [gpml.domain.types :as dom.types]
+            [gpml.handler.responses :as r]
+            [integrant.core :as ig]))
+
+(def ^:private get-enums-path-params-schema
+  [:map
+   [:entity-type
+    {:swagger {:description "Target entity type to get the enums from."
+               :type "string"
+               :enum dom.types/get-enums-entity-types}
+     :decode/string keyword
+     :decode/json keyword}
+    (apply conj [:enum] dom.types/get-enums-entity-types)]])
+
+(defmulti ^:private entity-type-available-enums
+  "Return available enum values for the given entity type"
+  identity)
+
+(defmethod entity-type-available-enums :policy
+  [_]
+  {:type-of-law dom.policy/types-of-laws
+   :status dom.policy/statuses
+   :geo-coverage-type dom.types/geo-coverage-types
+   :review-status dom.types/review-statuses
+   :sub-content-type dom.policy/sub-content-types
+   :related-content-resource-type dom.rc/resource-types
+   :related-content-relation-type dom.rc/relation-types
+   :connections-association-type dom.types/association-types
+   :source dom.types/resource-source-types})
+
+(defn get-entity-type-enums
+  [{{:keys [path]} :parameters}]
+  (let [entity-type (:entity-type path)]
+    (entity-type-available-enums entity-type)))
+
+(defmethod ig/init-key :gpml.handler.enums/get
+  [_ _]
+  (fn [req]
+    (r/ok
+     {:enums (get-entity-type-enums req)})))
+
+(defmethod ig/init-key :gpml.handler.enums/get-params
+  [_ _]
+  {:path get-enums-path-params-schema})


### PR DESCRIPTION
[Re #1730]

As explained in the issue, we have now a generic endpoint to provide with the enum values of Policy entity type, which allows a future extension for other entity types, if needed.

The values are obtained from the domain code, as those are the source of truth (up-to-date).

NOTE: Due to code freeze we should not merge this PR until we release into production the latest developments.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205908923746189