### PR TITLE
Introduce `gpml.scheduler.picture-file-reconciler`

### DIFF
--- a/backend/resources/gpml/duct.base.edn
+++ b/backend/resources/gpml/duct.base.edn
@@ -1026,4 +1026,10 @@
                                                                  :identity  "chat-active-status-observer"
                                                                  :cron      #duct/env ["SCHEDULER_CHAT_ACTIVE_STATUS_OBSERVER_CRON" Str
                                                                                        ;; Every 2 minutes
-                                                                                       :or "0 0/2 * * * ?"]}}}
+                                                                                       :or "0 0/2 * * * ?"]}}
+ :gpml.scheduler/picture-file-reconciler     {:config           #ig/ref :gpml.config/common
+                                              :scheduler-config {:time-zone #duct/env ["SCHEDULER_TIME_ZONE" Str :or "Europe/Madrid"]
+                                                                 :identity  "picture-file-reconciler"
+                                                                 :cron      #duct/env ["SCHEDULER_PICTURE_FILE_RECONCILER_CRON" Str
+                                                                                       ;; Every hour
+                                                                                       :or "0 0 * * * ?"]}}}

--- a/backend/src/duct_hierarchy.edn
+++ b/backend/src/duct_hierarchy.edn
@@ -1,4 +1,5 @@
 {:gpml.scheduler/leap-api-policy-importer    [:duct/daemon]
  :gpml.scheduler/brs-api-importer            [:duct/daemon]
  :gpml.scheduler/chat-active-status-observer [:duct/daemon]
+ :gpml.scheduler/picture-file-reconciler     [:duct/daemon]
  :gpml.scheduler/chat-message-summarizer     [:duct/daemon]}

--- a/backend/src/gpml/boundary/adapter/chat/ds_chat.clj
+++ b/backend/src/gpml/boundary/adapter/chat/ds_chat.clj
@@ -50,6 +50,7 @@
    :is-moderator
    :provisioned
    :unique-user-identifier
+   :profile-pic
    :updated
    :username])
 
