### PR TITLE
HTTP client refinements

### DIFF
--- a/backend/src/gpml/util/http_client.clj
+++ b/backend/src/gpml/util/http_client.clj
@@ -111,6 +111,7 @@
          (log logger :info :requesting logged-req)
          (let [response (client/request (merge req {:content-type :json
                                                     :connection-timeout timeout
+                                                    :connection-request-timeout timeout
                                                     :socket-timeout timeout
                                                     :throw-exceptions false}))]
            (timbre/with-context+ {:response response}

--- a/backend/src/gpml/util/http_client.clj
+++ b/backend/src/gpml/util/http_client.clj
@@ -100,11 +100,13 @@
                      :fallback fallback
                      :on-retry (fn [_ e]
                                  (timbre/with-context+ {:request-id request-id
-                                                        :request req}
+                                                        :request req
+                                                        :timeout timeout}
                                    (log logger :error :request-retry e)))
                      :on-failure (fn [_ e]
                                    (timbre/with-context+ {:request-id request-id
-                                                          :request req}
+                                                          :request req
+                                                          :timeout timeout}
                                      (log logger :error :request-failure e)))}
        (timbre/with-context+ {:request-id request-id
                               :request req}


### PR DESCRIPTION
* Specify a `:connection-request-timeout`
* Log the http timeouts as adequate