### PR TITLE
Feat: Fix cache inactive keys invalidation

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,23 +1,7 @@
 FROM nginx:1.26.1-alpine
 
 ENV GCS_BASE_URL=https://storage.googleapis.com/unep-gpml-public-test
-
-# Time intervals can be specified in milliseconds, seconds, minutes, hours,
-# days and so on, using the following suffixes:
-#
-# ms	milliseconds
-# s	    seconds
-# m	    minutes
-# h	    hours
-# d	    days
-# w	    weeks
-# M	    months, 30 days
-# y	    years, 365 days
-ENV PROXY_CACHE_VALID=6M
-
-# Sizes can be specified in bytes, kilobytes (suffixes k and K) or megabytes (suffixes m and M), for
-# example, “1024”, “8k”, “1m”.
-# Offsets may be also specified in gigabytes using g or G suffixes.
+ENV PROXY_CACHE_VALID=180d
 ENV PROXY_MAX_SIZE=2G
 
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -1,4 +1,4 @@
-proxy_cache_path /var/cache/nginx levels=1 keys_zone=resized:2m max_size=${PROXY_MAX_SIZE} use_temp_path=off;
+proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=resized:5m max_size=${PROXY_MAX_SIZE} inactive=${PROXY_CACHE_VALID} use_temp_path=off;
 
 large_client_header_buffers 16 32k;
 
@@ -87,7 +87,6 @@ server {
         proxy_pass        http://127.0.0.1:9079;
         proxy_cache       resized;
         proxy_cache_valid ${PROXY_CACHE_VALID};
-        proxy_ignore_headers Expires Cache-Control;
         add_header X-Cache-Status $upstream_cache_status;
     }
 
@@ -95,7 +94,6 @@ server {
         proxy_pass        http://127.0.0.1:9079;
         proxy_cache       resized;
         proxy_cache_valid ${PROXY_CACHE_VALID};
-        proxy_ignore_headers Expires Cache-Control;
         add_header X-Cache-Status $upstream_cache_status;
     }
 
@@ -103,7 +101,6 @@ server {
         proxy_pass        http://127.0.0.1:9079;
         proxy_cache       resized;
         proxy_cache_valid ${PROXY_CACHE_VALID};
-        proxy_ignore_headers Expires Cache-Control;
         add_header X-Cache-Status $upstream_cache_status;
     }
 
@@ -120,6 +117,10 @@ server {
     listen 9079;
     allow 127.0.0.1;
     deny all;
+
+    proxy_ignore_headers Expires Cache-Control;
+    proxy_hide_header Expires;
+    proxy_hide_header Cache-Control;
 
     location /img400 {
         image_filter_buffer 10M;


### PR DESCRIPTION
- The default value for inactive keys is 10min. We want to keep the files as long as possible.
- Remove misleading comments. It seems that proxy_cache_valid does not support all possible time settings.