### PR TITLE
Upgrade `timbre-json-appender`, use it in CI

### DIFF
--- a/backend/project.clj
+++ b/backend/project.clj
@@ -71,7 +71,7 @@
                  [ring-cors "0.1.13"]
                  [ring/ring-jetty-adapter "1.8.2"]
                  [twarc "0.1.15"]
-                 [viesti/timbre-json-appender "0.2.11" :exclusions [metosin/jsonista]]]
+                 [viesti/timbre-json-appender "0.2.12" :exclusions [metosin/jsonista]]]
   :resource-paths ["resources"]
   :prep-tasks     ["javac" "compile"]
   :jvm-opts ["-Djava.awt.headless=true"]

--- a/backend/test-resources/gpml/test-ci.edn
+++ b/backend/test-resources/gpml/test-ci.edn
@@ -1,0 +1,9 @@
+;; This file is used in CI to enable timbre-logger.json/logger as the sole logger.
+;; It's useful there since that logger shows all the contexts (per `timbre/with-context+`).
+{:gpml.timbre-logger.json/logger {}
+ :duct.logger/timbre             {:min-level        :debug
+                                  :level            :debug
+                                  :appenders        {:out #ig/ref :gpml.timbre-logger.json/logger}
+                                  :set-root-config? true}
+ :duct.logger.timbre/println     {:enabled? false}
+ :duct.logger.timbre/brief       {:enabled? false}}


### PR DESCRIPTION
 It's useful to use JSON logging in CI, since  the `timbre-json-appender` logger shows all the contexts (per `timbre/with-context+`).