### PR TITLE
Make the `/channel/public` and `/channel/private` endpoints accurate

### DIFF
--- a/backend/src/gpml/service/chat.clj
+++ b/backend/src/gpml/service/chat.clj
@@ -327,7 +327,7 @@
       result
       (assoc context :private? (-> result :channel
                                    (find :privacy)
-                                   (doto (assert "`:privacy` should be in the `:channel object`"))
+                                   (doto (assert "`:privacy` should be in the `:channel` object"))
                                    val
                                    (= port.chat/private))))))
 


### PR DESCRIPTION
Until now, they returned all channels. Now we're able for them to only return public and private channels, respectively.

cc @martinchristov 