### PR TITLE
DSC chat: introduce environment profiles

### DIFF
--- a/backend/dev/src/dev.clj
+++ b/backend/dev/src/dev.clj
@@ -30,7 +30,7 @@
 (duct/load-hierarchy)
 
 (defn read-config []
-  (-> "gpml/duct.edn" io/resource gpml.fixtures/read-config))
+  (-> "gpml/duct.edn" io/resource (gpml.fixtures/read-config :dev)))
 
 (defn test
   ([v]

--- a/backend/resources/gpml/duct.base.edn
+++ b/backend/resources/gpml/duct.base.edn
@@ -965,7 +965,8 @@
  :gpml.boundary.adapter.storage-client.gcs/client                   {}
 
  :gpml.boundary.adapter.chat/ds-chat          {:api-key #duct/env ["DEAD_SIMPLE_CHAT_API_KEY" Str]
-                                               :logger  #ig/ref :duct/logger}
+                                               :logger  #ig/ref :duct/logger
+                                               :profile #gpml/profile []}
  :duct.migrator/ragtime                       {:migrations #ig/ref :duct.migrator.ragtime/resources
                                                :logger     #ig/ref :duct/logger
                                                :strategy   :raise-error}

--- a/backend/resources/gpml/duct.base.edn
+++ b/backend/resources/gpml/duct.base.edn
@@ -723,7 +723,8 @@
                                                                      :client-id #duct/env ["AUTH0_BACKEND_CLIENT_ID" Str]
                                                                      :secret    #duct/env ["AUTH0_BACKEND_SECRET" Str]}
  [:duct/const :gpml.config/common]
- {:db                                  #ig/ref :duct.database/sql
+ {:profile                             #gpml/profile []
+  :db                                  #ig/ref :duct.database/sql
   :hikari                              #ig/ref :duct.database.sql/hikaricp
   :logger                              #ig/ref :duct/logger
   :scheduler                           #ig/ref :gpml/scheduler

--- a/backend/seeder/gpml/seeder/dummy.clj
+++ b/backend/seeder/gpml/seeder/dummy.clj
@@ -21,7 +21,9 @@
 
 (defn dev-system []
   (-> (duct/resource "gpml/duct.edn")
-      (duct/read-config {'gpml/eval eval})
+      (duct/read-config {'gpml/profile (fn [_]
+                                         :dev)
+                         'gpml/eval eval})
       (duct/prep-config [:duct.profile/dev])))
 
 (def lorem "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas luctus eros at consequat accumsan. Integer massa ligula, blandit at commodo vitae, vestibulum et erat.")

--- a/backend/seeder/gpml/seeder/main.clj
+++ b/backend/seeder/gpml/seeder/main.clj
@@ -32,7 +32,9 @@
 
 (defn- dev-system []
   (-> (duct/resource "gpml/duct.edn")
-      (duct/read-config {'gpml/eval eval})
+      (duct/read-config {'gpml/profile (fn [_]
+                                         :dev)
+                         'gpml/eval eval})
       (duct/prep-config [:duct.profile/dev])))
 
 (defn parse-date [x]

--- a/backend/src/gpml/main.clj
+++ b/backend/src/gpml/main.clj
@@ -19,5 +19,13 @@
           keys     (or (parse-keys args) [:duct/daemon])
           profiles [:duct.profile/prod]]
       (-> (resource "gpml/duct.edn")
-          (read-config)
+          (read-config {'gpml/profile (fn [_]
+                                        ;; In GCP we have the 'production' and 'test' environments.
+                                        ;; To avoid conflating GCP 'test' with local 'test',
+                                        ;; all GCP environments are prefixed with prod-.
+                                        ;; So we intend to have prod-production and prod-test.
+                                        (let [e (System/getenv "ENV_NAME")]
+                                          (when (empty? e)
+                                            (throw (ex-info "ENV_NAME is unset" {})))
+                                          (keyword (str "prod-" e))))})
           (exec-config profiles keys)))))

--- a/backend/src/gpml/service/permissions.clj
+++ b/backend/src/gpml/service/permissions.clj
@@ -34,7 +34,11 @@
                                        (or parent-resource-id
                                            root-app-resource-id))]
     (if-not (and success? parent-context)
-      (log logger :warn :will-not-create-context result)
+      (log logger :warn :will-not-create-context {:result result
+                                                  :context-type context-type
+                                                  :resource-id resource-id
+                                                  :parent-context-type parent-context-type
+                                                  :parent-resource-id parent-resource-id})
       (let [new-context {:context-type-name context-type
                          :resource-id resource-id}]
         (rbac/create-context! conn logger new-context parent-context)))))

--- a/backend/test/gpml/fixtures.clj
+++ b/backend/test/gpml/fixtures.clj
@@ -18,8 +18,10 @@
 (defmethod ig/init-key :gpml.test/db [_ spec]
   (sql/->Boundary spec))
 
-(defn read-config [x]
-  (duct/read-config x {'gpml/eval eval}))
+(defn read-config [x main-profile]
+  (duct/read-config x {'gpml/eval eval
+                       'gpml/profile (fn [_]
+                                       main-profile)}))
 
 (defn- test-system []
   (when (System/getenv "CI")
@@ -30,11 +32,12 @@
              (io/file "test-resources" "local.edn")))
 
   (-> (duct/resource "gpml/duct.edn")
-      (read-config)
+      (read-config :test)
 
       ;; support an ad-hoc profile for simple tweaks.
       ;; Note that duct doesn't make it easy to create custom profiles
-      (cond-> (io/resource "localtest.edn") (merge (read-config (duct/resource "localtest.edn"))))
+      (cond-> (io/resource "localtest.edn") (merge (read-config (duct/resource "localtest.edn")
+                                                                :test)))
 
       (duct/prep-config (cond-> [:duct.profile/test]
                           (System/getenv "CI")


### PR DESCRIPTION
Now, channel listings are limited to production/test/local - i.e. results won't be mixed any more.

Creating channels marks them as belonging them to production/test/local.

Existing test channels have already been marked as such.

@martinchristov 