@@ -638,8 +639,8 @@
      `port.chat/delete-private-channel            delete-channel*
      `port.chat/delete-public-channel             delete-channel*
      `port.chat/delete-user-account               delete-user-account*
-     `port.chat/get-channel                       get-channel*
      `port.chat/get-all-channels                  get-all-channels*
+     `port.chat/get-channel                       get-channel*
      `port.chat/get-private-channels              (get-all-channels-fn "private")
      `port.chat/get-public-channels               (get-all-channels-fn "public")
      `port.chat/get-channel-discussions           get-channel-discussions*

--- a/backend/src/gpml/boundary/port/chat.clj
+++ b/backend/src/gpml/boundary/port/chat.clj
@@ -61,6 +61,7 @@
    [:created :string]
    [:created-using-api :boolean]
    [:deactivated {:optional true} :boolean]
+   [:profile-pic {:optional true} [:maybe {} :string]]
    [:email :string]
    [:external-user-id :string]
    [:id :string]

--- a/backend/src/gpml/db/stakeholder.sql
+++ b/backend/src/gpml/db/stakeholder.sql
@@ -338,6 +338,7 @@ WHERE 1=1
 --~(when (seq (get-in params [:filters :roles])) " AND s.role = ANY(ARRAY[:v*:filters.roles]::stakeholder_role[])")
 --~(when (seq (get-in params [:filters :search-text])) " AND (LOWER(s.first_name) ILIKE '%' || :filters.search-text || '%' OR LOWER(s.last_name) ILIKE '%' || :filters.search-text || '%' OR LOWER(s.email) ILIKE '%' || :filters.search-text || '%')")
 --~(when (seq (get-in params [:filters :chat-accounts-ids])) " AND s.chat_account_id IN (:v*:filters.chat-accounts-ids)")
+--~(when (get-in params [:filters :chat-account-id-not-null]) " AND s.chat_account_id IS NOT NULL")
 GROUP BY s.id
 --~(when (get (:related-entities params) :organisation) ", o.id")
 --~(when (get (:related-entities params) :picture-file) ", f.id")

--- a/backend/src/gpml/scheduler/picture_file_reconciler.clj
+++ b/backend/src/gpml/scheduler/picture_file_reconciler.clj
@@ -1,0 +1,123 @@
+(ns gpml.scheduler.picture-file-reconciler
+  "Ensures that for any given Stakeholder record,
+  its corresponding DSC account has the same profile picture.
+
+  This serves two purposes:
+
+  - Fix all the profile pictures that were initially missing in DSC.
+    - (this purpose will become outdated after the first successful run)
+  - Propagate any possible profile picture changes from our app to DSC.
+    - It's a quite infrequent case, so this job is safe to run infrequently as well."
+  (:require
+   [duct.logger :refer [log]]
+   [gpml.boundary.port.chat :as port.chat]
+   [gpml.db.jdbc-util :as jdbc-util]
+   [gpml.db.stakeholder :as db.sth]
+   [gpml.service.file :as srv.file]
+   [gpml.util.malli :refer [check!]]
+   [gpml.util.result :refer [failure]]
+   [gpml.util.thread-transactions :refer [saga]]
+   [integrant.core :as ig]
+   [twarc.core :refer [defjob]]))
+
+(defn reconcile-profile-pictures [{:keys [db logger hikari]
+                                   chat :chat-adapter
+                                   :as config}]
+  {:pre [db hikari logger chat]}
+  (saga logger {:success? true}
+    (fn get-users-with-a-profile-picture-and-dsc-account [context]
+      (let [v (into {}
+                    (comp (map jdbc-util/db-result-snake-kw->db-result-kebab-kw)
+                          (filter :picture-file)
+                          (map (fn [{:keys [chat-account-id] :as s}]
+                                 [chat-account-id s])))
+                    (db.sth/get-stakeholders (:spec db)
+                                             {:filters {:chat-account-id-not-null true}
+                                              :related-entities #{:picture-file}}))]
+        (if (empty? v)
+          (do
+            (log logger :info :no-stakeholders)
+            (failure context :reason :no-stakeholders))
+          {:success? true
+           :stakeholders v})))
+
+    (fn get-all-channels [context]
+      (let [result (port.chat/get-all-channels chat :_)]
+        (if (:success? result)
+          (assoc context :channels (:channels result))
+          (failure context
+                   :reason :failed-to-get-all-channels
+                   :error-details {:result result}))))
+
+    (fn enrich-channels [context]
+      (reduce (fn [acc {channel-id :id}]
+                {:pre [channel-id]}
+                (let [result (port.chat/get-channel chat channel-id)]
+                  (if-not (:success? result)
+                    (failure acc
+                             :reason :could-not-get-channel
+                             :error-details {:result result})
+                    (update acc :extended-channels conj result))))
+              (assoc context :extended-channels [])
+              (:channels context)))
+
+    (fn extract-users [context]
+      (assoc context :dsc-users (into {}
+                                      (map (fn [{:keys [unique-user-identifier] :as user}]
+                                             {:pre [(check! port.chat/UserInfo user)]}
+                                             [unique-user-identifier user]))
+                                      (into #{}
+                                            (mapcat (fn [{{{members :data} :members} :channel}]
+                                                      {:pre [members]}
+                                                      members))
+                                            (:extended-channels context)))))
+
+    (fn determine-accounts-out-of-sync [context]
+      (assoc context
+             :stakeholders-with-newer-profile-picture
+             (into {}
+                   (filter (fn [[chat-account-id {:keys [picture-file] :as _stakeholder}]]
+                             (let [{picture-url :url} (srv.file/get-file-url config picture-file)
+                                   match (get-in context [:dsc-users chat-account-id])]
+                               (when-not match
+                                 (log logger :warn :no-match {:chat-account-id chat-account-id}))
+                               (and picture-url
+                                    match
+                                    (not= picture-url (get match :profile-pic))))))
+                   (:stakeholders context))))
+
+    (fn effect-changes [context]
+      (let [{:keys [affected] :as final}
+            (reduce (fn [acc [chat-account-id {:keys [picture-file] :as _stakeholder}]]
+                      (let [{picture-url :url} (srv.file/get-file-url config picture-file)]
+                        (assert picture-url)
+                        (let [result (port.chat/update-user-account chat
+                                                                    chat-account-id
+                                                                    {:profilePic picture-url})]
+                          (if (:success? result)
+                            (update acc :affected inc)
+                            (failure acc
+                                     :reason :could-not-update-user-account
+                                     :error-details {:result result})))))
+                    (assoc context :affected 0)
+                    (:stakeholders-with-newer-profile-picture context))]
+        (log logger :info :done {:affected affected})
+        final))))
+
+(defjob profile-picture-reconcilation
+  [_scheduler config]
+  (reconcile-profile-pictures config))
+
+(defn- schedule-job [{:keys [scheduler logger] :as config} scheduler-config]
+  (let [time-zone (java.util.TimeZone/getTimeZone ^String (:time-zone scheduler-config))]
+    (log logger :report :profile-picture-reconcilation scheduler-config)
+    (profile-picture-reconcilation scheduler
+                                   [config]
+                                   :trigger {:cron {:expression (:cron scheduler-config)
+                                                    :misfire-handling :fire-and-process
+                                                    :time-zone time-zone}}
+                                   :job {:identity (:identity scheduler-config)})))
+
+(defmethod ig/init-key :gpml.scheduler/picture-file-reconciler
+  [_ {:keys [config scheduler-config]}]
+  (schedule-job config scheduler-config))


### PR DESCRIPTION
Ensures that for any given Stakeholder record,
its corresponding DSC account has the same profile picture.

This serves two purposes:

- Fix all the profile pictures that were initially missing in DSC.
  - (this purpose will become outdated after the first successful run)
- Propagate any possible profile picture changes from our app to DSC.
  - It's a quite infrequent case, so this job is safe to run infrequently as well.