### PR TITLE
Implement Plastic Stragegy `/ensure-chat` endpoint

### DIFF
--- a/backend/resources/gpml/duct.base.edn
+++ b/backend/resources/gpml/duct.base.edn
@@ -610,6 +610,15 @@
                                    :handler    #ig/ref :gpml.handler.plastic-strategy/get-all
                                    :parameters #ig/ref :gpml.handler.plastic-strategy/get-all-params}}]
                            ["/{iso_code_a2}"
+                            ["/ensure-chat"
+                             {:post {:summary    "Ensures that this plastic strategy has an existing, valid associated chat channel. Idempotent. Admin only."
+                                     :middleware  [#ig/ref :gpml.auth/auth-middleware
+                                                   #ig/ref :gpml.auth/auth-required
+                                                   #ig/ref :gpml.auth/admin-auth-required]
+                                     :swagger    {:tags ["plastic-strategy" "admin"]}
+                                     :handler    #ig/ref :gpml.handler.plastic-strategy/admin-ensure-chat
+                                     :parameters #ig/ref :gpml.handler.plastic-strategy/admin-ensure-chat-params
+                                     :responses  #ig/ref :gpml.handler.plastic-strategy/admin-ensure-chat-responses}}]
                             [""
                              {:get {:summary    "Get a plastic strategy"
                                     :middleware [#ig/ref :gpml.auth/auth-middleware
@@ -920,6 +929,9 @@
  :gpml.handler.plastic-strategy/get-all-params                      {}
  :gpml.handler.plastic-strategy/get                                 #ig/ref :gpml.config/common
  :gpml.handler.plastic-strategy/get-params                          {}
+ :gpml.handler.plastic-strategy/admin-ensure-chat                   #ig/ref :gpml.config/common
+ :gpml.handler.plastic-strategy/admin-ensure-chat-params            {}
+ :gpml.handler.plastic-strategy/admin-ensure-chat-responses         {}
  :gpml.handler.plastic-strategy/update-steps                        #ig/ref :gpml.config/common
  :gpml.handler.plastic-strategy/update-steps-params                 {}
  :gpml.handler.plastic-strategy.team/get-members                    #ig/ref :gpml.config/common

--- a/backend/src/gpml/db/plastic_strategy.clj
+++ b/backend/src/gpml/db/plastic_strategy.clj
@@ -12,7 +12,9 @@
 
 (hugsql/def-db-fns "gpml/db/plastic_strategy.sql")
 
-(defn get-plastic-strategies [conn opts]
+(defn get-plastic-strategies
+  "Returned in kebab-case."
+  [conn opts]
   (try
     {:success? true
      :plastic-strategies (jdbc-util/db-result-snake-kw->db-result-kebab-kw
@@ -23,7 +25,9 @@
        :reason :exception
        :error-details {:msg (ex-message t)}})))
 
-(defn get-plastic-strategy [conn opts]
+(defn get-plastic-strategy
+  "Returned in kebab-case."
+  [conn opts]
   (try
     (let [{:keys [success? plastic-strategies] :as result}
           (get-plastic-strategies conn opts)]

--- a/backend/src/gpml/handler/browse.clj
+++ b/backend/src/gpml/handler/browse.clj
@@ -12,7 +12,7 @@
    [gpml.handler.responses :as r]
    [gpml.handler.util :as handler.util]
    [gpml.service.file :as srv.file]
-   [gpml.service.plastic-strategy :as srv.ps]
+   [gpml.service.plastic-strategy :as svc.ps]
    [gpml.util.postgresql :as pg-util]
    [gpml.util.regular-expressions :as util.regex]
    [integrant.core :as ig]
@@ -418,7 +418,7 @@ This filter requires the 'ps_country_iso_code_a2' to be set."
     api-search-opts
     (let [search-opts {:filters {:countries-iso-codes-a2 [ps-country-iso-code-a2]}}
           {:keys [success? plastic-strategy]}
-          (srv.ps/get-plastic-strategy config search-opts)]
+          (svc.ps/get-plastic-strategy config search-opts)]
       (if success?
         (assoc api-search-opts :plastic-strategy-id (:id plastic-strategy))
         api-search-opts))))

--- a/backend/src/gpml/handler/organisation.clj
+++ b/backend/src/gpml/handler/organisation.clj
@@ -15,7 +15,7 @@
    [gpml.handler.responses :as r]
    [gpml.service.file :as srv.file]
    [gpml.service.permissions :as srv.permissions]
-   [gpml.service.plastic-strategy :as srv.ps]
+   [gpml.service.plastic-strategy :as svc.ps]
    [gpml.util :as util]
    [gpml.util.email :as email]
    [gpml.util.geo :as geo]
@@ -300,7 +300,7 @@
     api-search-opts
     (let [search-opts {:filters {:countries-iso-codes-a2 [ps-country-iso-code-a2]}}
           {:keys [success? plastic-strategy]}
-          (srv.ps/get-plastic-strategy config search-opts)]
+          (svc.ps/get-plastic-strategy config search-opts)]
       (if success?
         (assoc api-search-opts :plastic-strategy-id (:id plastic-strategy))
         api-search-opts))))

--- a/backend/src/gpml/handler/plastic_strategy/bookmark.clj
+++ b/backend/src/gpml/handler/plastic_strategy/bookmark.clj
@@ -6,8 +6,8 @@
    [gpml.domain.types :as dom.types]
    [gpml.handler.resource.permission :as h.r.permission]
    [gpml.handler.responses :as r]
-   [gpml.service.plastic-strategy :as srv.ps]
-   [gpml.service.plastic-strategy.bookmark :as srv.ps.bookmark]
+   [gpml.service.plastic-strategy :as svc.ps]
+   [gpml.service.plastic-strategy.bookmark :as svc.ps.bookmark]
    [integrant.core :as ig]))
 
 (def ^:private common-ps-bookmark-path-params-schema
@@ -43,7 +43,7 @@
   (let [country-iso-code-a2 (get-in parameters [:path :iso_code_a2])
         search-opts {:filters {:countries-iso-codes-a2 [country-iso-code-a2]}}
         {:keys [success? plastic-strategy reason] :as get-ps-result}
-        (srv.ps/get-plastic-strategy config search-opts)]
+        (svc.ps/get-plastic-strategy config search-opts)]
     (if-not success?
       (if (= reason :not-found)
         (r/not-found {})
@@ -57,7 +57,7 @@
         (r/forbidden {:message "Unauthorized"})
         (let [body-params (-> (cske/transform-keys ->kebab-case (:body parameters))
                               (assoc :plastic-strategy-id (:id plastic-strategy)))
-              result (srv.ps.bookmark/handle-ps-bookmark config body-params)]
+              result (svc.ps.bookmark/handle-ps-bookmark config body-params)]
           (if (:success? result)
             (r/ok {})
             (if (= (:reason result) :already-exists)

--- a/backend/src/gpml/handler/plastic_strategy/file.clj
+++ b/backend/src/gpml/handler/plastic_strategy/file.clj
@@ -5,8 +5,8 @@
    [clojure.string :as str]
    [gpml.handler.resource.permission :as h.r.permission]
    [gpml.handler.responses :as r]
-   [gpml.service.plastic-strategy :as srv.ps]
-   [gpml.service.plastic-strategy.file :as srv.ps.file]
+   [gpml.service.plastic-strategy :as svc.ps]
+   [gpml.service.plastic-strategy.file :as svc.ps.file]
    [gpml.util :as util]
    [integrant.core :as ig]
    [malli.util :as mu]))
@@ -49,7 +49,7 @@
   (let [country-iso-code-a2 (:iso_code_a2 path)
         search-opts {:filters {:countries-iso-codes-a2 [country-iso-code-a2]}}
         {:keys [success? plastic-strategy reason] :as get-ps-result}
-        (srv.ps/get-plastic-strategy config search-opts)]
+        (svc.ps/get-plastic-strategy config search-opts)]
     (if-not success?
       (if (= reason :not-found)
         (r/not-found {})
@@ -63,7 +63,7 @@
         (r/forbidden {:message "Unauthorized"})
         (let [body-params (-> (cske/transform-keys ->kebab-case body)
                               (assoc :plastic-strategy-id (:id plastic-strategy)))
-              result (srv.ps.file/create-ps-file config
+              result (svc.ps.file/create-ps-file config
                                                  body-params)]
           (if (:success? result)
             (r/ok {})
@@ -73,7 +73,7 @@
   (let [country-iso-code-a2 (:iso_code_a2 path)
         search-opts {:filters {:countries-iso-codes-a2 [country-iso-code-a2]}}
         {:keys [success? plastic-strategy reason] :as get-ps-result}
-        (srv.ps/get-plastic-strategy config search-opts)]
+        (svc.ps/get-plastic-strategy config search-opts)]
     (if-not success?
       (if (= reason :not-found)
         (r/not-found {})
@@ -87,7 +87,7 @@
         (r/forbidden {:message "Unauthorized"})
         (let [body-params (-> (cske/transform-keys ->kebab-case body)
                               (assoc :plastic-strategy-id (:id plastic-strategy)))
-              result (srv.ps.file/delete-ps-file config
+              result (svc.ps.file/delete-ps-file config
                                                  body-params)]
           (if (:success? result)
             (r/ok {})
@@ -97,7 +97,7 @@
   (let [country-iso-code-a2 (:iso_code_a2 path)
         search-opts {:filters {:countries-iso-codes-a2 [country-iso-code-a2]}}
         {:keys [success? plastic-strategy reason] :as get-ps-result}
-        (srv.ps/get-plastic-strategy config search-opts)]
+        (svc.ps/get-plastic-strategy config search-opts)]
     (if-not success?
       (if (= reason :not-found)
         (r/not-found {})
@@ -112,7 +112,7 @@
         (let [search-opts {:filters (cond-> {:plastic-strategies-ids [(:id plastic-strategy)]}
                                       (:section_key query)
                                       (assoc :sections-keys [(:section_key query)]))}
-              result (srv.ps.file/get-ps-files config
+              result (svc.ps.file/get-ps-files config
                                                search-opts)]
           (if (:success? result)
             (r/ok (cske/transform-keys ->snake_case (:ps-files result)))

--- a/backend/src/gpml/handler/plastic_strategy/team.clj
+++ b/backend/src/gpml/handler/plastic_strategy/team.clj
@@ -6,8 +6,8 @@
    [gpml.domain.types :as dom.types]
    [gpml.handler.resource.permission :as h.r.permission]
    [gpml.handler.responses :as r]
-   [gpml.service.plastic-strategy :as srv.ps]
-   [gpml.service.plastic-strategy.team :as srv.ps.team]
+   [gpml.service.plastic-strategy :as svc.ps]
+   [gpml.service.plastic-strategy.team :as svc.ps.team]
    [gpml.util :as util]
    [gpml.util.malli :as util.malli]
    [integrant.core :as ig]
@@ -65,7 +65,7 @@
   (let [country-iso-code-a2 (:iso_code_a2 path)
         search-opts {:filters {:countries-iso-codes-a2 [country-iso-code-a2]}}
         {:keys [success? plastic-strategy reason] :as get-ps-result}
-        (srv.ps/get-plastic-strategy config search-opts)]
+        (svc.ps/get-plastic-strategy config search-opts)]
     (if-not success?
       (if (= reason :not-found)
         (r/not-found {})
@@ -79,7 +79,7 @@
         (r/forbidden {:message "Unauthorized"})
         (let [body-params (-> (cske/transform-keys ->kebab-case body)
                               (assoc :plastic-strategy-id (:id plastic-strategy)))
-              result (srv.ps.team/add-ps-team-member config
+              result (svc.ps.team/add-ps-team-member config
                                                      plastic-strategy
                                                      body-params)]
           (if (:success? result)
@@ -92,7 +92,7 @@
   (let [country-iso-code-a2 (:iso_code_a2 path)
         search-opts {:filters {:countries-iso-codes-a2 [country-iso-code-a2]}}
         {:keys [success? plastic-strategy reason] :as get-ps-result}
-        (srv.ps/get-plastic-strategy config search-opts)]
+        (svc.ps/get-plastic-strategy config search-opts)]
     (if-not success?
       (if (= reason :not-found)
         (r/not-found {})
@@ -106,7 +106,7 @@
         (r/forbidden {:message "Unauthorized"})
         (let [body-params (-> (cske/transform-keys ->kebab-case body)
                               (assoc :plastic-strategy-id (:id plastic-strategy)))
-              result (srv.ps.team/update-ps-team-member config
+              result (svc.ps.team/update-ps-team-member config
                                                         body-params)]
           (if (:success? result)
             (r/ok {})
@@ -114,7 +114,7 @@
 
 (defn- get-ps-team-members [config req]
   (let [country-iso-code-a2 (get-in req [:parameters :path :iso_code_a2])
-        result (srv.ps.team/get-ps-team-members config
+        result (svc.ps.team/get-ps-team-members config
                                                 country-iso-code-a2)]
     (if (:success? result)
       (r/ok (cske/transform-keys ->snake_case (:ps-team-members result)))
@@ -126,14 +126,14 @@
   (let [country-iso-code-a2 (:iso_code_a2 path)
         search-opts {:filters {:countries-iso-codes-a2 [country-iso-code-a2]}}
         {:keys [success? plastic-strategy reason] :as get-ps-result}
-        (srv.ps/get-plastic-strategy config search-opts)]
+        (svc.ps/get-plastic-strategy config search-opts)]
     (if-not success?
       (if (= reason :not-found)
         (r/not-found {})
         (r/server-error (dissoc get-ps-result :success?)))
       (let [body-params (-> (cske/transform-keys ->kebab-case body)
                             (assoc :plastic-strategy plastic-strategy))
-            result (srv.ps.team/invite-user-to-ps-team config body-params)]
+            result (svc.ps.team/invite-user-to-ps-team config body-params)]
         (if (:success? result)
           (r/ok {:invitation_id (get-in result [:invitation :id])})
           (if (= (:reason result) :already-exists)
@@ -144,7 +144,7 @@
   (let [country-iso-code-a2 (:iso_code_a2 path)
         search-opts {:filters {:countries-iso-codes-a2 [country-iso-code-a2]}}
         {:keys [success? plastic-strategy reason] :as get-ps-result}
-        (srv.ps/get-plastic-strategy config search-opts)]
+        (svc.ps/get-plastic-strategy config search-opts)]
     (if-not success?
       (if (= reason :not-found)
         (r/not-found {})
@@ -157,7 +157,7 @@
                                                   :root-context? false})
         (r/forbidden {:message "Unauthorized"})
         (let [user-id (:user_id body)
-              result (srv.ps.team/delete-ps-team-member config
+              result (svc.ps.team/delete-ps-team-member config
                                                         plastic-strategy
                                                         user-id)]
           (if (:success? result)

--- a/backend/src/gpml/handler/programmatic/plastic_strategy.clj
+++ b/backend/src/gpml/handler/programmatic/plastic_strategy.clj
@@ -3,7 +3,7 @@
    [camel-snake-kebab.core :refer [->kebab-case]]
    [camel-snake-kebab.extras :as cske]
    [gpml.handler.responses :as r]
-   [gpml.service.plastic-strategy :as srv.ps]
+   [gpml.service.plastic-strategy :as svc.ps]
    [integrant.core :as ig]))
 
 (def ^:private create-plastic-strategies-params-schema
@@ -27,7 +27,7 @@
 
 (defn- create-plastic-strategies [config req]
   (let [pses-payload (cske/transform-keys ->kebab-case (get-in req [:parameters :body]))
-        result (srv.ps/create-plastic-strategies config pses-payload)]
+        result (svc.ps/create-plastic-strategies config pses-payload)]
     (if (:success? result)
       (r/ok (select-keys result [:success? :channels]))
       (r/server-error (dissoc result :success?)))))

--- a/backend/src/gpml/service/plastic_strategy/team.clj
+++ b/backend/src/gpml/service/plastic_strategy/team.clj
@@ -7,7 +7,7 @@
    [gpml.service.chat :as svc.chat]
    [gpml.service.invitation :as srv.invitation]
    [gpml.service.permissions :as srv.permissions]
-   [gpml.service.plastic-strategy :as srv.ps]
+   [gpml.service.plastic-strategy :as svc.ps]
    [gpml.util.email :as util.email]
    [gpml.util.thread-transactions :as tht]))
 
@@ -244,7 +244,7 @@
 (defn get-ps-team-members [{:keys [db] :as config} country-iso-code-a2]
   (let [search-opts {:filters {:countries-iso-codes-a2 [country-iso-code-a2]}}
         {:keys [success? plastic-strategy] :as result}
-        (srv.ps/get-plastic-strategy config search-opts)]
+        (svc.ps/get-plastic-strategy config search-opts)]
     (if success?
       (db.ps.team/get-ps-team-members (:spec db)
                                       {:filters {:plastic-strategies-ids [(:id plastic-strategy)]}})

--- a/backend/src/gpml/service/stakeholder.clj
+++ b/backend/src/gpml/service/stakeholder.clj
@@ -11,7 +11,7 @@
    [gpml.service.chat :as svc.chat]
    [gpml.service.file :as srv.file]
    [gpml.service.permissions :as srv.permissions]
-   [gpml.service.plastic-strategy :as srv.ps]
+   [gpml.service.plastic-strategy :as svc.ps]
    [gpml.util :as util]
    [gpml.util.image :as util.image]
    [gpml.util.thread-transactions :as tht]
@@ -478,7 +478,7 @@
             (if-not (and invited?
                          (= (:type invitation) :plastic-strategy))
               context
-              (let [result (srv.ps/setup-invited-plastic-strategy-user config (:id old-stakeholder))]
+              (let [result (svc.ps/setup-invited-plastic-strategy-user config (:id old-stakeholder))]
                 (if (:success? result)
                   context
                   (assoc context


### PR DESCRIPTION
Ensures that the given plastic strategy has an existing, valid associated chat channel. Idempotent. Admin only.

We may create similar endpoints for similar needs (e.g. ensuring that users have an existing DSC account or an in-sync profile picture)

Swagger:

![image](https://github.com/akvo/unep-gpml/assets/1162994/247fc503-9158-4856-94f6-843f6c21b10a)

@martinchristov 