### PR TITLE
Make `plastic-strategy` code fail more clearly

### DIFF
--- a/backend/src/gpml/db/plastic_strategy/team.clj
+++ b/backend/src/gpml/db/plastic_strategy/team.clj
@@ -1,10 +1,13 @@
 (ns gpml.db.plastic-strategy.team
   #:ns-tracker{:resource-deps ["plastic_strategy/team.sql"]}
   (:require
+   [duct.logger :refer [log]]
    [gpml.db.jdbc-util :as jdbc-util]
    [gpml.util :as util]
    [gpml.util.postgresql :as util.pgsql]
-   [hugsql.core :as hugsql]))
+   [gpml.util.result :refer [failure]]
+   [hugsql.core :as hugsql]
+   [taoensso.timbre :as timbre]))
 
 (declare add-ps-team-member*
          update-ps-team-member*
@@ -32,60 +35,62 @@
     (add-ps-team-member* conn (ps-team-member->p-ps-team-member ps-team-member))
     {:success? true}))
 
-(defn update-ps-team-member [conn ps-team-member-updates]
+(defn update-ps-team-member [logger conn ps-team-member-updates]
   (try
     (let [p-ps-team-member-updates (update ps-team-member-updates :updates ps-team-member->p-ps-team-member)
           affected (update-ps-team-member* conn p-ps-team-member-updates)]
       (if (= affected 1)
         {:success? true}
-        {:success? false
-         :reason :unexpected-number-of-affected-rows
-         :error-details {:expected-affected-rows 1
-                         :actual-affected-rows affected}}))
+        (failure {:reason :unexpected-number-of-affected-rows
+                  :error-details {:expected-affected-rows 1
+                                  :actual-affected-rows affected}})))
     (catch Exception t
-      {:success? false
-       :reason :exception
-       :error-details {:msg (ex-message t)}})))
+      (timbre/with-context+ {::ps-team-member-updates ps-team-member-updates}
+        (log logger :error :could-not-update-ps-team-member t))
+      (failure {:reason :exception
+                :error-details {:msg (ex-message t)}}))))
 
-(defn delete-ps-team-member [conn plastic-strategy-id user-id]
+(defn delete-ps-team-member [logger conn plastic-strategy-id user-id]
   (try
     (let [affected (delete-ps-team-member* conn
                                            {:plastic-strategy-id plastic-strategy-id
                                             :user-id user-id})]
       (if (= affected 1)
         {:success? true}
-        {:success? false
-         :reason :unexpected-number-of-affected-rows
-         :error-details {:expected-affected-rows 1
-                         :actual-affected-rows affected}}))
+        (failure {:reason :unexpected-number-of-affected-rows
+                  :error-details {:expected-affected-rows 1
+                                  :actual-affected-rows affected}})))
     (catch Exception t
-      {:success? false
-       :reason :exception
-       :error-details {:msg (ex-message t)}})))
+      (timbre/with-context+ {::plastic-strategy-id plastic-strategy-id
+                             ::user-id user-id}
+        (log logger :error :could-not-delete-ps-team-member t))
+      (failure {:reason :exception
+                :error-details {:msg (ex-message t)}}))))
 
-(defn get-ps-team-members [conn opts]
+(defn get-ps-team-members [logger conn opts]
   (try
     {:success? true
      :ps-team-members (->> (get-ps-team-members* conn opts)
                            (mapv p-ps-team-member->ps-team-member)
                            (jdbc-util/db-result-snake-kw->db-result-kebab-kw))}
     (catch Exception t
-      {:success? false
-       :reason :exception
-       :error-details {:msg (ex-message t)}})))
+      (timbre/with-context+ {::opts opts}
+        (log logger :error :could-not-get-ps-team-members t))
+      (failure {:reason :exception
+                :error-details {:msg (ex-message t)}}))))
 
-(defn get-ps-team-member [conn opts]
+(defn get-ps-team-member [logger conn opts]
   (try
     (let [{:keys [success? ps-team-members] :as result}
-          (get-ps-team-members conn opts)]
+          (get-ps-team-members logger conn opts)]
       (if-not success?
         result
         (if (= (count ps-team-members) 1)
           {:success? true
            :ps-team-member (first ps-team-members)}
-          {:success? false
-           :reason :not-found})))
+          (failure {:reason :not-found}))))
     (catch Exception t
-      {:success? false
-       :reason :exception
-       :error-details {:msg (ex-message t)}})))
+      (timbre/with-context+ {::opts opts}
+        (log logger :error :could-not-get-ps-team-member t))
+      (failure {:reason :exception
+                :error-details {:msg (ex-message t)}}))))

