### PR TITLE
`chat-message-summarizer`: misc refinements

### DIFF
--- a/backend/.cljfmt.edn
+++ b/backend/.cljfmt.edn
@@ -1,8 +1,9 @@
-{:extra-indents {gpml.handler.responses/http-status [[:block 1]]
-                 gpml.db.jdbc-util/with-constraint-violation-check [[:block 1]]
-                 gpml.handler.monitoring/metrics [[:block 2]]
-                 saga [[:block 2]]
-                 http-status [[:block 1]]
-                 with-constraint-violation-check [[:block 1]]
-                 metrics [[:block 2]]}
+{:extra-indents       {gpml.handler.responses/http-status                [[:block 1]]
+                       gpml.db.jdbc-util/with-constraint-violation-check [[:block 1]]
+                       gpml.handler.monitoring/metrics                   [[:block 2]]
+                       saga                                              [[:block 2]]
+                       logging-if-false                                  [[:block 2]]
+                       http-status                                       [[:block 1]]
+                       with-constraint-violation-check                   [[:block 1]]
+                       metrics                                           [[:block 2]]}
  :sort-ns-references? true}

--- a/backend/dev/src/dev.clj
+++ b/backend/dev/src/dev.clj
@@ -167,8 +167,8 @@
                .getAbsolutePath
                (sh "test" ;; "production" | "test"
                    ;; times are UTC
-                   "2024-03-30T19:42:00Z"
-                   "2024-03-30T20:00:00Z")
+                   "2024-03-31T12:00:00Z"
+                   "2024-03-31T12:10:00Z")
                :out
                json/<-json)))
 

--- a/backend/src/gpml/boundary/adapter/chat/ds_chat.clj
+++ b/backend/src/gpml/boundary/adapter/chat/ds_chat.clj
@@ -283,7 +283,9 @@
                                      {:url (build-api-endpoint-url "/api/v1/chatRoom/" channel-id "/messages")
                                       :method :get
                                       :query-params {:auth api-key
-                                                     :limit "1"}
+                                                     ;; NOTE: this used to be "1", but gpml.scheduler.chat-message-summarizer
+                                                     ;; needs something more generous.
+                                                     :limit "20"}
                                       :as :json-keyword-keys})]
             (if-not (<= 200 status 299)
               (failure {:reason :failed-to-get-messages
@@ -717,12 +719,12 @@
                                         uniqueUserIdentifier
                                         (-> a-public-channel :channel :id))
   ;; OR
-  ;; 
+  ;;
   (gpml.service.chat/join-channel (dev/config-component)
                                   (-> a-public-channel :channel :id)
                                   (:stakeholder a-user))
 
-;;
+  ;;
   (println (format "https://deadsimplechat.com/%s?uniqueUserIdentifier=%s" (-> a-public-channel :channel :id) uniqueUserIdentifier))
 
   (port.chat/get-channel (dev/component :gpml.boundary.adapter.chat/ds-chat)


### PR DESCRIPTION
* Don't hit the DSC /messages endpoint with a limit of just `1`
* Avoid `reduce` when possible - can act funny
* More precise logging