### PR TITLE
Fix GET /api/detail/project/{id}

### DIFF
--- a/backend/src/gpml/handler/detail.clj
+++ b/backend/src/gpml/handler/detail.clj
@@ -417,6 +417,9 @@
 (defmethod extra-details "event" [config resource-type event]
   (add-extra-details config event resource-type {}))
 
+(defmethod extra-details "project" [config resource-type resource]
+  (add-extra-details config resource resource-type {}))
+
 (defmethod extra-details "organisation" [config resource-type organisation]
   (add-extra-details config organisation resource-type {:tags? true
                                                         :entity-connections? false


### PR DESCRIPTION
Fix `GET /api/detail/project/{id}` returns empty response