### PR TITLE
Fix Case Study field mismatch error

### DIFF
--- a/frontend/src/modules/flexible-forms/form.jsx
+++ b/frontend/src/modules/flexible-forms/form.jsx
@@ -1605,6 +1605,12 @@ const FlexibleForm = ({
 
     data.geoCoverageType = Object.keys(data.geoCoverageType)[0]
 
+    // Transform Case Study summary field to description field to match database schema
+    if (data?.summary) {
+      data.description = data.summary
+      delete data.summary
+    }
+
     delete data.orgName
 
     data.tags =

--- a/frontend/src/pages/add-content/index.jsx
+++ b/frontend/src/pages/add-content/index.jsx
@@ -574,7 +574,7 @@ const formConfigs = {
     rows: [
       [{ name: 'url', span: 24, required: true }],
       [{ name: 'title', span: 24, required: true }],
-      [{ name: 'summary', span: 24, required: true, label: 'Description' }],
+      [{ name: 'description', span: 24, required: true, label: 'Description' }],
       [
         { name: 'geoCoverageType', span: 12, required: true },
         {
@@ -1722,6 +1722,9 @@ const DynamicContentForm = () => {
           ...(data.type === 'policy' && { abstract: data.summary }),
           ...(data.type === 'technology' && { remarks: data.summary }),
           ...((data.type === 'event' || data.type === 'initiative') && {
+            description: data.summary,
+          }),
+          ...(data.type === 'case_study' && {
             description: data.summary,
           }),
           geoCoverageType: data.geoCoverageType || '',


### PR DESCRIPTION
Transform Case Study form to use description field instead of summary to match database schema. This resolves the 'column summary does not exist' error when updating Case Studies.

Changes:
- Update Case Study form submission to transform summary → description field
- Change Case Study form configuration to use description field
- Add Case Study editing logic to handle field transformation between frontend and backend

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210341594674167