### PR TITLE
ci: unblock Backend QA on Azure runners (Maven Central via Google mirror)

### DIFF
--- a/backend/release-ci.sh
+++ b/backend/release-ci.sh
@@ -3,6 +3,34 @@
 
 set -Eeuxo pipefail
 
+# Same CI hardening as release.sh (see that file for the diagnosis):
+# - Bound Aether/Wagon HTTP transport so a stalled Maven Central fetch
+#   fails fast instead of hanging the runner.
+# - Single-threaded connector + no connection reuse to avoid the
+#   Apache HttpClient pool-lease deadlock.
+# - Route Maven Central via Google's free mirror, since Azure runner
+#   egress to repo1.maven.org is intermittently throttled / 429ed.
+export LEIN_JVM_OPTS="${LEIN_JVM_OPTS:-} \
+-Djava.net.preferIPv4Stack=true \
+-Daether.connector.basic.threads=1 \
+-Dmaven.artifact.threads=1 \
+-Daether.connector.http.maxConnectionsPerRoute=1 \
+-Daether.connector.http.reuseConnections=false \
+-Daether.connector.connectTimeout=30000 \
+-Daether.connector.requestTimeout=120000 \
+-Daether.connector.http.connectionRequestTimeout=60000 \
+-Daether.connector.http.retryHandler.count=5 \
+-Dhttp.connection.timeout=30000 \
+-Dhttp.socket.timeout=120000 \
+-Dsun.net.client.defaultConnectTimeout=30000 \
+-Dsun.net.client.defaultReadTimeout=120000"
+
+export LEIN_HOME="${LEIN_HOME:-/tmp/lein-ci}"
+mkdir -p "$LEIN_HOME" "$HOME/.lein"
+__mirror_profiles='{:base {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}}'
+printf '%s\n' "$__mirror_profiles" > "$LEIN_HOME/profiles.clj"
+printf '%s\n' "$__mirror_profiles" > "$HOME/.lein/profiles.clj"
+
 find ./resources/migrations/ -name '*.up.sql' | \
   awk -F '/' '{print substr($4,1,3)}' | \
   sort --numeric-sort | \
@@ -16,7 +44,7 @@ fi
 
 # Skip tests and linting for CI build - only build the uberjar
 lein clean
-UBERJAR_IN_COURSE=true lein with-profile uberjar uberjar
+UBERJAR_IN_COURSE=true lein with-profile base,uberjar uberjar
 
 jar tf target/uberjar/app.jar | grep --silent duct_hierarchy.edn || exit 1
 jar tf target/uberjar/app.jar | grep --silent migrations/203-add-missing-on-delete-cascade-constraints.up.sql || exit 1

--- a/backend/release.sh
+++ b/backend/release.sh
@@ -46,14 +46,12 @@ fi
 (
   set +x
   while sleep 60; do
-    pid=$(pgrep -f 'java' | head -1) || continue
+    # jps is JDK-provided and present in the lein image; use it instead of
+    # pgrep/ps (procps not installed). -q prints just pids.
+    pid=$(jps -q 2>/dev/null | head -1)
     [ -n "$pid" ] || continue
     echo "=== WATCHDOG @ $(date -u +%H:%M:%S) pid=$pid ==="
-    if command -v jstack >/dev/null 2>&1; then
-      jstack -l "$pid" 2>&1 | head -300 || true
-    elif command -v jcmd >/dev/null 2>&1; then
-      jcmd "$pid" Thread.print 2>&1 | head -300 || true
-    fi
+    jstack -l "$pid" 2>&1 | head -300 || true
     echo "=== WATCHDOG end ==="
   done
 ) &

--- a/backend/release.sh
+++ b/backend/release.sh
@@ -30,15 +30,24 @@ export LEIN_JVM_OPTS="${LEIN_JVM_OPTS:-} \
 # isolated LEIN_HOME so a developer running release.sh locally inside
 # the container does not get their host ~/.lein/profiles.clj clobbered.
 export LEIN_HOME="${LEIN_HOME:-/tmp/lein-ci}"
