### PR TITLE
Draft `gpml.scheduler.chat-active-status-observer`

### DIFF
--- a/backend/dev/resources/dev.edn
+++ b/backend/dev/resources/dev.edn
@@ -3,8 +3,11 @@
                               :logger #ig/ref :duct/logger
                               :maximum-pool-size 1}
 
- :mocks.boundary.adapter.storage-client/local-file-system
- {:base-path #duct/env ["LOCAL_FS_STORAGE_BASE_PATH" Str]}
+ :mocks.boundary.adapter.storage-client/local-file-system {:base-path #duct/env ["LOCAL_FS_STORAGE_BASE_PATH" Str]}
+
+ :gpml/scheduler #ig/ref :gpml/noop-scheduler ;; Remove the scheduler as it's fairly annoying to have misc tasks being regularly run (which disrupts the logs, etc)
+ :gpml/twarc-scheduler {:disabled true}
+ :gpml/noop-scheduler {:logger #ig/ref :duct/logger}
 
  ;; NOTE: uncomment this if you're working on the BE and doing things
  ;; with images.

--- a/backend/resources/gpml/duct.base.edn
+++ b/backend/resources/gpml/duct.base.edn
@@ -1018,4 +1018,10 @@
                                                                   :identity  "chat-message-summarizer"
                                                                   :cron      #duct/env ["SCHEDULER_CHAT_MESSAGE_SUMMARIZER_CRON" Str
                                                                                         ;; Every five minutes
-                                                                                        :or "0 0/5 * * * ?"]}}}
+                                                                                        :or "0 0/5 * * * ?"]}}
+ :gpml.scheduler/chat-active-status-observer {:config           #ig/ref :gpml.config/common
+                                              :scheduler-config {:time-zone #duct/env ["SCHEDULER_TIME_ZONE" Str :or "Europe/Madrid"]
+                                                                 :identity  "chat-active-status-observer"
+                                                                 :cron      #duct/env ["SCHEDULER_CHAT_ACTIVE_STATUS_OBSERVER_CRON" Str
+                                                                                       ;; Every 2 minutes
+                                                                                       :or "0 0/2 * * * ?"]}}}

--- a/backend/resources/migrations/214-add-last-active-at-to-chat-membership.up.sql
+++ b/backend/resources/migrations/214-add-last-active-at-to-chat-membership.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE chat_channel_membership ADD COLUMN last_active_at TIMESTAMPTZ;

--- a/backend/src/duct_hierarchy.edn
+++ b/backend/src/duct_hierarchy.edn
@@ -1,3 +1,4 @@
-{:gpml.scheduler/leap-api-policy-importer [:duct/daemon]
- :gpml.scheduler/brs-api-importer         [:duct/daemon]
- :gpml.scheduler/chat-message-summarizer  [:duct/daemon]}
+{:gpml.scheduler/leap-api-policy-importer    [:duct/daemon]
+ :gpml.scheduler/brs-api-importer            [:duct/daemon]
+ :gpml.scheduler/chat-active-status-observer [:duct/daemon]
+ :gpml.scheduler/chat-message-summarizer     [:duct/daemon]}

