### PR TITLE
Undo a comment from a migration

### DIFF
--- a/backend/resources/migrations/206-create-chat-channel-metadata.up.sql
+++ b/backend/resources/migrations/206-create-chat-channel-metadata.up.sql
@@ -1,4 +1,3 @@
--- NOTE: this table is discarded in the subsequent migration.
 CREATE TABLE chat_channel_input_box (
   stakeholder_id INTEGER REFERENCES stakeholder(id) ON DELETE CASCADE,
   chat_channel_id TEXT NOT NULL,


### PR DESCRIPTION
Chaning migrations' contents alters their sha, foiling migrations application in production.