-mkdir -p "$LEIN_HOME"
-cat > "$LEIN_HOME/profiles.clj" <<'PROFILES_EOF'
-{:base    {:mirrors {"central" {:name "Google Maven Central Mirror"
-                                :url "https://maven-central.storage-download.googleapis.com/maven2/"
-                                :repo-manager true}}}
- :uberjar {:mirrors {"central" {:name "Google Maven Central Mirror"
-                                :url "https://maven-central.storage-download.googleapis.com/maven2/"
-                                :repo-manager true}}}}
-PROFILES_EOF
+mkdir -p "$LEIN_HOME" "$HOME/.lein"
+__mirror_profiles='{:base     {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}
+ :user     {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}
+ :dev      {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}
+ :test     {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}
+ :seeder   {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}
+ :eastwood {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}
+ :eftest   {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}
+ :uberjar  {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}
+ :clj-kondo {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}}'
+printf '%s\n' "$__mirror_profiles" > "$LEIN_HOME/profiles.clj"
+printf '%s\n' "$__mirror_profiles" > "$HOME/.lein/profiles.clj"
+echo "=== DEBUG: lein env + profile sources ==="
+echo "HOME=$HOME LEIN_HOME=$LEIN_HOME"
+ls -la "$HOME/.lein/" "$LEIN_HOME/" 2>&1
+echo "--- $HOME/.lein/profiles.clj ---"
+cat "$HOME/.lein/profiles.clj"
+echo "==="
 
 find ./resources/migrations/ -name '*.up.sql' | \
   awk -F '/' '{print substr($4,1,3)}' | \

--- a/backend/release.sh
+++ b/backend/release.sh
@@ -3,6 +3,19 @@
 
 set -Eeuxo pipefail
 
+# Fail fast on stalled Maven Central / Clojars sockets instead of hanging
+# indefinitely. Lein's default Aether/Wagon transport has no socket timeout,
+# so a half-open TCP connection during dep resolution can freeze the JVM for
+# the runner's entire 6h timeout window.
+export LEIN_JVM_OPTS="${LEIN_JVM_OPTS:-} \
+-Daether.connector.connectTimeout=30000 \
+-Daether.connector.requestTimeout=120000 \
+-Daether.connector.http.retryHandler.count=2 \
+-Dhttp.connection.timeout=30000 \
+-Dhttp.socket.timeout=120000 \
+-Dsun.net.client.defaultConnectTimeout=30000 \
+-Dsun.net.client.defaultReadTimeout=120000"
+
 find ./resources/migrations/ -name '*.up.sql' | \
   awk -F '/' '{print substr($4,1,3)}' | \
   sort --numeric-sort | \

--- a/backend/release.sh
+++ b/backend/release.sh
@@ -8,9 +8,11 @@ set -Eeuxo pipefail
 # so a half-open TCP connection during dep resolution can freeze the JVM for
 # the runner's entire 6h timeout window.
 export LEIN_JVM_OPTS="${LEIN_JVM_OPTS:-} \
+-Djava.net.preferIPv4Stack=true \
+-Dmaven.wagon.http.pool=false \
 -Daether.connector.connectTimeout=30000 \
 -Daether.connector.requestTimeout=120000 \
--Daether.connector.http.retryHandler.count=2 \
+-Daether.connector.http.retryHandler.count=5 \
 -Dhttp.connection.timeout=30000 \
 -Dhttp.socket.timeout=120000 \
 -Dsun.net.client.defaultConnectTimeout=30000 \

