### PR TITLE
Implement admin 'add user to channel' endpoint

### DIFF
--- a/backend/src/gpml/service/chat.clj
+++ b/backend/src/gpml/service/chat.clj
@@ -45,7 +45,9 @@
       {:success? false
        :reason :failed-to-update-stakeholder})))
 
-(defn create-user-account [{:keys [db chat-adapter logger] :as config} user-id]
+(defn create-user-account
+  "Idempotent - also returns success if the stakeholder and/or chat account already existed."
+  [{:keys [db chat-adapter logger] :as config} user-id]
   {:post [(check! [:or
                    (success-with :stakeholder CreatedUser)
                    (failure-with :reason any?)]


### PR DESCRIPTION
Idempotently ensures that the given user has a chat account.

[http://localhost:3000/api/docs/index.html#/chat/post_api_chat_admin_channel__id__add_user__user_id_](http://localhost:3000/api/docs/index.html#/chat/post_api_chat_admin_channel__id__add_user__user_id_)

@martinchristov 