### PR TITLE
Add GitHub Actions QA workflow and test helpers

### DIFF
--- a/.github/helpers/backend-qa.sh
+++ b/.github/helpers/backend-qa.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -Eeuxo pipefail
+
+backend_qa() {
+  # Clean any existing build artifacts to avoid permission issues
+  rm -rf backend/target
+  rm -f backend/.eastwood
+
+  # Run QA using docker compose (starts db automatically, uses compose volume mounts)
+  docker compose run \
+    --rm \
+    backend \
+    bash release.sh
+
+  # Stop database container to clean up (match ci/build.sh pattern)
+  docker stop unep-gpml-db-1 || true
+
+  # Clean up files created by Docker (owned by root)
+  rm -f backend/.eastwood
+  rm -f backend/test-resources/local.edn
+}
+
+backend_qa

--- a/.github/helpers/frontend-qa.sh
+++ b/.github/helpers/frontend-qa.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -Eeuxo pipefail
+
+frontend_qa() {
+  # Run QA using docker compose (no-deps to skip database)
+  docker compose run \
+    --rm \
+    --no-deps \
+    frontend \
+    bash release.sh
+}
+
+frontend_qa

--- a/.github/helpers/integration-test.sh
+++ b/.github/helpers/integration-test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#shellcheck disable=SC2039
+
+set -Eeuxo pipefail
+
+CI_COMMIT="${GITHUB_SHA:=local}"
+CI_COMMIT="${CI_COMMIT:0:7}"
+export CI_COMMIT
+
+lein_path="${HOME}/.lein"
+m2_path="${HOME}/.m2"
+image_prefix="eu.gcr.io/akvo-lumen/unep-gpml"
+
+mkdir -p "${lein_path}"
+mkdir -p "${m2_path}"
+
+dc () {
+  docker compose --ansi never "$@"
+}
+
+export -f dc
+
+dci () {
+  dc -f docker-compose.yml -f docker-compose.ci.yml "$@"
+}
+
+export -f dci
+
+backend_build () {
+  # Use release-ci.sh to skip tests (already run in backend-qa job)
+  dc run \
+     --rm \
+     backend \
+     bash release-ci.sh
+
+  docker build \
+         --quiet \
+	       --tag "${image_prefix}/backend:latest" \
+         --tag "${image_prefix}/backend:${CI_COMMIT}" backend
+
+  # Stop unused container to save memory
+  docker stop unep-gpml-db-1 || true
+}
+
+frontend_build () {
+  rm -rf frontend/.env
+  echo 'REACT_APP_AUTH0_CLIENT_ID="dxfYNPO4D9ovQr5NHFkOU3jwJzXhcq5J"' >> frontend/.env
+  echo 'REACT_APP_AUTH0_DOMAIN="unep-gpml-test.eu.auth0.com"' >> frontend/.env
+  echo 'NEXT_PUBLIC_CHAT_API_DOMAIN_URL="https://rocket-chat.akvotest.org"' >> frontend/.env
+  echo 'NEXT_PUBLIC_ENV=test' >> frontend/.env
+  echo 'NEXT_PUBLIC_DSC_URL="https://deadsimplechat.com"' >> frontend/.env
+  echo 'NEXT_PUBLIC_DSC_API_URL="https://api.deadsimplechat.com"' >> frontend/.env
+  echo 'NEXT_PUBLIC_DSC_PUBLIC_KEY="pub_42747a344c7475336e2d4f46624c3333494d68745a784c316d4150626c4c32714a5146494c6b4d44764a4556456f5847"' >> frontend/.env
+
+  dc run \
+     --rm \
+     --no-deps \
+     frontend \
+     bash release.sh
+
+  docker build \
+         --quiet \
+	       --tag "${image_prefix}/frontend:latest" \
+	       --tag "${image_prefix}/frontend:${CI_COMMIT}" frontend
+}
+
+nginx_build () {
+  docker build \
+         --quiet \
+         --tag "${image_prefix}/nginx:latest" \
+         --tag "${image_prefix}/nginx:${CI_COMMIT}" nginx
+}
+
+strapi_build () {
+  docker build -f strapi/Dockerfile.prod \
+         --quiet \
+         --tag "${image_prefix}/strapi:latest" \
+         --tag "${image_prefix}/strapi:${CI_COMMIT}" strapi
+}
+
+# Build all images
+backend_build
+docker stop unep-gpml-db-1 || true
+
+frontend_build
+strapi_build
+nginx_build
+
+# Run integration tests with helpers mounted and Auth0 credentials
+if ! docker compose -f docker-compose.yml -f docker-compose.ci.yml run \
+  --no-TTY \
+  --rm \
+  -e GPML_AUTH0_USER \
+  -e GPML_AUTH0_PASSWORD \
+  -v "$(pwd)/.github/helpers:/test-utils:ro" \
+  ci \
+  bash -c "source /test-utils/test-utils.sh && /test-utils/run-tests.sh"; then
+  echo "Integration tests failed. Logs:"
+  dci logs
+  exit 1
+fi
+
+echo "Integration tests passed successfully!"

