### PR TITLE
Chat listings: filter out Plastic Strategy channels from results

### DIFF
--- a/backend/src/gpml/handler/chat.clj
+++ b/backend/src/gpml/handler/chat.clj
@@ -610,6 +610,7 @@ so you don't need to call the POST /api/chat/user/account endpoint beforehand."
                        {:url (str "http://localhost:3000/api/chat/channel/details/" channel-id)
                         :as :json-keyword-keys})
 
+  ;; NOTE: channels associated to Plastic Strategies are filtered out
   (http-client/request (dev/logger)
                        {:url "http://localhost:3000/api/chat/channel/all"
                         :as :json-keyword-keys})


### PR DESCRIPTION
Affected endpoints:

* /api/chat/channel/all
* /api/chat/channel/public
* /api/chat/channel/private
* /api/chat/user/channel