### PR TITLE
Refactor chat channel joining

### DIFF
--- a/backend/dev/src/dev.clj
+++ b/backend/dev/src/dev.clj
@@ -54,6 +54,9 @@
 (defn component [c]
   (get system c))
 
+(defn hikari []
+  (component :duct.database.sql/hikaricp))
+
 (defn config-component []
   (get system [:duct/const :gpml.config/common]))
 

--- a/backend/resources/migrations/207-create_chat_channel_membership.up.sql
+++ b/backend/resources/migrations/207-create_chat_channel_membership.up.sql
@@ -1,7 +1,7 @@
--- NOTE: this table is discarded in the subsequent migration.
-CREATE TABLE chat_channel_input_box (
+DROP TABLE chat_channel_input_box;
+--;;
+CREATE TABLE chat_channel_membership (
   stakeholder_id INTEGER REFERENCES stakeholder(id) ON DELETE CASCADE,
   chat_channel_id TEXT NOT NULL,
-  enabled BOOLEAN NOT NULL DEFAULT FALSE,
   PRIMARY KEY (stakeholder_id, chat_channel_id)
 );

--- a/backend/resources/migrations/208-add_chat_channel_id_index.up.sql
+++ b/backend/resources/migrations/208-add_chat_channel_id_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_chat_channel_id ON chat_channel_membership (chat_channel_id);

--- a/backend/src/gpml/db.clj
+++ b/backend/src/gpml/db.clj
@@ -1,6 +1,7 @@
 (ns gpml.db
   (:require
    [clojure.java.jdbc :as jdbc]
+   [gpml.util.malli :refer [check! failure-with success-with]]
    [honey.sql]
    [integrant.core :as ig]
    [next.jdbc]
@@ -17,18 +18,44 @@
   (result-set-read-column [pgobj _metadata _i]
     (vec (.getArray pgobj))))
 
+(def Result
+  [:or
+   (success-with :result any?)
+   (failure-with :error-details [:map [:ex-class :string]])])
+
+;; XXX logger arg
 (defn execute! [hikari honey-data]
-  (let [formatted (honey.sql/format honey-data)]
-    (when *assert*
-      (timbre/info formatted))
-    (next.jdbc/execute! (-> hikari :spec :datasource)
-                        formatted
-                        {:builder-fn next.jdbc.result-set/as-unqualified-kebab-maps})))
+  {:post [(check! Result %)]}
+  (try
+    (let [formatted (honey.sql/format honey-data)
+          v (next.jdbc/execute! (-> hikari :spec :datasource)
+                                formatted
+                                {:builder-fn next.jdbc.result-set/as-unqualified-kebab-maps})]
+      (timbre/with-context+ {:sql-result v}
+        (when *assert*
+          (timbre/info formatted)))
+      {:success? true
+       :result v})
+    (catch Exception e
+      (timbre/error e)
+      {:success? false
+       :reason :exception
+       :error-details {:ex-class (-> e class str)}})))
 
 (defn execute-one! [hikari honey-data]
-  (let [formatted (honey.sql/format honey-data)]
-    (when *assert*
-      (timbre/info formatted))
-    (next.jdbc/execute-one! (-> hikari :spec :datasource)
-                            formatted
-                            {:builder-fn next.jdbc.result-set/as-unqualified-kebab-maps})))
+  {:post [(check! Result %)]}
+  (try
+    (let [formatted (honey.sql/format honey-data)
+          v (next.jdbc/execute-one! (-> hikari :spec :datasource)
+                                    formatted
+                                    {:builder-fn next.jdbc.result-set/as-unqualified-kebab-maps})]
+      (when *assert*
+        (timbre/with-context+ {:sql-result v}
+          (timbre/info formatted)))
+      {:success? true
+       :result v})
+    (catch Exception e
+      (timbre/error e)
+      {:success? false
+       :reason :exception
+       :error-details {:ex-class (-> e class str)}})))

