### PR TITLE
Create chat account on GPML sign up

### DIFF
--- a/backend/dev/resources/test.edn
+++ b/backend/dev/resources/test.edn
@@ -9,6 +9,10 @@
  :mocks.boundary.adapter.storage-client/local-file-system
  {:base-path #duct/env ["LOCAL_FS_STORAGE_BASE_PATH" Str]}
 
+ :mocks.boundary.adapter.chat/rocket-chat
+ {}
+
  [:duct/const :gpml.config/common]
- {:storage-client-adapter #ig/ref :mocks.boundary.adapter.storage-client/local-file-system
+ {:chat-adapter #ig/ref :mocks.boundary.adapter.chat/rocket-chat
+  :storage-client-adapter #ig/ref :mocks.boundary.adapter.storage-client/local-file-system
   :storage-bucket-name #duct/env ["LOCAL_FS_STORAGE_BUCKET_NAME" Str]}}

--- a/backend/dev/src/mocks/boundary/adapter/chat/rocket_chat.clj
+++ b/backend/dev/src/mocks/boundary/adapter/chat/rocket_chat.clj
@@ -1,0 +1,19 @@
+(ns mocks.boundary.adapter.chat.rocket-chat
+  (:require [gpml.boundary.port.chat :as port]
+            [gpml.util :as util]
+            [integrant.core :as ig]))
+
+(defn- create-user-account
+  []
+  {:success? true
+   :user {:id (str (util/uuid))
+          :active true}})
+
+(defrecord MockRocketChat []
+  port/Chat
+  (create-user-account [_ _]
+    (create-user-account)))
+
+(defmethod ig/init-key :mocks.boundary.adapter.chat/rocket-chat
+  [_ _]
+  (->MockRocketChat))

--- a/backend/src/gpml/handler/submission.clj
+++ b/backend/src/gpml/handler/submission.clj
@@ -12,7 +12,6 @@
             [gpml.handler.responses :as r]
             [gpml.handler.stakeholder.tag :as handler.stakeholder.tag]
             [gpml.handler.util :as handler.util]
-            [gpml.service.chat :as srv.chat]
             [gpml.service.file :as srv.file]
             [gpml.service.permissions :as srv.permissions]
             [gpml.util.auth0 :as auth0]

--- a/backend/src/gpml/handler/submission.clj
+++ b/backend/src/gpml/handler/submission.clj
@@ -155,12 +155,6 @@
         (throw (ex-info "Failed to unassign role from user" {:user-id stakeholder-id}))))
     (srv.permissions/unassign-all-roles config stakeholder-id)))
 
-(defn- handle-stakeholder-chat-account-creation
-  [config stakeholder-id]
-  (let [result (srv.chat/create-user-account config stakeholder-id)]
-    (when-not (:success? result)
-      (throw (ex-info "Failed to create chat user account" {:user-id stakeholder-id})))))
-
 (defn- notify-admins-submission-status
   [{:keys [mailjet-config]} resource-type resource-details]
   (let [creator (:creator resource-details)
@@ -194,10 +188,7 @@
                   (handle-stakeholder-role-change {:conn tx
                                                    :logger logger}
                                                   (:id submission)
-                                                  (:review_status submission))
-                  (when (and (= (:chat_account_status resource-details) "pending-activation")
-                             (= (:review_status resource-details) "APPROVED"))
-                    (handle-stakeholder-chat-account-creation config (:id resource-details))))
+                                                  (:review_status submission)))
                 (notify-admins-submission-status config resource-type resource-details)
                 (r/ok {:success? true
                        :message "Successfuly Updated"

--- a/backend/src/gpml/service/stakeholder.clj
+++ b/backend/src/gpml/service/stakeholder.clj
@@ -13,7 +13,8 @@
             [gpml.util :as util]
             [gpml.util.image :as util.image]
             [gpml.util.thread-transactions :as tht]
-            [medley.core :as medley]))
+            [medley.core :as medley]
+            [gpml.service.chat :as srv.chat]))
 
 (defn create-stakeholder
   [{:keys [db logger mailjet-config] :as config} stakeholder]
@@ -189,7 +190,31 @@
                 (assoc context
                        :success? false
                        :reason :failed-to-assign-role-to-stakeholder
-                       :error-details (:error-details result)))))}]]
+                       :error-details (:error-details result)))))
+          :rollback-fn
+          (fn rollback-assign-role
+            [{:keys [stakeholder] :as context}]
+            (let [role-unassignments [{:role-name :unapproved-user
+                                       :context-type :application
+                                       :resource-id srv.permissions/root-app-resource-id
+                                       :user-id (:id stakeholder)}]
+                  result (first (srv.permissions/unassign-roles-from-users
+                                 {:conn conn
+                                  :logger logger}
+                                 role-unassignments))]
+              (when-not (:success? result)
+                (log logger :error ::failed-to-rollback-assign-role-to-stakeholder {:result result})))
+            context)}
+         {:txn-fn
+          (fn create-chat-account
+            [{:keys [stakeholder]}]
+            (let [result (srv.chat/create-user-account config (:id stakeholder))]
+              (if (:success? result)
+                context
+                (assoc context
+                       :success? false
+                       :reason :failed-to-create-chat-user-account
+                       :error-details {:result result}))))}]]
     (tht/thread-transactions logger transactions context)))
 
 (defn update-stakeholder

--- a/backend/src/gpml/service/stakeholder.clj
+++ b/backend/src/gpml/service/stakeholder.clj
@@ -7,14 +7,14 @@
             [gpml.domain.file :as dom.file]
             [gpml.handler.organisation :as handler.org]
             [gpml.handler.stakeholder.tag :as handler.stakeholder.tag]
+            [gpml.service.chat :as srv.chat]
             [gpml.service.file :as srv.file]
             [gpml.service.permissions :as srv.permissions]
             [gpml.service.plastic-strategy :as srv.ps]
             [gpml.util :as util]
             [gpml.util.image :as util.image]
             [gpml.util.thread-transactions :as tht]
-            [medley.core :as medley]
-            [gpml.service.chat :as srv.chat]))
+            [medley.core :as medley]))
 
 (defn create-stakeholder
   [{:keys [db logger mailjet-config] :as config} stakeholder]

--- a/backend/src/gpml/service/stakeholder.clj
+++ b/backend/src/gpml/service/stakeholder.clj
@@ -207,10 +207,13 @@
             context)}
          {:txn-fn
           (fn create-chat-account
-            [{:keys [stakeholder]}]
-            (let [result (srv.chat/create-user-account config (:id stakeholder))]
-              (if (:success? result)
-                context
+            [{:keys [stakeholder] :as context}]
+            (let [{success? :success? updated-user :stakeholder :as result}
+                  (srv.chat/create-user-account config (:id stakeholder))]
+              (if success?
+                (-> context
+                    (assoc-in [:stakeholder :chat_account_id] (:chat-account-id updated-user))
+                    (assoc-in [:stakeholder :chat_account_status] (:chat-account-status updated-user)))
                 (assoc context
                        :success? false
                        :reason :failed-to-create-chat-user-account


### PR DESCRIPTION
* I'm moving the chat account creation from user approval to sign
up. So now, when the user finishes the onboarding process we create
its account on RocketChat.