--- a/backend/src/gpml/service/plastic_strategy/team.clj
+++ b/backend/src/gpml/service/plastic_strategy/team.clj
@@ -8,6 +8,7 @@
    [gpml.service.permissions :as srv.permissions]
    [gpml.service.plastic-strategy :as svc.ps]
    [gpml.util.email :as util.email]
+   [gpml.util.result :refer [failure]]
    [gpml.util.thread-transactions :as tht]))
 
 (defn- assign-ps-team-member-role [{:keys [db logger]} ps-team-member]
@@ -30,32 +31,30 @@
               (if success?
                 context
                 (if (= reason :already-exists)
-                  (assoc context
-                         :success? false
-                         :reason :ps-team-member-already-exists
-                         :error-details {:result result})
-                  (assoc context
-                         :success? false
-                         :reason :failed-to-add-team-member
-                         :error-details {:result result})))))
+                  (failure context
+                           :reason :ps-team-member-already-exists
+                           :error-details {:result result})
+                  (failure context
+                           :reason :failed-to-add-team-member
+                           :error-details {:result result})))))
           :rollback-fn
           (fn rollback-add-ps-team-member
             [{{:keys [plastic-strategy-id user-id]} :ps-team-member :as context}]
-            (db.ps.team/delete-ps-team-member (:spec db) plastic-strategy-id user-id)
+            (db.ps.team/delete-ps-team-member logger (:spec db) plastic-strategy-id user-id)
             context)}
          {:txn-fn
           (fn tx-get-ps-team-member
             [{{:keys [plastic-strategy-id user-id]} :ps-team-member :as context}]
             (let [search-opts {:filters {:plastic-strategies-ids [plastic-strategy-id]
                                          :users-ids [user-id]}}
-                  result (db.ps.team/get-ps-team-member (:spec db)
+                  result (db.ps.team/get-ps-team-member logger
+                                                        (:spec db)
                                                         search-opts)]
               (if (:success? result)
                 (update context :ps-team-member merge (:ps-team-member result))
-                (assoc context
-                       :success? false
-                       :reason :failed-to-get-ps-team-member
-                       :error-details {:result result}))))}
+                (failure context
+                         :reason :failed-to-get-ps-team-member
+                         :error-details {:result result}))))}
          {:txn-fn
           (fn tx-assign-role-to-user
             [{:keys [ps-team-member] :as context}]
@@ -63,10 +62,9 @@
                   (assign-ps-team-member-role config ps-team-member)]
               (if success?
                 context
-                (assoc context
-                       :success? false
-                       :reason reason
-                       :error-details error-details))))
+                (failure context
+                         :reason reason
+                         :error-details error-details))))
           :rollback-fn
           (fn rollback-assign-role-to-user
             [{:keys [ps-team-member] :as context}]
@@ -90,10 +88,9 @@
                                                 ps-team-member)]
               (if (:success? result)
                 {:success? true}
-                (assoc context
-                       :success? false
-                       :reason :failed-to-add-team-member-to-ps-chat-channel
-                       :result {:result result}))))
+                (failure context
+                         :reason :failed-to-add-team-member-to-ps-chat-channel
+                         :result {:result result}))))
           :rollback-fn
           (fn remove-team-member-from-ps-chat-channel
             [{:keys [ps-team-member plastic-strategy] :as context}]
@@ -102,10 +99,9 @@
                                                  ps-team-member)]
               (if (:success? result)
                 {:success? true}
-                (assoc context
-                       :success? false
-                       :reason :failed-to-remove-team-member-from-ps-chat-channel
-                       :error-details {:result result}))))}
+                (failure context
+                         :reason :failed-to-remove-team-member-from-ps-chat-channel
+                         :error-details {:result result}))))}
          {:txn-fn
           (fn tx-notify-user
             [{:keys [ps-team-member plastic-strategy] :as context}]
@@ -129,13 +125,12 @@
             (let [search-opts {:filters {:plastic-strategies-ids [plastic-strategy-id]
                                          :users-ids [user-id]}}
                   {:keys [success? ps-team-member reason error-details]}
-                  (db.ps.team/get-ps-team-member (:spec db) search-opts)]
+                  (db.ps.team/get-ps-team-member logger (:spec db) search-opts)]
               (if success?
                 (assoc context :old-ps-team-member ps-team-member)
-                (assoc context
-                       :success? false
-                       :reason reason
-                       :error-details error-details))))}
+                (failure context
+                         :reason reason
+                         :error-details error-details))))}
          {:txn-fn
           (fn tx-update-ps-team-member
             [{{:keys [plastic-strategy-id user-id] :as ps-team-member} :ps-team-member :as context}]
@@ -143,20 +138,21 @@
                                  :user-id user-id
                                  :updates (dissoc ps-team-member :plastic-strategy-id :user-id)}
                   {:keys [success? reason error-details]}
-                  (db.ps.team/update-ps-team-member (:spec db) update-params)]
+                  (db.ps.team/update-ps-team-member logger (:spec db) update-params)]
               (if success?
                 context
-                (assoc context
-                       :success? false
-                       :reason reason
-                       :error-details error-details))))
+                (failure context
+                         :reason reason
+                         :error-details error-details))))
           :rollback-fn
           (fn rollback-update-ps-team-member
             [{{:keys [plastic-strategy-id id teams role]} :old-ps-team-member :as context}]
-            (db.ps.team/update-ps-team-member (:spec db) {:plastic-strategy-id plastic-strategy-id
-                                                          :user-id id
-                                                          :updates {:teams teams
-                                                                    :role role}})
+            (db.ps.team/update-ps-team-member logger
+                                              (:spec db)
+                                              {:plastic-strategy-id plastic-strategy-id
+                                               :user-id id
+                                               :updates {:teams teams
+                                                         :role role}})
             (dissoc context :old-ps-team-member))}
          {:txn-fn
           (fn tx-update-user-role-assignment
@@ -193,28 +189,28 @@
                                                                        :logger logger}
                                                                       role-unassignments))]
                 (if-not success?
-                  (assoc context
-                         :success? false
-                         :reason :failed-to-unassign-previous-role
-                         :error-details result)
+                  (failure context
+                           :reason :failed-to-unassign-previous-role
+                           :error-details result)
                   (let [{:keys [success? reason error-details]}
                         (assign-ps-team-member-role config ps-team-member)]
                     (if success?
                       (dissoc context :old-ps-team-member)
-                      (assoc context
-                             :success? false
-                             :reason reason
-                             :error-details error-details)))))))}]
+                      (failure context
+                               :reason reason
+                               :error-details error-details)))))))}]
         context {:success? true
                  :ps-team-member ps-team-member}]
     (tht/thread-transactions logger transactions context)))
 