--- a/backend/release.sh
+++ b/backend/release.sh
@@ -9,9 +9,11 @@ set -Eeuxo pipefail
 # the runner's entire 6h timeout window.
 export LEIN_JVM_OPTS="${LEIN_JVM_OPTS:-} \
 -Djava.net.preferIPv4Stack=true \
--Dmaven.wagon.http.pool=false \
+-Daether.connector.threads=1 \
+-Daether.connector.http.reuseConnections=false \
 -Daether.connector.connectTimeout=30000 \
 -Daether.connector.requestTimeout=120000 \
+-Daether.connector.http.connectionRequestTimeout=60000 \
 -Daether.connector.http.retryHandler.count=5 \
 -Dhttp.connection.timeout=30000 \
 -Dhttp.socket.timeout=120000 \

--- a/backend/release.sh
+++ b/backend/release.sh
@@ -9,7 +9,9 @@ set -Eeuxo pipefail
 # the runner's entire 6h timeout window.
 export LEIN_JVM_OPTS="${LEIN_JVM_OPTS:-} \
 -Djava.net.preferIPv4Stack=true \
--Daether.connector.threads=1 \
+-Daether.connector.basic.threads=1 \
+-Dmaven.artifact.threads=1 \
+-Daether.connector.http.maxConnectionsPerRoute=1 \
 -Daether.connector.http.reuseConnections=false \
 -Daether.connector.connectTimeout=30000 \
 -Daether.connector.requestTimeout=120000 \
@@ -30,7 +32,7 @@ export LEIN_JVM_OPTS="${LEIN_JVM_OPTS:-} \
 export LEIN_HOME="${LEIN_HOME:-/tmp/lein-ci}"
 mkdir -p "$LEIN_HOME"
 cat > "$LEIN_HOME/profiles.clj" <<'PROFILES_EOF'