--- a/backend/src/gpml/db.clj
+++ b/backend/src/gpml/db.clj
@@ -4,7 +4,8 @@
    [honey.sql]
    [integrant.core :as ig]
    [next.jdbc]
-   [next.jdbc.result-set])
+   [next.jdbc.result-set]
+   [taoensso.timbre :as timbre])
   (:import
    (org.postgresql.jdbc PgArray)))
 
@@ -16,13 +17,18 @@
   (result-set-read-column [pgobj _metadata _i]
     (vec (.getArray pgobj))))
 
-;; XXX SQL logging
 (defn execute! [hikari honey-data]
-  (next.jdbc/execute! (-> hikari :spec :datasource)
-                      (honey.sql/format honey-data)
-                      {:builder-fn next.jdbc.result-set/as-unqualified-kebab-maps}))
+  (let [formatted (honey.sql/format honey-data)]
+    (when *assert*
+      (timbre/info formatted))
+    (next.jdbc/execute! (-> hikari :spec :datasource)
+                        formatted
+                        {:builder-fn next.jdbc.result-set/as-unqualified-kebab-maps})))
 
 (defn execute-one! [hikari honey-data]
-  (next.jdbc/execute-one! (-> hikari :spec :datasource)
-                          (honey.sql/format honey-data)
-                          {:builder-fn next.jdbc.result-set/as-unqualified-kebab-maps}))
+  (let [formatted (honey.sql/format honey-data)]
+    (when *assert*
+      (timbre/info formatted))
+    (next.jdbc/execute-one! (-> hikari :spec :datasource)
+                            formatted
+                            {:builder-fn next.jdbc.result-set/as-unqualified-kebab-maps})))

--- a/backend/src/gpml/handler/chat.clj
+++ b/backend/src/gpml/handler/chat.clj
@@ -370,10 +370,6 @@ so you don't need to call the POST /api/chat/user/account endpoint beforehand."
                         :content-type :json
                         :as :json-keyword-keys})
 
