### PR TITLE
Fix `stakeholder_badge_stakeholder_id_fkey` constraint

### DIFF
--- a/backend/resources/migrations/213-fix-stakeholder-badge-stakeholder-id-fkey.up.sql
+++ b/backend/resources/migrations/213-fix-stakeholder-badge-stakeholder-id-fkey.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.stakeholder_badge DROP CONSTRAINT stakeholder_badge_stakeholder_id_fkey;
+ALTER TABLE public.stakeholder_badge
+  ADD CONSTRAINT stakeholder_badge_stakeholder_id_fkey FOREIGN KEY (stakeholder_id) REFERENCES stakeholder(id) ON DELETE CASCADE;


### PR DESCRIPTION
It was missing an `ON DELETE CASCADE`