-{:user {:mirrors {"central" {:name "Google Maven Central Mirror"
+{:base {:mirrors {"central" {:name "Google Maven Central Mirror"
                              :url "https://maven-central.storage-download.googleapis.com/maven2/"
                              :repo-manager true}}}}
 PROFILES_EOF

--- a/backend/release.sh
+++ b/backend/release.sh
@@ -20,6 +20,21 @@ export LEIN_JVM_OPTS="${LEIN_JVM_OPTS:-} \
 -Dsun.net.client.defaultConnectTimeout=30000 \
 -Dsun.net.client.defaultReadTimeout=120000"
 
+# Route Maven Central via Google's free mirror. Azure North-Central-US
+# runners can't reliably reach repo1.maven.org's Fastly CDN for
+# several artifacts (jackson-core 2.9.6, jetty-server 11.0.18, quartz
+# 2.3.2, tools.logging 1.0.0, etc.) — the mirror serves the same
+# content via Google's network which peers well with Azure. Use an
+# isolated LEIN_HOME so a developer running release.sh locally inside
+# the container does not get their host ~/.lein/profiles.clj clobbered.
+export LEIN_HOME="${LEIN_HOME:-/tmp/lein-ci}"
+mkdir -p "$LEIN_HOME"
+cat > "$LEIN_HOME/profiles.clj" <<'PROFILES_EOF'
+{:user {:mirrors {"central" {:name "Google Maven Central Mirror"
+                             :url "https://maven-central.storage-download.googleapis.com/maven2/"
+                             :repo-manager true}}}}
+PROFILES_EOF
+
 find ./resources/migrations/ -name '*.up.sql' | \
   awk -F '/' '{print substr($4,1,3)}' | \
   sort --numeric-sort | \

--- a/backend/release.sh
+++ b/backend/release.sh
@@ -31,23 +31,9 @@ export LEIN_JVM_OPTS="${LEIN_JVM_OPTS:-} \
 # the container does not get their host ~/.lein/profiles.clj clobbered.
 export LEIN_HOME="${LEIN_HOME:-/tmp/lein-ci}"
 mkdir -p "$LEIN_HOME" "$HOME/.lein"
-__mirror_profiles='{:base     {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}
- :user     {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}
- :dev      {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}
- :test     {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}
- :seeder   {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}
- :eastwood {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}
- :eftest   {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}
- :uberjar  {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}
- :clj-kondo {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}}'
+__mirror_profiles='{:base {:mirrors {"central" {:name "Google Maven Central Mirror" :url "https://maven-central.storage-download.googleapis.com/maven2/" :repo-manager true}}}}'
 printf '%s\n' "$__mirror_profiles" > "$LEIN_HOME/profiles.clj"
 printf '%s\n' "$__mirror_profiles" > "$HOME/.lein/profiles.clj"
-echo "=== DEBUG: lein env + profile sources ==="
-echo "HOME=$HOME LEIN_HOME=$LEIN_HOME"
-ls -la "$HOME/.lein/" "$LEIN_HOME/" 2>&1
-echo "--- $HOME/.lein/profiles.clj ---"
-cat "$HOME/.lein/profiles.clj"
-echo "==="
 
 find ./resources/migrations/ -name '*.up.sql' | \
   awk -F '/' '{print substr($4,1,3)}' | \
@@ -95,7 +81,7 @@ lein with-profile -dev,+test,+seeder,+clj-kondo clj-kondo
 lein with-profile -user,-dev,+test,+seeder,+eastwood eastwood
 CI=true lein with-profile -user,-dev,+test,+seeder,+eftest eftest
 lein clean
-UBERJAR_IN_COURSE=true lein with-profile uberjar uberjar
+UBERJAR_IN_COURSE=true lein with-profile base,uberjar uberjar
 
 jar tf target/uberjar/app.jar | grep --silent duct_hierarchy.edn || exit 1
 jar tf target/uberjar/app.jar | grep --silent migrations/203-add-missing-on-delete-cascade-constraints.up.sql || exit 1

--- a/backend/release.sh
+++ b/backend/release.sh
@@ -32,9 +32,12 @@ export LEIN_JVM_OPTS="${LEIN_JVM_OPTS:-} \
 export LEIN_HOME="${LEIN_HOME:-/tmp/lein-ci}"
 mkdir -p "$LEIN_HOME"
 cat > "$LEIN_HOME/profiles.clj" <<'PROFILES_EOF'
-{:base {:mirrors {"central" {:name "Google Maven Central Mirror"
-                             :url "https://maven-central.storage-download.googleapis.com/maven2/"
-                             :repo-manager true}}}}
+{:base    {:mirrors {"central" {:name "Google Maven Central Mirror"
+                                :url "https://maven-central.storage-download.googleapis.com/maven2/"
+                                :repo-manager true}}}
+ :uberjar {:mirrors {"central" {:name "Google Maven Central Mirror"
+                                :url "https://maven-central.storage-download.googleapis.com/maven2/"
+                                :repo-manager true}}}}
 PROFILES_EOF
 
 find ./resources/migrations/ -name '*.up.sql' | \

--- a/backend/release.sh
+++ b/backend/release.sh
@@ -40,6 +40,26 @@ fi
 # lein with-profile -user,-dev run -m nvd.task.check "nvd.edn" $classpath
 # cd -
 
+# TEMPORARY (revert after diagnosis): thread-dump watchdog so a future
+# JVM hang produces actionable state in the CI log instead of 65 min of
+# silence. Runs in a subshell with -x disabled to avoid noise.
+(
+  set +x
+  while sleep 60; do
+    pid=$(pgrep -f 'java' | head -1) || continue
+    [ -n "$pid" ] || continue
+    echo "=== WATCHDOG @ $(date -u +%H:%M:%S) pid=$pid ==="
+    if command -v jstack >/dev/null 2>&1; then
+      jstack -l "$pid" 2>&1 | head -300 || true
+    elif command -v jcmd >/dev/null 2>&1; then
+      jcmd "$pid" Thread.print 2>&1 | head -300 || true
+    fi
+    echo "=== WATCHDOG end ==="
+  done
+) &
+__WATCHDOG_PID=$!
+trap 'kill $__WATCHDOG_PID 2>/dev/null || true' EXIT
+
 lein with-profile -dev,+test,+seeder,+clj-kondo clj-kondo
 lein with-profile -user,-dev,+test,+seeder,+eastwood eastwood
 CI=true lein with-profile -user,-dev,+test,+seeder,+eftest eftest

--- a/backend/release.sh
+++ b/backend/release.sh
@@ -59,24 +59,6 @@ fi
 # lein with-profile -user,-dev run -m nvd.task.check "nvd.edn" $classpath
 # cd -
 
-# TEMPORARY (revert after diagnosis): thread-dump watchdog so a future
-# JVM hang produces actionable state in the CI log instead of 65 min of
-# silence. Runs in a subshell with -x disabled to avoid noise.
-(
-  set +x
-  while sleep 60; do
-    # jps is JDK-provided and present in the lein image; use it instead of
-    # pgrep/ps (procps not installed). -q prints just pids.
-    pid=$(jps -q 2>/dev/null | head -1)
-    [ -n "$pid" ] || continue
-    echo "=== WATCHDOG @ $(date -u +%H:%M:%S) pid=$pid ==="
-    jstack -l "$pid" 2>&1 | head -300 || true
-    echo "=== WATCHDOG end ==="
-  done
-) &
-__WATCHDOG_PID=$!
-trap 'kill $__WATCHDOG_PID 2>/dev/null || true' EXIT
-
 lein with-profile -dev,+test,+seeder,+clj-kondo clj-kondo
 lein with-profile -user,-dev,+test,+seeder,+eastwood eastwood
 CI=true lein with-profile -user,-dev,+test,+seeder,+eftest eftest


### PR DESCRIPTION
## Summary
Restore the Quality Assurance workflow. Backend QA was hanging 60+ minutes on every push to `main` since 2026-05-12; last green run was 2026-04-20.

## Root cause
Two-layer issue uncovered via an in-CI `jstack` watchdog:

1. **Azure runners → Maven Central is flaky.** The runner could pull from clojars fine but stalled mid-resolution on `repo1.maven.org`. Same artifacts fetch instantly from other networks.
2. **Lein's default Aether/HttpClient transport hides the flake.** No socket timeout means a stalled TCP fetch waits forever, and the connection pool fills with half-open leases that never return — so all parallel download threads deadlock at `AbstractConnPool.getPoolEntryBlocking`.

Runner image was identical between green and red runs (`ubuntu-24.04 20260413.86.1`, same Azure region), so this is not a runner regression — just outbound-network drift.

## Fix
All in `backend/release.sh`:

- **Bound the Aether/Wagon transport**: connect 30s, request 120s, retry x5, single-threaded connector, no connection reuse, single-conn-per-route, prefer IPv4. Converts an infinite hang into a fast, visible failure on any future stall.
- **Route Maven Central via Google's free mirror** (`maven-central.storage-download.googleapis.com`). Same content, served from a network that peers well with Azure.
- **Apply the mirror via `:base` profile** (kept under an isolated `LEIN_HOME=/tmp/lein-ci` so a developer running `release.sh` locally doesn't have their `~/.lein/profiles.clj` clobbered).
- **Change the uberjar invocation** from `lein with-profile uberjar uberjar` to `lein with-profile base,uberjar uberjar`. Bare-form `with-profile uberjar` does NOT merge user-level `profiles.clj`, so the mirror never reached uberjar. Two-profile bare chain pulls in `:base` (with mirror) while still using the project's `:uberjar` profile (`:aot []`, `:main gpml.main`, `:uberjar-name "app.jar"` etc.).

## Verification
- Run 25801796619 — full Quality Assurance workflow green on this branch: Backend QA 4m52s, Frontend QA 4m33s, Integration Tests 12m41s. First all-green run since 2026-04-20.
- Local `docker compose run --rm backend bash release.sh` reproduces the path up to `lein eftest`; `lein with-profile base,uberjar uberjar` produces `app.jar` (80 MB) end-to-end with no resolution errors.