### PR TITLE
Fix logic for transnational_counts_per_country CTE in map-counts

### DIFF
--- a/backend/src/gpml/db/landing.sql
+++ b/backend/src/gpml/db/landing.sql
@@ -14,10 +14,9 @@ transnational_counts_per_country AS (
 	 topic,
 	 COUNT(DISTINCT json->>'id') AS topic_count
   FROM filtered_entities
-  LEFT JOIN json_array_elements_text((json->>'geo_coverage_values')::JSON) cgcs
-  ON json->>'geo_coverage_values' IS NOT NULL
+  LEFT JOIN json_array_elements_text((json->>'geo_coverage_country_groups')::JSON) cgcs
+  ON json->>'geo_coverage_country_groups' IS NOT NULL
   JOIN country_group_country cgc ON cgc.country_group = (cgcs.value)::TEXT::INT
-  OR cgc.country = (cgcs.value)::TEXT::INT
   WHERE (cgcs.value)::TEXT <> 'null' AND json->>'geo_coverage_type' = 'transnational'
   GROUP BY cgc.country, topic
 ),


### PR DESCRIPTION
* The idea here is to get those resources that have "geo_coverage_type" = "transnational", take their transnational values ("geo_coverage_country_groups") and retrieve the countries associated to each transnational. This way we link a transnational resource to all countries that are part of a specific transnational group. For example, if we have an Event resource which its "geo_coverage_type" is "transnational" and the value is "Europe", we should add +1 to the counter of all countries that are part of "Europe" country group.
* Before we were matching all possible values of "geo_coverage" by using the "geo_coverage_values" which has a mix of "geo_coverage_countries" and "geo_coverage_country_groups" which is not right. We just want to get the country groups of the resource and link it to the countries that are part of those country groups.
* As a consequence of the previous logic the query was doing a lot of effort because it was processing all the possible values of "geo_coverage_values", making it very very slow.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205947350642719