### PR TITLE
Avoid sql error in `get-tags-from-resources`

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -11,6 +11,7 @@ pom.xml.asc
 /.dir-locals.el
 /profiles.clj
 /dev/resources/local.edn
+/dev/resources/localtest.edn
 /dev/src/local.clj
 .eastwood
 flycheck_.dir-locals.elc

--- a/backend/src/gpml/db/resource/tag.clj
+++ b/backend/src/gpml/db/resource/tag.clj
@@ -13,3 +13,16 @@
          delete-resource-tags)
 
 (hugsql/def-db-fns "gpml/db/resource/tag.sql" {:quoting :ansi})
+
+(alter-meta! #'get-tags-from-resources assoc :private true)
+
+(defn safely-get-tags-from-resources
+  "Get all the tags for all the resources"
+  [db params]
+  (if-not (seq (:resource-ids params))
+    ;; Avoid SQL error, since ` in ()` isn't valid SQL.
+    ;; This could also be avoided in .sql itself with something like ---(when (or (seq (:resource-ids params)) " WHERE rt.:i:resource-col in (:v*:resource-ids)"),
+    ;; however my attempt didn't immediately succeed.
+    ;; We also could migrate the query to honeysql.
+    []
+    (get-tags-from-resources db params)))

--- a/backend/src/gpml/scheduler/brs_api_importer.clj
+++ b/backend/src/gpml/scheduler/brs_api_importer.clj
@@ -477,10 +477,10 @@
         ;; Tags
         old-tags-relations
         (when (seq tags-table-data)
-          (->> (db.r.tag/get-tags-from-resources tx
-                                                 {:table (str (name entity-name) "_tag")
-                                                  :resource-col (name entity-name)
-                                                  :resource-ids entities-ids})
+          (->> (db.r.tag/safely-get-tags-from-resources tx
+                                                        {:table (str (name entity-name) "_tag")
+                                                         :resource-col (name entity-name)
+                                                         :resource-ids entities-ids})
                (group-by (juxt entity-name :tag))))
         {:keys [created-tags-relations created-tags]}
         (when (seq tags-table-data)

--- a/backend/src/gpml/scheduler/leap_api_policy_importer.clj
+++ b/backend/src/gpml/scheduler/leap_api_policy_importer.clj
@@ -585,12 +585,11 @@
                                            :tag resolved-tag-id}))
                                       policy-tags)
           existing-policy-tags (when (seq processed-policy-tags)
-                                 (db.resource.tag/get-tags-from-resources
-                                  trans-conn
-                                  {:table "policy_tag"
-                                   :resource-col "policy"
-                                   :resource-ids (mapv #(get % :policy)
-                                                       processed-policy-tags)}))
+                                 (db.resource.tag/safely-get-tags-from-resources trans-conn
+                                                                                 {:table "policy_tag"
+                                                                                  :resource-col "policy"
+                                                                                  :resource-ids (mapv #(get % :policy)
+                                                                                                      processed-policy-tags)}))
           existing-policy-tags-set (->> existing-policy-tags
                                         (mapv #(vector (get % :policy)
                                                        (get % :tag)))


### PR DESCRIPTION
https://akvo-foundation.sentry.io/issues/5022209500 popped up this morning. It was an old latent bug.