### PR TITLE
Fix delete resource in detail api

### DIFF
--- a/backend/resources/migrations/203-add-missing-on-delete-cascade-constraints.up.sql
+++ b/backend/resources/migrations/203-add-missing-on-delete-cascade-constraints.up.sql
@@ -1,0 +1,28 @@
+BEGIN;
+--;;
+ALTER TABLE resource_organisation
+DROP CONSTRAINT resource_organisation_organisation_fkey,
+DROP CONSTRAINT resource_organisation_resource_fkey,
+ADD CONSTRAINT resource_organisation_organisation_fkey FOREIGN KEY (organisation) REFERENCES organisation (id) ON DELETE CASCADE,
+ADD CONSTRAINT resource_organisation_resource_fkey FOREIGN KEY (resource) REFERENCES resource(id) ON DELETE CASCADE;
+--;;
+ALTER TABLE resource_language_url
+DROP CONSTRAINT resource_language_url_language_fkey,
+DROP CONSTRAINT resource_language_url_resource_fkey,
+ADD CONSTRAINT resource_language_url_language_fkey FOREIGN KEY (language) REFERENCES language(id) ON DELETE CASCADE,
+ADD CONSTRAINT resource_language_url_resource_fkey FOREIGN KEY (resource) REFERENCES resource(id) ON DELETE CASCADE;
+--;;
+ALTER TABLE event_language_url
+DROP CONSTRAINT event_language_url_language_fkey,
+DROP CONSTRAINT event_language_url_event_fkey,
+ADD CONSTRAINT event_language_url_language_fkey FOREIGN KEY (language) REFERENCES language(id) ON DELETE CASCADE,
+ADD CONSTRAINT event_language_url_event_fkey FOREIGN KEY (event) REFERENCES event(id) ON DELETE CASCADE;
+--;;
+ALTER TABLE technology_language_url
+DROP CONSTRAINT technology_language_url_language_fkey,
+DROP CONSTRAINT technology_language_url_technology_fkey,
+ADD CONSTRAINT technology_language_url_language_fkey FOREIGN KEY (language) REFERENCES language(id) ON DELETE CASCADE,
+ADD CONSTRAINT technology_language_url_technology_fkey FOREIGN KEY (technology) REFERENCES technology(id) ON DELETE CASCADE;
+--;;
+COMMIT;
+

--- a/backend/src/gpml/db/resource/detail.clj
+++ b/backend/src/gpml/db/resource/detail.clj
@@ -1,5 +1,40 @@
 (ns gpml.db.resource.detail
   {:ns-tracker/resource-deps ["resource/detail.sql"]}
-  (:require [hugsql.core :as hugsql]))
+  (:require [clojure.java.jdbc :as jdbc]
+            [dev.gethop.rbac :as rbac]
+            [gpml.db.resource.related-content :as db.resource.detail]
+            [hugsql.core :as hugsql]))
+
+(declare get-resource
+         delete-resource*)
 
 (hugsql/def-db-fns "gpml/db/resource/detail.sql" {:quoting :ansi})
+
+(defn- delete-resource-related-contents
+  [conn {:keys [id type]}]
+  (try
+    (db.resource.detail/delete-related-contents conn
+                                                {:resource-id id
+                                                 :resource-table-name type})
+    {:success? true}
+    (catch Throwable t
+      {:success? false
+       :reason :exception
+       :error-details {:msg (ex-message t)}})))
+
+(defn delete-resource
+  [conn logger {:keys [id type rbac-context-type] :as opts}]
+  (try
+    (jdbc/with-db-transaction [tx conn]
+      (when-not (:success? (rbac/delete-context! tx logger {:context-type-name rbac-context-type
+                                                            :resource-id id}))
+        (throw (ex-info "Failed to delete RBAC context." {:reason :failed-to-delete-rbac-context})))
+      (when-not (:success? (delete-resource-related-contents tx opts))
+        (throw (ex-info "Failed to delete related contents." {:reason :failed-to-delete-related-contents})))
+      (when-not (= 1 (delete-resource* tx {:table-name type :id id}))
+        (throw (ex-info "Failed to delete resource." {:reason :unexpected-number-of-affected-rows})))
+      {:success? true})
+    (catch Throwable t
+      {:success? false
+       :reason :exception
+       :error-details {:msg (ex-message t)}})))

--- a/backend/src/gpml/db/resource/detail.sql
+++ b/backend/src/gpml/db/resource/detail.sql
@@ -3,3 +3,7 @@
 SELECT *
 FROM :i:table-name
 WHERE id = :id::integer
+
+-- :name delete-resource* :execute :affected
+DELETE FROM :i:table-name
+WHERE id = :id;


### PR DESCRIPTION
* These tables needs to have the ON DELETE CASCADE constraint so
PostgreSQL handles the deletion of references by itself.
* Also use HugSQL available functions to delete the associated
references that can't have a foreign key, i.e., "rbac_context" and "related_content".

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205956160722172