### PR TITLE
Fix: Use the GCS_BUCKET_URL from Strapi config

### DIFF
--- a/ci/k8s/deployment.template.yml
+++ b/ci/k8s/deployment.template.yml
@@ -33,6 +33,13 @@ spec:
           limits:
             cpu: "200m"
             memory: "64Mi"
+        env:
+        - name: GCS_BASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: unep-gpml
+              key: strapi-gcs-base-url
+
       - name: frontend
         image: eu.gcr.io/akvo-lumen/unep-gpml/frontend:${CI_COMMIT}
         ports:


### PR DESCRIPTION
The `nginx` container is prepared to use an environment variable, we use the same config from Strapi