--- a/backend/src/gpml/boundary/port/chat.clj
+++ b/backend/src/gpml/boundary/port/chat.clj
@@ -265,6 +265,12 @@
     get-channel-discussions [this channel-id])
 
   (^{:schema [:or
+              (success-with :user-ids [:sequential any? #_UniqueUserIdentifier]) ;; XXX I'm assuming it returns such ids. Can be requested.
+              (failure-with :error-details any?)]}
+    get-channel-present-users [this channel-id]
+    "Returns the User IDs of the users currently active in the given channel.")
+
+  (^{:schema [:or
               (success-with :channels Channels)
               (failure-with :error-details any?)]}
     get-private-channels [this opts])

--- a/backend/src/gpml/main.clj
+++ b/backend/src/gpml/main.clj
@@ -7,6 +7,7 @@
     ;; Load multimethods:
     (require 'gpml.handler.detail
              'gpml.programmatic
+             'gpml.scheduler.chat-active-status-observer
              'gpml.scheduler.chat-message-summarizer
              'gpml.timbre-logger
              'gpml.timbre-logger.json

--- a/backend/src/gpml/scheduler.clj
+++ b/backend/src/gpml/scheduler.clj
@@ -12,8 +12,8 @@
   nil)
 
 (defmethod ig/init-key :gpml/twarc-scheduler [_ {:keys [thread-count disabled logger]}]
-  (log logger :report :starting-twarc-scheduler {})
   (when-not disabled
+    (log logger :report :starting-twarc-scheduler {})
     (-> (twarc/make-scheduler {:threadPool.threadCount thread-count
                                :plugin.triggHistory.class "org.quartz.plugins.history.LoggingTriggerHistoryPlugin"
                                :plugin.jobHistory.class "org.quartz.plugins.history.LoggingJobHistoryPlugin"})
@@ -131,7 +131,9 @@
     (shutdown [this])
     (standby [this])))
 
-(defmethod ig/init-key :gpml/noop-scheduler [_ _]
+(defmethod ig/init-key :gpml/noop-scheduler [_ {:keys [logger]}]
+  (assert logger)
+  (log logger :report :starting-noop-scheduler {})
   (twarc.impl.core/map->Scheduler {:twarc/quartz (new-mock-scheduler)
                                    :twarc/name (str `noop)
                                    :twarc/listeners (atom {})}))

--- a/backend/src/gpml/scheduler/chat_active_status_observer.clj
+++ b/backend/src/gpml/scheduler/chat_active_status_observer.clj
@@ -1,0 +1,120 @@
+(ns gpml.scheduler.chat-active-status-observer
+  "Observes and persist changes in the active status of channels' users.
+
+  ns state: done, needs an endpoint update from DSC side."
+  (:require
+   [duct.logger :refer [log]]
+   [gpml.boundary.port.chat :as port.chat]
+   [gpml.db :as db]
+   [gpml.util.malli :refer [check!]]
+   [gpml.util.thread-transactions :refer [saga]]
+   [integrant.core :as ig]
+   [twarc.core :refer [defjob]]))
+
+(defn update-chat-channel-membership-prepared-statement [updates]
+  {:pre [(check! [:sequential {:min 1}
+                  [:map {:closed true}
+                   [:stakeholder_id number?]
+                   [:chat_channel_id :string]]]
+                 updates)]}
+  (let [sql (format "UPDATE chat_channel_membership
+SET last_active_at = now()
+FROM (
+  VALUES
+      %s
+      ) AS new_values (stakeholder_id, chat_channel_id)
+WHERE chat_channel_membership.stakeholder_id = new_values.stakeholder_id
+  AND chat_channel_membership.chat_channel_id = new_values.chat_channel_id"
+                    (->> updates
+                         (map (fn [_]
+                                "(?, ?)"))
+                         (interpose ", ")
+                         (apply str)))]
+    (reduce into
+            [sql]
+            (mapv (fn [{:keys [stakeholder_id chat_channel_id]}]
+                    {:pre [stakeholder_id chat_channel_id]}
+                    [stakeholder_id chat_channel_id])
+                  updates))))
+
+(comment
+  (update-chat-channel-membership-prepared-statement [{:stakeholder_id 1
+                                                       :chat_channel_id "2"}
+                                                      {:stakeholder_id 3
+                                                       :chat_channel_id "4"}]))
+
+(defn observe-chat-channels [{:keys [logger hikari]
+                              chat :chat-adapter}]
+  {:pre [hikari logger chat]}
+  (log logger :report :observe-chat-channels {})
+  (saga logger {:success? true}
+    (fn [_context]
+      (port.chat/get-all-channels chat {}))
+
+    (fn assoc-channel-present-users [{:keys [channels]}]
+      (reduce (fn [acc {:keys [id] :as _channel}]
+                {:pre [id]}
+                (let [{:keys [success? user-ids]
+                       :as channel-result} (port.chat/get-channel-present-users chat id)]
+                  (if-not success?
+                    (reduced channel-result)
+                    (assoc-in acc [:channel-present-users id] user-ids))))
+              {:success? true}
+              channels))
+
+    (fn persist-changed-presence-values [{:keys [channel-present-users] :as context}]
+      {:pre [channel-present-users]}
+      (let [updates (reduce (fn [acc [channel-id user-ids]]
+                              (into acc
+                                    (mapv (fn [user-id]
+                                            {:stakeholder_id
+                                             (if (any? (rand-int 1))
+                                               (-> hikari
+                                                   (db/execute-one!
+                                                    {:select [:stakeholder.id]
+                                                     :from :stakeholder
+                                                     :join [:chat_channel_membership
+                                                            [:=
+                                                             :stakeholder.id
+                                                             :chat_channel_membership.stakeholder_id]]
+                                                     :limit 1})
+                                                   :result
+                                                   :id
+                                                   (doto (assert "Please make sure there's at least one user that belongs to one channel")))
+                                               ;; currently this is an internal user id,
+                                               ;; not a unique user id so it's a useless value:
+                                               user-id)
+                                             :chat_channel_id channel-id})
+                                          user-ids)))
+                            []
+                            channel-present-users)]
+        (if (empty? updates)
+          (do
+            (log logger :info :nothing-to-update)
+            context)
+          (let [{{:next.jdbc/keys [update-count]} :result
+                 :as result} (db/execute-one! hikari
+                                              (update-chat-channel-membership-prepared-statement updates))]
+            (log logger :info :successfully-updated-presence {:update-count update-count})
+            result))))))
+
+(comment
+  (observe-chat-channels (dev/config-component)))
+
+(defjob chat-active-status-observation
+  [_scheduler config]
+  (observe-chat-channels config))
+
+(defn- schedule-job [{:keys [scheduler logger] :as config} scheduler-config]
+  (let [time-zone (java.util.TimeZone/getTimeZone ^String (:time-zone scheduler-config))]
+    (log logger :report :chat-active-status-observation scheduler-config)
+    (chat-active-status-observation scheduler
+                                    [config]
+                                    :trigger {:cron {:expression (:cron scheduler-config)
+                                                     :misfire-handling :fire-and-process
+                                                     :time-zone time-zone}}
+                                    :job {:identity (:identity scheduler-config)})))
+
+(defmethod ig/init-key :gpml.scheduler/chat-active-status-observer
+  [_ {:keys [config scheduler-config]}]
+  (schedule-job config scheduler-config))

--- a/backend/src/gpml/service/chat.clj
+++ b/backend/src/gpml/service/chat.clj
@@ -17,7 +17,7 @@
 (def CreatedUser
   [:map {:closed true}
    [:id any?]
-   [:chat-account-id any?]
+   [:chat-account-id port.chat/UniqueUserIdentifier]
    [:chat-account-status any?]
    [:chat-account-auth-token any?]])
 

--- a/backend/src/gpml/util/thread_transactions.clj
+++ b/backend/src/gpml/util/thread_transactions.clj
@@ -55,7 +55,9 @@
                                          ;; Support shorthand syntax:
                                          {:txn-fn head})
           result (safe-run logger txn-fn args-map)]
-      (assert (contains? result :success?))
+      (assert (check! [:map
+                       [:success? any?]]
+                      result))
       (if-not (:success? result)
         result
         (let [next-result (thread-transactions logger (rest txns) result)]

--- a/backend/test-resources/test.edn
+++ b/backend/test-resources/test.edn
@@ -14,7 +14,7 @@
 
  :gpml/scheduler #ig/ref :gpml/noop-scheduler ;; Disabled until this thread leak is fixed https://github.com/akvo/unep-gpml/issues/1779
  :gpml/twarc-scheduler {:disabled true}
- :gpml/noop-scheduler {}
+ :gpml/noop-scheduler {:logger #ig/ref :duct/logger}
 
  [:duct/const :gpml.config/common]
  {:chat-adapter           #ig/ref :mocks.boundary.adapter.chat/ds-chat


### PR DESCRIPTION
The `observer` updates the chat active status regularly, for each channel<->user relationship.

It's verified to work, however it depends on a DSC update to be production-ready.