-(defn get-ps-team-members [{:keys [db] :as config} country-iso-code-a2]
+(defn get-ps-team-members [{:keys [db logger] :as config} country-iso-code-a2]
+  {:pre [db logger]}
   (let [search-opts {:filters {:countries-iso-codes-a2 [country-iso-code-a2]}}
         {:keys [success? plastic-strategy] :as result}
         (svc.ps/get-plastic-strategy config search-opts)]
     (if success?
-      (db.ps.team/get-ps-team-members (:spec db)
+      (db.ps.team/get-ps-team-members logger
+                                      (:spec db)
                                       {:filters {:plastic-strategies-ids [(:id plastic-strategy)]}})
       result)))
 
@@ -238,14 +234,12 @@
                        :user-id (:user-id result)
                        :invitation (:invitation result))
                 (if (= (:reason result) :already-exists)
-                  (assoc context
-                         :success? false
-                         :reason (:reason result)
-                         :error-details {:result result})
-                  (assoc context
-                         :success? false
-                         :reason :failed-to-invite-user
-                         :error-details {:result result})))))}
+                  (failure context
+                           :reason (:reason result)
+                           :error-details {:result result})
+                  (failure context
+                           :reason :failed-to-invite-user
+                           :error-details {:result result})))))}
          {:txn-fn
           (fn tx-add-user-to-ps-team
             [{:keys [ps-team-invitation user-id] :as context}]
@@ -256,10 +250,9 @@
                   result (db.ps.team/add-ps-team-member (:spec db) ps-team-member)]
               (if (:success? result)
                 context
-                (assoc context
-                       :success? false
-                       :reason :failed-to-add-ps-team-member
-                       :error-details {:result result}))))}]
+                (failure context
+                         :reason :failed-to-add-ps-team-member
+                         :error-details {:result result}))))}]
         context {:success? true
                  :ps-team-invitation ps-team-invitation}]
     (tht/thread-transactions logger transactions context)))
