### PR TITLE
Fix duplicated records under `files` property

### DIFF
--- a/backend/src/gpml/db/topic.clj
+++ b/backend/src/gpml/db/topic.clj
@@ -253,8 +253,8 @@
        %s
        %s
        %s
-       json_agg(jsonb_build_object('id', f.id, 'object-key', f.object_key, 'visibility', f.visibility)) FILTER (WHERE f.id IS NOT NULL) AS files,
-       json_agg(json_build_object('id', t.id, 'tag', t.tag)) FILTER (WHERE t.id IS NOT NULL) AS tags
+       json_agg(distinct jsonb_build_object('id', f.id, 'object-key', f.object_key, 'visibility', f.visibility)) FILTER (WHERE f.id IS NOT NULL) AS files,
+       json_agg(distinct jsonb_build_object('id', t.id, 'tag', t.tag)) FILTER (WHERE t.id IS NOT NULL) AS tags
    FROM %s e
    LEFT JOIN %s_tag et ON et.%s = e.id LEFT JOIN tag t ON et.tag = t.id
    %s


### PR DESCRIPTION
When aggregating the json objects into an array, the query makes a cartesian product of files x tags, duplicating the same file per number of tags.