### PR TITLE
Set `DEAD_SIMPLE_CHAT_API_KEY` in k8s

### DIFF
--- a/.env
+++ b/.env
@@ -41,11 +41,7 @@ BRS_API_PROJECTS_ENDPOINT=/Projects/Projects.svc/Projects
 CORS_ALLOWED_ORIGINS=localhost
 
 # Chat
-CHAT_API_DOMAIN_URL=https://rocket-chat.akvotest.org
-CHAT_API_URL_PATH=/api/v1
-CHAT_API_KEY=
-CHAT_API_USER_ID=
-# You can obtain this one in https://deadsimplechat.com/dashboard/developer (private key):
+# You can obtain this one in https://deadsimplechat.com/dashboard/developer (private key), or our Vault:
 DEAD_SIMPLE_CHAT_API_KEY=
 
 # Strapi Settings [SAMPLE]

--- a/ci/k8s/deployment.template.yml
+++ b/ci/k8s/deployment.template.yml
@@ -210,26 +210,11 @@ spec:
             secretKeyRef:
               name: unep-gpml
               key: gcs-api-host-name
-        - name: CHAT_API_DOMAIN_URL
+        - name: DEAD_SIMPLE_CHAT_API_KEY
           valueFrom:
             secretKeyRef:
               name: unep-gpml
-              key: chat-api-domain-url
-        - name: CHAT_API_URL_PATH
-          valueFrom:
-            secretKeyRef:
-              name: unep-gpml
-              key: chat-api-url-path
-        - name: CHAT_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: unep-gpml
-              key: chat-api-key
-        - name: CHAT_API_USER_ID
-          valueFrom:
-            secretKeyRef:
-              name: unep-gpml
-              key: chat-api-user-id
+              key: dead-simple-chat-api-key
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: "/secrets/cloudsql/credentials.json"
         readinessProbe:


### PR DESCRIPTION
Also removes env vars no longer used following https://github.com/akvo/unep-gpml/pull/1807