### PR TITLE
Make org name optional

### DIFF
--- a/backend/src/gpml/boundary/port/chat.clj
+++ b/backend/src/gpml/boundary/port/chat.clj
@@ -134,7 +134,7 @@
 
 (def Org
   [:map {:closed true}
-   [:name :string]])
+   [:name {:optional true} :string]])
 
 (def PresentedUser
   [:map


### PR DESCRIPTION
@martinchristov NOTE: org name is now optional in the related Chat endpoint, reflecting the DB schema.

Swagger was more strict than our DB in this case.