### PR TITLE
1734 Allow total tags removal from stakeholders

### DIFF
--- a/backend/src/gpml/handler/stakeholder/expert.clj
+++ b/backend/src/gpml/handler/stakeholder/expert.clj
@@ -211,12 +211,13 @@
                              (cske/transform-keys ->snake_case))]
         (doseq [{:keys [email expertise]} body
                 :let [stakeholder-id (get-in (group-by :email expert-stakeholders) [email 0 :id])]]
-          (handler.stakeholder.tag/save-stakeholder-tags
-           conn
-           logger
-           mailjet-config
-           {:tags (handler.stakeholder.tag/api-stakeholder-tags->stakeholder-tags {:expertise expertise})
-            :stakeholder-id stakeholder-id})
+          (when (seq expertise)
+            (handler.stakeholder.tag/save-stakeholder-tags
+             conn
+             logger
+             mailjet-config
+             {:tags (handler.stakeholder.tag/api-stakeholder-tags->stakeholder-tags {:expertise expertise})
+              :stakeholder-id stakeholder-id}))
           (let [{:keys [success?]} (srv.permissions/create-resource-context
                                     {:conn conn
                                      :logger logger}

--- a/backend/src/gpml/service/stakeholder.clj
+++ b/backend/src/gpml/service/stakeholder.clj
@@ -193,7 +193,7 @@
     (tht/thread-transactions logger transactions context)))
 
 (defn update-stakeholder
-  [{:keys [db logger mailjet-config] :as config} stakeholder]
+  [{:keys [db logger mailjet-config] :as config} stakeholder partial-tags-override-rel-cats]
   (let [conn (:spec db)
         context {:success? true
                  :stakeholder stakeholder}
@@ -290,7 +290,7 @@
          {:txn-fn
           (fn save-stakeholder-tags
             [{:keys [stakeholder] :as context}]
-            (if-not (seq (:tags stakeholder))
+            (if-not (contains? (set (keys stakeholder)) :tags)
               context
               (let [result (handler.stakeholder.tag/save-stakeholder-tags
                             conn
@@ -299,7 +299,8 @@
                             {:tags (:tags stakeholder)
                              :stakeholder-id (:id stakeholder)
                              :handle-errors? true
-                             :update? true})]
+                             :update? true
+                             :partial-tags-override-rel-cats partial-tags-override-rel-cats})]
                 (if (:success? result)
                   context
                   (assoc context


### PR DESCRIPTION
[Re #1734]

As explained in the issue, the generic user (stakeholder) tag assignation machinery was not ready to allow to remove all the tags of a given relation-category (offering, seeking or expertise), so now we have refactored the code to allow so. Since, the tags assignation is a partial thing (per category), the fix is quite more ellaborated, as we need to keep the old tags that are not part of the target category, so those are not overriden.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205913551594845