### PR TITLE
Fixes mar 13

### DIFF
--- a/backend/src/gpml/boundary/adapter/chat/ds_chat.clj
+++ b/backend/src/gpml/boundary/adapter/chat/ds_chat.clj
@@ -277,6 +277,8 @@
                                                        (mapv (fn [{:keys [message created user]}]
                                                                {:message message
                                                                 :created created
+                                                                ;; We pass :chat-account-id for the service to retrieve users from the DB later.
+                                                                ;; Note that this is a sensitive field that is removed from HTTP responses.
                                                                 :chat-account-id (:unique-user-identifier user)
                                                                 :username (:username user)})
                                                              messages)))))})))))))

--- a/backend/src/gpml/handler/chat.clj
+++ b/backend/src/gpml/handler/chat.clj
@@ -417,6 +417,9 @@ so you don't need to call the POST /api/chat/user/account endpoint beforehand."
                         :content-type :json
                         :as :json-keyword-keys})
 
+  (let [cid (:chat_account_id (gpml.db.stakeholder/stakeholder-by-email (dev/conn) {:email "abc@abc.net"}))]
+    (println (format "https://deadsimplechat.com/%s?uniqueUserIdentifier=%s" channel-id cid)))
+
   ;; should include the user that joined with the earlier http://localhost:3000/api/chat/channel/public call
   (http-client/request (dev/logger)
                        {:url (str "http://localhost:3000/api/chat/channel/details/" channel-id)

--- a/backend/src/gpml/service/chat.clj
+++ b/backend/src/gpml/service/chat.clj
@@ -332,9 +332,12 @@
 (defn join-channel [{:keys [db hikari chat-adapter logger] :as config}
                     channel-id
                     {user-id :id
-                     unique-user-identifier :chat-channel-id
-                     :as _user}]
-  {:pre [db hikari chat-adapter logger channel-id user-id unique-user-identifier]}
+                     unique-user-identifier :chat_account_id
+                     :as user}]
+  {:pre [db hikari chat-adapter logger channel-id user-id
+         (check! [:map [:chat_account_id some?]]
+                 user)
+         unique-user-identifier]}
   (saga logger (create-user-account config user-id)
     (partial assoc-private config channel-id)
 


### PR DESCRIPTION
* Correctly destructure `unique-user-identifier`
* Remove `:chat-account-id` from a Swagger schema
  * It's a property used internally and removed before being returned over HTTP.