--- a/.github/helpers/run-tests.sh
+++ b/.github/helpers/run-tests.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+# Wait for services to be ready (using wait4ports installed by entrypoint.sh)
+wait4ports -q -s 1 -t 300 tcp://localhost:80 tcp://localhost:3000 tcp://db:5432
+
+# Run HTTP endpoint tests
+http_get "http://localhost/index.html" 200
+http_get "http://localhost/api/swagger.json" 200
+http_get "http://localhost/api/docs/index.html" 200
+http_get "http://localhost/api/country" 200
+
+# Authentication tests
+token=$(get_token)
+
+# Verify token was retrieved
+if [[ -z "${token}" || "${token}" == "null" ]]; then
+  echo "ERROR: Failed to retrieve Auth0 token"
+  exit 1
+fi
+
+http_get "http://localhost/api/profile" 401
+http_get "http://localhost/api/profile" 403 --header "Authorization: Bearer"
+http_get "http://localhost/api/profile" 403 --header "Authorization: Bearer foo"
+http_get "http://localhost/api/profile" 200 --header "Authorization: Bearer ${token}"
+
+echo "All integration tests passed!"

--- a/.github/helpers/test-utils.sh
+++ b/.github/helpers/test-utils.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#shellcheck disable=SC2039
+
+set -Eeuo pipefail
+
+# Get Auth0 token for integration tests
+get_token () {
+  curl --silent \
+    --data "client_id=dxfYNPO4D9ovQr5NHFkOU3jwJzXhcq5J" \
+    --data "username=${GPML_AUTH0_USER}" \
+    --data "password=${GPML_AUTH0_PASSWORD}" \
+    --data "grant_type=password" \
+    --data "scope=openid email" \
+    --data "connection=Username-Password-Authentication" \
+    --url "https://unep-gpml-test.eu.auth0.com/oauth/token" \
+  | jq -r -M '.id_token'
+}
+
+# HTTP test helper - checks if response contains expected status code
+http_get() {
+  url="${1}"
+  shift
+  code="${1}"
+  shift
+  curl --verbose --url "${url}" "$@" 2>&1 | grep "< HTTP.*${code}"
+}
+
+export -f get_token
+export -f http_get

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,91 @@
+name: Quality Assurance
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  backend-qa:
+    name: Backend QA
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2
+            ~/.lein
+          key: m2-${{ hashFiles('backend/project.clj') }}
+          restore-keys: |
+            m2-
+
+      - name: Run Backend QA
+        shell: bash
+        run: ./.github/helpers/backend-qa.sh
+
+  frontend-qa:
+    name: Frontend QA
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache Node modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            frontend/node_modules
+            ~/.npm
+          key: node-modules-${{ hashFiles('frontend/package.json') }}
+          restore-keys: |
+            node-modules-
+
+      - name: Run Frontend QA
+        shell: bash
+        run: ./.github/helpers/frontend-qa.sh
+
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    needs: [backend-qa, frontend-qa]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2
+            ~/.lein
+          key: m2-${{ hashFiles('backend/project.clj') }}
+          restore-keys: |
+            m2-
+
+      - name: Cache Node modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            frontend/node_modules
+            ~/.npm
+          key: node-modules-${{ hashFiles('frontend/package.json') }}
+          restore-keys: |
+            node-modules-
+
+      - name: Run Integration Tests
+        shell: bash
+        env:
+          GPML_AUTH0_USER: ${{ secrets.GPML_AUTH0_USER }}
+          GPML_AUTH0_PASSWORD: ${{ secrets.GPML_AUTH0_PASSWORD }}
+        run: |
+          bash ./.github/helpers/integration-test.sh
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.ci.yml down -v || true


### PR DESCRIPTION
This adds a comprehensive GitHub Actions workflow for quality assurance that includes:
- Backend QA job with linting and testing
- Frontend QA job with linting and build validation
- Integration tests job that runs after QA passes
- Shared helper scripts for test execution and utilities
- Dependency caching for Maven and Node modules