-  (port.chat/add-user-to-public-channel (dev/component :gpml.boundary.adapter.chat/ds-chat) ;; XXX should add user to the table
-                                        (:chat_account_id (gpml.db.stakeholder/stakeholder-by-email (dev/conn) {:email "abc@abc.net"}))
-                                        channel-id)
-
   ;; should include the user that joined with the earlier http://localhost:3000/api/chat/channel/public call
   (http-client/request (dev/logger)
                        {:url (str "http://localhost:3000/api/chat/channel/details/" channel-id)

--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -33,7 +33,7 @@
    [gpml.handler.responses :as r]
    [gpml.handler.stakeholder.tag :as handler.stakeholder.tag]
    [gpml.service.association :as srv.association]
-   [gpml.service.chat :as srv.chat]
+   [gpml.service.chat :as svc.chat]
    [gpml.service.file :as srv.file]
    [gpml.service.permissions :as srv.permissions]
    [gpml.util :as util]
@@ -468,7 +468,7 @@
             (if-not (and (= resource-type "stakeholder")
                          (seq (:chat_account_id resource)))
               context
-              (let [result (srv.chat/create-user-account config (:id resource))]
+              (let [result (svc.chat/create-user-account config (:id resource))]
                 (if (:success? result)
                   context
                   (do

--- a/backend/src/gpml/service/chat.clj
+++ b/backend/src/gpml/service/chat.clj
@@ -9,7 +9,8 @@
    [gpml.service.file :as srv.file]
    [gpml.util.email :as util.email]
    [gpml.util.malli :refer [check!]]
-   [gpml.util.thread-transactions :as tht]))
+   [gpml.util.thread-transactions :as tht]
+   [taoensso.timbre :as timbre]))
 
 (defn- select-successful-user-creation-keys
   "Exists to ensure type homogeinity across code branches"
@@ -167,71 +168,78 @@
   (-> user
       (select-keys [:role :tags :picture_file :first_name :picture_id :org :id :picture :organisation_role :last_name :country])))
 
-(defn get-channel-details [{:keys [db chat-adapter logger] :as config} channel-id]
+(defn get-channel-details [{:keys [db hikari chat-adapter logger] :as config} channel-id]
+  {:pre [db hikari chat-adapter logger channel-id]}
   (let [transactions
-        [{:txn-fn
-          (fn tx-get-channel [context]
-            (let [result (port.chat/get-channel chat-adapter channel-id)]
-              (if (:success? result)
-                (assoc context :channel (:channel result))
-                (assoc context
-                       :success? false
-                       :reason :failed-to-get-channel
-                       :error-details {:result result}))))}
-         {:txn-fn
-          (fn tx-get-channel-discussions [context]
-            (let [result (port.chat/get-channel-discussions chat-adapter channel-id)]
-              (if (:success? result)
-                (assoc-in context [:channel :discussions] (:discussions result))
-                (assoc context
-                       :success? false
-                       :reason :failed-to-get-channel-discussions
-                       :error-details {:result result}))))}
-         {:txn-fn
-          (fn tx-get-channel-users [{:keys [channel] :as context}]
-            (let [chat-account-ids (->> channel
-                                        :members
-                                        :data
-                                        (mapv :unique-user-identifier))
-                  result (try
-                           (if (seq chat-account-ids)
-                             {:success? true
-                              :stakeholders (find-users-by-chat-account-id db chat-account-ids)}
-                             (do
-                               (log logger :warn :empty-chat-account-ids)
-                               {:success? true
-                                :stakeholders []}))
-                           (catch Exception t
-                             (log logger :error :could-not-get-stakeholders t)
-                             {:success? false
-                              :reason :exception
-                              :error-details {:msg (ex-message t)}}))]
-              (-> (if (:success? result)
-                    (assoc-in context [:channel :users] (->> (:stakeholders result)
-                                                             (add-users-pictures-urls config)
-                                                             (mapv present-user)))
-                    (assoc context
-                           :success? false
-                           :reason :failed-to-get-channel-users
-                           :error-details {:result result}))
-                  ;; No longer needed / can be confusing to include it:
-                  (update :channel dissoc :members))))}
-         {:txn-fn
-          (fn enrich-messages-users [context]
-            (try
-              (update-in context [:channel :messages :messages] (fn [messages]
-                                                                  (mapv (fn [{:keys [chat-account-id] :as message}]
-                                                                          {:pre [chat-account-id]}
-                                                                          (let [[user] (find-users-by-chat-account-id db [chat-account-id])]
-                                                                            (-> message
-                                                                                (dissoc :chat-account-id)
-                                                                                (assoc :user (present-user user)))))
-                                                                        messages)))
-              (catch Exception t
-                (log logger :error :could-not-get-stakeholders t)
-                {:success? false
-                 :reason :exception
-                 :error-details {:msg (ex-message t)}})))}]
+        [(fn tx-get-channel [context]
+           (let [result (port.chat/get-channel chat-adapter channel-id)]
+             (if (:success? result)
+               (assoc context :channel (:channel result))
+               (assoc context
+                      :success? false
+                      :reason :failed-to-get-channel
+                      :error-details {:result result}))))
+         (fn tx-get-channel-discussions [context]
+           (let [result (port.chat/get-channel-discussions chat-adapter channel-id)]
+             (if (:success? result)
+               (assoc-in context [:channel :discussions] (:discussions result))
+               (assoc context
+                      :success? false
+                      :reason :failed-to-get-channel-discussions
+                      :error-details {:result result}))))
+         (fn tx-get-channel-users [{:keys [channel] :as context}]
+           (let [;; Unused for now. Maybe we can use it to insert missing users due to plausible sync issues:
+                 _chat-account-ids-from-dsc (->> channel
+                                                 :members
+                                                 :data
+                                                 (mapv :unique-user-identifier))
+                 chat-account-ids-from-db (db/execute-one! hikari {:select :stakeholder.chat_account_id
+                                                                   :from :stakeholder
+                                                                   :join [:chat_channel_membership
+                                                                          [:=
+                                                                           :stakeholder.id
+                                                                           :chat_channel_membership.stakeholder_id]]
+                                                                   :where [:= :chat_channel_id channel-id]})
+                 chat-account-ids chat-account-ids-from-db
+                 result (try
+                          (if (seq chat-account-ids)
+                            {:success? true
+                             :stakeholders (find-users-by-chat-account-id db chat-account-ids)}
+                            (do
+                              (timbre/with-context+ {:channel channel}
+                                (log logger :warn :empty-chat-account-ids))
+                              {:success? true
+                               :stakeholders []}))
+                          (catch Exception t
+                            (log logger :error :could-not-get-stakeholders t)
+                            {:success? false
+                             :reason :exception
+                             :error-details {:msg (ex-message t)}}))]
+             (-> (if (:success? result)
+                   (assoc-in context [:channel :users] (->> (:stakeholders result)
+                                                            (add-users-pictures-urls config)
+                                                            (mapv present-user)))
+                   (assoc context
+                          :success? false
+                          :reason :failed-to-get-channel-users
+                          :error-details {:result result}))
+                 ;; No longer needed / can be confusing to include it:
+                 (update :channel dissoc :members))))
+         (fn enrich-messages-users [context]
+           (try
+             (update-in context [:channel :messages :messages] (fn [messages]
+                                                                 (mapv (fn [{:keys [chat-account-id] :as message}]
+                                                                         {:pre [chat-account-id]}
+                                                                         (let [[user] (find-users-by-chat-account-id db [chat-account-id])]
+                                                                           (-> message
+                                                                               (dissoc :chat-account-id)
+                                                                               (assoc :user (present-user user)))))
+                                                                       messages)))
+             (catch Exception t
+               (log logger :error :could-not-get-stakeholders t)
+               {:success? false
+                :reason :exception
+                :error-details {:msg (ex-message t)}})))]
         context {:success? true
                  :channel-id channel-id}]
     (tht/thread-transactions logger transactions context)))
@@ -244,8 +252,13 @@
                                                                           channel-id
                                                                           channel-name)))
 
-(defn join-channel [{:keys [db hikari chat-adapter logger] :as config} channel-id user-id private?]
-  {:pre [db hikari chat-adapter logger channel-id user-id
+(defn join-channel [{:keys [db hikari chat-adapter logger] :as config}
+                    channel-id
+                    {user-id :id
+                     unique-user-identifier :chat-channel-id
+                     :as _user}
+                    private?]
+  {:pre [db hikari chat-adapter logger user-id
          (check! :boolean private?)]}
   (let [transactions
         [(fn get-channel [_context]
@@ -263,9 +276,13 @@
 
          (when private?
            {:txn-fn (fn add-to-dsc [_context]
-                      (port.chat/add-user-to-private-channel chat-adapter user-id channel-id))
+                      (if unique-user-identifier
+                        (port.chat/add-user-to-private-channel chat-adapter unique-user-identifier channel-id)
+                        {:success? false}))
             :rollback-fn (fn remove-from-dsc [_context]
-                           (port.chat/remove-user-from-channel chat-adapter user-id channel-id :_))})
+                           (if unique-user-identifier
+                             (port.chat/remove-user-from-channel chat-adapter unique-user-identifier channel-id :_)
+                             {:success? false}))})
 
          {:txn-fn (fn add-to-tables [_context]
                     (db/execute-one! hikari {:insert-into :chat_channel_membership

--- a/backend/src/gpml/service/plastic_strategy.clj
+++ b/backend/src/gpml/service/plastic_strategy.clj
@@ -2,7 +2,6 @@
   (:require
    [duct.logger :refer [log]]
    [gpml.boundary.port.chat :as port.chat]
-   [gpml.db :as db]
    [gpml.db.plastic-strategy :as db.ps]
    [gpml.db.plastic-strategy.team :as db.ps.team]
    [gpml.service.chat :as svc.chat]
@@ -104,9 +103,9 @@
             (let [_custom-fields {:ps-country-iso-code-a2 (get-in plastic-strategy [:country :iso-code-a2])}
                   #_#_result {}
                   #_;; XXX
-                    (port.chat/set-public-channel-custom-fields (:chat-adapter config)
-                                                                (:id channel)
-                                                                custom-fields)]
+                  (port.chat/set-public-channel-custom-fields (:chat-adapter config)
+                                                              (:id channel)
+                                                              custom-fields)]
               #_(if 1  ;; (:success? result)
                   )
               context
@@ -213,7 +212,7 @@
                   (log logger :error :rollback-assign-plastic-strategy-rbac-role {:reason result})))
               context))}
          {:txn-fn
-          (fn add-user-to-ps-channel [{:keys [plastic-strategy ps-team-member chat-account-id] :as context}]
+          (fn add-user-to-ps-channel [{:keys [plastic-strategy ps-team-member] :as context}]
             {:pre [ps-team-member]}
             (let [result (svc.chat/join-channel config
                                                 (:chat-channel-id plastic-strategy)

--- a/backend/src/gpml/service/plastic_strategy.clj
+++ b/backend/src/gpml/service/plastic_strategy.clj
@@ -2,9 +2,10 @@
   (:require
    [duct.logger :refer [log]]
    [gpml.boundary.port.chat :as port.chat]
+   [gpml.db :as db]
    [gpml.db.plastic-strategy :as db.ps]
    [gpml.db.plastic-strategy.team :as db.ps.team]
-   [gpml.service.chat :as srv.chat]
+   [gpml.service.chat :as svc.chat]
    [gpml.service.permissions :as srv.permissions]
    [gpml.util.thread-transactions :as tht]
    [taoensso.timbre :as timbre]))
@@ -19,7 +20,8 @@
   (db.ps/update-plastic-strategy (:spec db) {:id id
                                              :updates {:steps steps}}))
 
-(defn create-plastic-strategy [{:keys [db logger] :as config} ps-payload]
+(defn create-plastic-strategy [{:keys [db hikari logger] :as config} ps-payload]
+  {:pre [db hikari logger]}
   (let [transactions
         [{:txn-fn
           (fn tx-create-plastic-strategy
@@ -211,34 +213,19 @@
                   (log logger :error :rollback-assign-plastic-strategy-rbac-role {:reason result})))
               context))}
          {:txn-fn
-          (fn create-chat-account
-            [{:keys [ps-team-member] :as context}]
-            (let [result (srv.chat/create-user-account config (:id ps-team-member))]
-              (if (:success? result)
-                (assoc context :chat-account-id (get-in result [:chat-user-account :id]))
-                (assoc context
-                       :reason :failed-to-create-chat-account
-                       :error-details {:result result}))))
-          :rollback-fn
-          (fn rollback-create-chat-account
-            [{:keys [chat-account-id] :as context}]
-            (let [result (port.chat/delete-user-account (:chat-adapter config) chat-account-id {})]
-              (when-not (:success? result)
-                (timbre/with-context+ {::context context}
-                  (log logger :error :failed-to-rollback-create-chat-account {:result result}))))
-            context)}
-         {:txn-fn
-          (fn add-user-to-ps-channel
-            [{:keys [plastic-strategy chat-account-id] :as context}]
-            (let [result (port.chat/add-user-to-public-channel (:chat-adapter config)
-                                                               chat-account-id
-                                                               (:chat-channel-id plastic-strategy))]
+          (fn add-user-to-ps-channel [{:keys [plastic-strategy ps-team-member chat-account-id] :as context}]
+            {:pre [ps-team-member]}
+            (let [result (svc.chat/join-channel config
+                                                (:chat-channel-id plastic-strategy)
+                                                ps-team-member
+                                                false)]
               (if (:success? result)
                 context
                 (assoc context
                        :success? false
                        :reason :failed-to-add-user-to-ps-channel
-                       :error-details {:result result}))))}]
+                       :error-details {:result result}))))
+          #_:rollback-fn}]
         context {:success? true
                  :user-id user-id}]
     (tht/thread-transactions logger transactions context)))

--- a/backend/src/gpml/service/plastic_strategy/team.clj
+++ b/backend/src/gpml/service/plastic_strategy/team.clj
@@ -4,7 +4,7 @@
    [gpml.boundary.port.chat :as port.chat]
    [gpml.db.plastic-strategy.team :as db.ps.team]
    [gpml.db.stakeholder :as db.stakeholder]
-   [gpml.service.chat :as srv.chat]
+   [gpml.service.chat :as svc.chat]
    [gpml.service.invitation :as srv.invitation]
    [gpml.service.permissions :as srv.permissions]
    [gpml.service.plastic-strategy :as srv.ps]
@@ -89,7 +89,7 @@
             (if (seq (:chat-account-id ps-team-member))
               context
               (let [{:keys [success? chat-user-account] :as result}
-                    (srv.chat/create-user-account config (:id ps-team-member))]
+                    (svc.chat/create-user-account config (:id ps-team-member))]
                 (if success?
                   (-> context
                       (assoc-in [:ps-team-member :chat-account-id] (:id chat-user-account))
@@ -115,9 +115,10 @@
          {:txn-fn
           (fn tx-add-team-member-to-ps-chat-channel
             [{:keys [ps-team-member plastic-strategy] :as context}]
-            (let [result (port.chat/add-user-to-public-channel (:chat-adapter config)
-                                                               (:chat-account-id ps-team-member)
-                                                               (:chat-channel-id plastic-strategy))]
+            (let [result (svc.chat/join-channel config
+                                                (:chat-channel-id plastic-strategy)
+                                                ps-team-member
+                                                false)]
               (if (:success? result)
                 {:success? true}
                 (assoc context
@@ -321,9 +322,10 @@
             [{:keys [plastic-strategy ps-team-member] :as context}]
             (if-not (seq (:chat-account-id ps-team-member))
               context
-              (let [result (port.chat/add-user-to-public-channel (:chat-adapter config)
-                                                                 (:chat-account-id ps-team-member)
-                                                                 (:chat-channel-id plastic-strategy))]
+              (let [result (svc.chat/join-channel config
+                                                  (:chat-channel-id plastic-strategy)
+                                                  ps-team-member
+                                                  false)]
                 (if (:success? result)
                   context
                   (do

--- a/backend/src/gpml/service/stakeholder.clj
+++ b/backend/src/gpml/service/stakeholder.clj
@@ -8,7 +8,7 @@
    [gpml.domain.file :as dom.file]
    [gpml.handler.organisation :as handler.org]
    [gpml.handler.stakeholder.tag :as handler.stakeholder.tag]
-   [gpml.service.chat :as srv.chat]
+   [gpml.service.chat :as svc.chat]
    [gpml.service.file :as srv.file]
    [gpml.service.permissions :as srv.permissions]
    [gpml.service.plastic-strategy :as srv.ps]
@@ -209,7 +209,7 @@
           (fn create-chat-account
             [{:keys [stakeholder] :as context}]
             (let [{success? :success? updated-user :stakeholder :as result}
-                  (srv.chat/create-user-account config (:id stakeholder))]
+                  (svc.chat/create-user-account config (:id stakeholder))]
               (if success?
                 (-> context
                     (assoc-in [:stakeholder :chat_account_id] (:chat-account-id updated-user))

--- a/backend/src/gpml/util/thread_transactions.clj
+++ b/backend/src/gpml/util/thread_transactions.clj
@@ -55,6 +55,7 @@
                                          ;; Support shorthand syntax:
                                          {:txn-fn head})
           result (safe-run logger txn-fn args-map)]
+      (assert (contains? result :success?))
       (if-not (:success? result)
         result
         (let [next-result (thread-transactions logger (rest txns) result)]


### PR DESCRIPTION
Now joining a channel is performed primarily though the service, which takes care of DSC-level joning, and DB-level persistence.

Membership queries now hit our DB, not DSC.