@@ -268,20 +261,19 @@
   (let [transactions
         [(fn tx-get-ps-team-member
            [{:keys [plastic-strategy user-id] :as context}]
-           (let [result (db.ps.team/get-ps-team-member (:spec db)
+           (let [result (db.ps.team/get-ps-team-member logger
+                                                       (:spec db)
                                                        {:filters {:plastic-strategies-ids [(:id plastic-strategy)]
                                                                   :users-ids [user-id]}})]
              (if (:success? result)
                (assoc context :ps-team-member (:ps-team-member result))
                (if (= (:reason result) :not-found)
-                 (assoc context
-                        :success? false
-                        :reason :ps-team-member-not-found
-                        :error-details {:result result})
-                 (assoc context
-                        :success? false
-                        :reason :failed-to-get-ps-team-member
-                        :error-details {:result result})))))
+                 (failure context
+                          :reason :ps-team-member-not-found
+                          :error-details {:result result})
+                 (failure context
+                          :reason :failed-to-get-ps-team-member
+                          :error-details {:result result})))))
          {:txn-fn
           (fn tx-remove-user-from-ps-channel
             [{:keys [plastic-strategy ps-team-member] :as context}]
@@ -292,10 +284,9 @@
                                                    ps-team-member)]
                 (if (:success? result)
                   context
-                  (assoc context
-                         :success? false
-                         :reason :failed-to-remove-user-from-ps-channel
-                         :error-details {:result result})))))
+                  (failure context
+                           :reason :failed-to-remove-user-from-ps-channel
+                           :error-details {:result result})))))
           :rollback-fn
           (fn rollback-remove-user-from-ps-channel
             [{:keys [plastic-strategy ps-team-member] :as context}]
@@ -325,10 +316,9 @@
                                                                       role-unassignments))]
                 (if success?
                   context
-                  (assoc context
-                         :success? false
-                         :reason :failed-to-unassign-ps-team-member-rbac-role
-                         :error-details {:result result})))))
+                  (failure context
+                           :reason :failed-to-unassign-ps-team-member-rbac-role
+                           :error-details {:result result})))))
           :rollback-fn
           (fn rollback-unassign-ps-team-member-rbac-role
             [{:keys [ps-team-member] :as context}]
@@ -355,17 +345,18 @@
               (let [result (db.stakeholder/delete-stakeholder (:spec db) user-id)]
                 (if (:success? result)
                   context
-                  (assoc context
-                         :success? false
-                         :reason :failed-to-delete-ps-team-member
-                         :error-details {:result result})))
-              (let [result (db.ps.team/delete-ps-team-member (:spec db) (:id plastic-strategy) user-id)]
+                  (failure context
+                           :reason :failed-to-delete-ps-team-member
+                           :error-details {:result result})))
+              (let [result (db.ps.team/delete-ps-team-member logger
+                                                             (:spec db)
+                                                             (:id plastic-strategy)
+                                                             user-id)]
                 (if (:success? result)
                   {:success? true}
-                  (assoc context
-                         :success? false
-                         :reason :failed-to-delete-ps-team-member
-                         :error-details {:result result})))))}]
+                  (failure context
+                           :reason :failed-to-delete-ps-team-member
+                           :error-details {:result result})))))}]
         context {:success? true
                  :plastic-strategy plastic-strategy
                  :user-id user-id}]


### PR DESCRIPTION
As (unfortunately) usual, exceptions were being swalloed in misc corners of the codebase, making diagnostics unnecessarily  hard.

@martinchristov , please reproduce the `There is a 500 when trying POST /api/plastic-strategy/0A/team/member` issue. It should fail again, just with better logs.

Please record the exact time of your attempt

Cheers - V