### PR TITLE
Feature: Ignore GCS cache headers

### DIFF
--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -87,6 +87,7 @@ server {
         proxy_pass        http://127.0.0.1:9079;
         proxy_cache       resized;
         proxy_cache_valid ${PROXY_CACHE_VALID};
+        proxy_ignore_headers Expires Cache-Control;
         add_header X-Cache-Status $upstream_cache_status;
     }
 
@@ -94,6 +95,7 @@ server {
         proxy_pass        http://127.0.0.1:9079;
         proxy_cache       resized;
         proxy_cache_valid ${PROXY_CACHE_VALID};
+        proxy_ignore_headers Expires Cache-Control;
         add_header X-Cache-Status $upstream_cache_status;
     }
 
@@ -101,6 +103,7 @@ server {
         proxy_pass        http://127.0.0.1:9079;
         proxy_cache       resized;
         proxy_cache_valid ${PROXY_CACHE_VALID};
+        proxy_ignore_headers Expires Cache-Control;
         add_header X-Cache-Status $upstream_cache_status;
     }
 
@@ -108,6 +111,7 @@ server {
         proxy_pass        http://127.0.0.1:9079;
         proxy_cache       resized;
         proxy_cache_valid ${PROXY_CACHE_VALID};
+        proxy_ignore_headers Expires Cache-Control;
         add_header X-Cache-Status $upstream_cache_status;
     }
 }


### PR DESCRIPTION
https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ignore_headers

We want to cache resized images as much as possible