### PR TITLE
Fix `/user/channel` endpoint to not return channels that the user left

### DIFF
--- a/backend/src/gpml/boundary/adapter/chat/ds_chat.clj
+++ b/backend/src/gpml/boundary/adapter/chat/ds_chat.clj
@@ -338,15 +338,7 @@
           :else
           {:success? true
            :channels (into []
-                           (comp (filter (comp valid-ids :id))
-                                 (remove (fn [{:keys [privacy] :as channel}]
-                                           {:pre [(check! port.chat/Channel channel
-                                                          port.chat/ChannelPrivacy privacy)]}
-                                           ;; DSC likes to return public channels in the "/api/v2/user/$user-id/rooms" endpoint
-                                           ;; for a given user
-                                           ;; even though it has no API concept of joining a public channel.
-                                           ;; Remove those:
-                                           (= privacy port.chat/public))))
+                           (filter (comp valid-ids :id))
                            (:channels all))}))
       {:success? false
        :reason :failed-to-add-user-to-channel


### PR DESCRIPTION
This one really fixes it after the insufficient https://github.com/akvo/unep-gpml/pull/1856

It's tricky as internally, channels have to, simultaneously:

- include specified channels (per our DB)
- exclude channels that DSC considers as user-joined (even if there's no such concept for them, as far as public channels go)