### PR TITLE
Filter PSes based on RBAC user read permission

### DIFF
--- a/backend/src/gpml/db/plastic_strategy.sql
+++ b/backend/src/gpml/db/plastic_strategy.sql
@@ -10,6 +10,12 @@ json_build_object('id', c.id,
 		  'headequarter', c.headquarter) AS country
 FROM plastic_strategy ps
 INNER JOIN country c ON c.id = country_id
+/*~ (when (get-in params [:filters :rbac-user-id]) */
+JOIN rbac_context rc ON rc.resource_id = ps.id AND rc.context_type_name = 'plastic-strategy'
+JOIN rbac_role_assignment rra ON rra.context_id = rc.id AND rra.user_id = :filters.rbac-user-id
+JOIN rbac_role_permission rrp ON rrp.role_id = rra.role_id
+JOIN rbac_permission rp ON rp.id = rrp.permission_id AND rp.name = 'plastic-strategy/read'
+/*~ ) ~*/
 WHERE 1=1
 --~(when (seq (get-in params [:filters :ids])) " AND ps.id IN (:v*:filters.ids)")
 --~(when (seq (get-in params [:filters :countries-ids])) " AND ps.country_id IN (:v*:filters.countries-ids)")

--- a/backend/src/gpml/handler/plastic_strategy.clj
+++ b/backend/src/gpml/handler/plastic_strategy.clj
@@ -4,7 +4,6 @@
             [clojure.string :as str]
             [gpml.handler.resource.permission :as h.r.permission]
             [gpml.handler.responses :as r]
-            [gpml.service.permissions :as srv.permissions]
             [gpml.service.plastic-strategy :as srv.ps]
             [integrant.core :as ig]))
 


### PR DESCRIPTION
* If the "rbac-user-id" has the "plastic-strategy/read" permission then it can read that plastic strategy information. So, we filter out those PSes in which the user doesn't have permissions.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205999789361874