### PR TITLE
nginx: cache /api/browse?limit=1 to absorb homepage SSR load

### DIFF
--- a/nginx/templates/default-hpa.conf.template
+++ b/nginx/templates/default-hpa.conf.template
@@ -39,6 +39,28 @@ server {
        return 301 https://$host$request_uri;
     }
 
+    # Cache /api/browse ONLY for the homepage SSR call (exactly ?limit=1).
+    # All other query string variants bypass the cache and pass through.
+    location = /api/browse {
+        set $browse_no_cache 1;
+        if ($args = "limit=1") { set $browse_no_cache 0; }
+        proxy_cache resized;
+        proxy_cache_valid 200 5m;
+        proxy_cache_key "$request_uri";
+        proxy_cache_bypass $browse_no_cache;
+        proxy_no_cache $browse_no_cache;
+        proxy_cache_lock on;
+        proxy_cache_lock_timeout 5s;
+        proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+        proxy_ignore_headers Set-Cookie Cache-Control Expires;
+        proxy_hide_header Set-Cookie;
+        add_header X-Cache-Status $upstream_cache_status always;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_pass http://backend:3000/api/browse;
+    }
+
     location /api {
         proxy_set_header        Host $host;
         proxy_set_header        X-Real-IP $remote_addr;

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -39,6 +39,28 @@ server {
        return 301 https://$host$request_uri;
     }
 
+    # Cache /api/browse ONLY for the homepage SSR call (exactly ?limit=1).
+    # All other query string variants bypass the cache and pass through.
+    location = /api/browse {
+        set $browse_no_cache 1;
+        if ($args = "limit=1") { set $browse_no_cache 0; }
+        proxy_cache resized;
+        proxy_cache_valid 200 5m;
+        proxy_cache_key "$request_uri";
+        proxy_cache_bypass $browse_no_cache;
+        proxy_no_cache $browse_no_cache;
+        proxy_cache_lock on;
+        proxy_cache_lock_timeout 5s;
+        proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+        proxy_ignore_headers Set-Cookie Cache-Control Expires;
+        proxy_hide_header Set-Cookie;
+        add_header X-Cache-Status $upstream_cache_status always;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_pass http://localhost:3000/api/browse;
+    }
+
     location /api {
         proxy_set_header        Host $host;
         proxy_set_header        X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
Add an exact-match nginx location for `/api/browse` that caches the response **only** when the query string is exactly `limit=1` — i.e. the homepage SSR call. Every other variant of `/api/browse?...` (filter queries from catalogue pages, etc.) bypasses cache and passes through unchanged.

Applied to both `default-hpa.conf.template` (prod) and `default.conf.template` (dev) for parity.

## Why
The homepage server-side render fires a call to `/api/browse?limit=1` on every render. Combined with health-check probes and bot/crawler traffic hitting `/`, the result is a steady fan-out of identical heavy backend queries on every page hit. Caching that one URL for 5 minutes collapses the fan-out without affecting any user-facing filtered queries.

## Behaviour
| Request | Behaviour |
|---|---|
| `GET /api/browse?limit=1` | Cached 5 min (`X-Cache-Status: HIT`) |
| `GET /api/browse?limit=2` | Bypass — passes through to backend |
| `GET /api/browse?tag=foo&topic=bar` | Bypass — passes through to backend |
| `GET /api/browse` (no args) | Bypass — passes through to backend |
| Any other path | Unaffected |

Implementation details:
- Reuses the existing `resized` proxy_cache_path zone defined at the top of the file (no new disk/memory allocation).
- `proxy_cache_lock on` collapses concurrent identical requests into a single backend hit during cache-fill, so a thundering herd can't bypass the cache.
- `proxy_cache_use_stale` keeps the homepage rendering off a stale cache entry if backend is briefly unreachable.

## Test plan
- [ ] Image build + deploy.
- [ ] `curl -I https://<host>/api/browse?limit=1` returns `X-Cache-Status: HIT` (after 1 priming request).
- [ ] `curl -I https://<host>/api/browse?limit=2` returns `X-Cache-Status: BYPASS`.
- [ ] `curl -I https://<host>/api/browse?tag=foo` returns `X-Cache-Status: BYPASS`.
- [ ] Catalogue pages still show fresh filtered results.

## Note
The proper fix is to stop the homepage from calling the public URL for that data — this cache is the safety net underneath that work, not a substitute for it.